### PR TITLE
Add man page for git-ls

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,6 +36,8 @@ archives:
     format_overrides:
       - goos: windows
         formats: ["zip"]
+    files:
+      - manpage/git-ls.1
 
 changelog:
   sort: asc
@@ -53,3 +55,6 @@ brews:
       owner: llimllib
       name: homebrew-git-ls
       branch: main
+    install: |
+      bin.install "git-ls"
+      man1.install "manpage/git-ls.1"

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,10 @@ TRANSCRIPTS := $(wildcard transcripts/*)
 STATIC := $(wildcard static/*)
 
 .PHONY: all
-all: git-ls manpage/git-ls.1
+all: git-ls
 
 git-ls: $(SRC)
 	go build
-
-.PHONY: manpage/git-ls.1
-manpage/git-ls.1:
-	@# Man page is already generated, just verify it exists
-	@test -f manpage/git-ls.1 || (echo "Error: manpage/git-ls.1 not found" && exit 1)
 
 # depends on golangci-lint:
 # https://golangci-lint.run/welcome/install/#local-installation

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,15 @@ TRANSCRIPTS := $(wildcard transcripts/*)
 STATIC := $(wildcard static/*)
 
 .PHONY: all
-all: git-ls
+all: git-ls manpage/git-ls.1
 
 git-ls: $(SRC)
 	go build
+
+.PHONY: manpage/git-ls.1
+manpage/git-ls.1:
+	@# Man page is already generated, just verify it exists
+	@test -f manpage/git-ls.1 || (echo "Error: manpage/git-ls.1 not found" && exit 1)
 
 # depends on golangci-lint:
 # https://golangci-lint.run/welcome/install/#local-installation

--- a/manpage/README.md
+++ b/manpage/README.md
@@ -1,0 +1,47 @@
+# Man Page Setup
+
+This directory contains the man page for git-ls.
+
+## Files
+
+- `git-ls.1` - The man page in roff format
+
+## Testing Locally
+
+To test the man page:
+
+```bash
+man ./git-ls.1
+```
+
+To install it locally (so `git ls --help` works):
+
+```bash
+mkdir -p ~/.local/share/man/man1
+cp git-ls.1 ~/.local/share/man/man1/
+```
+
+Then `git ls --help` should display the man page.
+
+## Homebrew Installation
+
+When you release via goreleaser, the man page will automatically be:
+1. Included in release tarballs (see `.goreleaser.yaml`)
+2. Installed to `/opt/homebrew/share/man/man1/` via the Homebrew formula
+
+Users who install via `brew install llimllib/git-ls/git-ls` will automatically get the man page, and `git ls --help` will work correctly.
+
+## Updating the Man Page
+
+The man page is written in roff format. Key macros:
+
+- `.TH` - Title header (page title, section, date, etc.)
+- `.SH` - Section header
+- `.TP` - Tagged paragraph (for options)
+- `.B` - Bold text
+- `.I` - Italic text
+- `.BI` - Bold-italic (mixed)
+- `.BR` - Bold-roman (mixed)
+- `.PP` - Paragraph break
+
+Test your changes with `man ./git-ls.1` before committing.

--- a/manpage/git-ls.1
+++ b/manpage/git-ls.1
@@ -1,0 +1,81 @@
+.TH GIT-LS 1 "2026-04-08" "git-ls" "User Commands"
+.SH NAME
+git-ls \- show the current directory annotated with links and git info
+.SH SYNOPSIS
+.B git ls
+.RI [ <dir> ]
+.SH DESCRIPTION
+.B git-ls
+displays the files in the current directory, their current git status, a short
+diffstat, their last modified date, the author and a portion of the last commit
+message for that file.
+.PP
+All files are hyperlinked with OSC8 hyperlinks, so you should be able to open
+them by clicking on them in a properly-configured terminal. The author names are
+hyperlinked to GitHub if the repository has a GitHub remote, as are commit messages.
+.SH OPTIONS
+.TP
+.B \-\-version
+Print the version number and exit.
+.TP
+.BR \-\-help ", " \-h
+Print the help message and exit.
+.TP
+.BI \-\-diffWidth= n
+Print the diffStat graph with the given width. Default is 4.
+.TP
+.BI \-\-format= col1,col2,...
+Specify which columns to display and in what order. Valid columns:
+.BR status ", " diff ", " filename ", " shorthash ", " hash ", " date ", " author ", "
+.BR email ", " numstat ", " commitmessage .
+.br
+Default:
+.BR status,diff,filename,shorthash,date,author,commitmessage .
+.TP
+.B \-\-mono\-hash
+Use a single color (cyan) for all commit hashes instead of coloring each hash
+uniquely based on its value.
+.TP
+.B \-\-nerdfont
+Replace git status letters with Nerd Font icons (requires a Nerd Font-patched
+terminal font).
+.TP
+.BR \-c ", " \-\-changed\-only
+Only show files that have changes (appear in git status). This filters out
+unmodified tracked files and shows only files with status indicators (modified,
+added, deleted, renamed, etc.).
+.SH EXAMPLES
+.TP
+.B git ls
+Show all files in the current directory with git information.
+.TP
+.B git ls \-\-changed\-only
+Show only files that have uncommitted changes.
+.TP
+.B git ls \-\-format=filename,status,author
+Show custom columns: filename, status, and author only.
+.TP
+.B git ls \-\-diffWidth=8
+Show a wider diffstat graph (8 characters instead of 4).
+.SH TERMINAL SUPPORT
+For the best experience, use a terminal that supports OSC8 hyperlinks, such as:
+.IP \(bu 2
+kitty
+.IP \(bu 2
+iTerm2
+.IP \(bu 2
+WezTerm
+.PP
+In these terminals, you can click on filenames to open them in your preferred
+editor, or click on a PR number in a commit status to go straight to that PR in
+your browser.
+.SH AUTHOR
+Written by Bill Mill.
+.SH BUGS
+Report bugs at: https://github.com/llimllib/git-ls/issues
+.SH SEE ALSO
+.BR git (1),
+.BR git-status (1),
+.BR git-log (1)
+.PP
+Full documentation at: https://github.com/llimllib/git-ls

--- a/transcripts/42-add-man-page.html
+++ b/transcripts/42-add-man-page.html
@@ -1,0 +1,4017 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Session Export</title>
+  <style>
+    :root {
+      --accent: #8abeb7;
+      --border: #5f87ff;
+      --borderAccent: #00d7ff;
+      --borderMuted: #505050;
+      --success: #b5bd68;
+      --error: #cc6666;
+      --warning: #ffff00;
+      --muted: #808080;
+      --dim: #666666;
+      --text: #e5e5e7;
+      --thinkingText: #808080;
+      --selectedBg: #3a3a4a;
+      --userMessageBg: #343541;
+      --userMessageText: #e5e5e7;
+      --customMessageBg: #2d2838;
+      --customMessageText: #e5e5e7;
+      --customMessageLabel: #9575cd;
+      --toolPendingBg: #282832;
+      --toolSuccessBg: #283228;
+      --toolErrorBg: #3c2828;
+      --toolTitle: #e5e5e7;
+      --toolOutput: #808080;
+      --mdHeading: #f0c674;
+      --mdLink: #81a2be;
+      --mdLinkUrl: #666666;
+      --mdCode: #8abeb7;
+      --mdCodeBlock: #b5bd68;
+      --mdCodeBlockBorder: #808080;
+      --mdQuote: #808080;
+      --mdQuoteBorder: #808080;
+      --mdHr: #808080;
+      --mdListBullet: #8abeb7;
+      --toolDiffAdded: #b5bd68;
+      --toolDiffRemoved: #cc6666;
+      --toolDiffContext: #808080;
+      --syntaxComment: #6A9955;
+      --syntaxKeyword: #569CD6;
+      --syntaxFunction: #DCDCAA;
+      --syntaxVariable: #9CDCFE;
+      --syntaxString: #CE9178;
+      --syntaxNumber: #B5CEA8;
+      --syntaxType: #4EC9B0;
+      --syntaxOperator: #D4D4D4;
+      --syntaxPunctuation: #D4D4D4;
+      --thinkingOff: #505050;
+      --thinkingMinimal: #6e6e6e;
+      --thinkingLow: #5f87af;
+      --thinkingMedium: #81a2be;
+      --thinkingHigh: #b294bb;
+      --thinkingXhigh: #d183e8;
+      --bashMode: #b5bd68;
+      --exportPageBg: #18181e;
+      --exportCardBg: #1e1e24;
+      --exportInfoBg: #3c3728;
+      --body-bg: #18181e;
+      --container-bg: #1e1e24;
+      --info-bg: #3c3728;
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    :root {
+      --line-height: 18px; /* 12px font * 1.5 */
+      --sidebar-width: 400px;
+      --sidebar-min-width: 240px;
+      --sidebar-max-width: 840px;
+      --sidebar-resizer-width: 6px;
+    }
+
+    body {
+      font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
+      font-size: 12px;
+      line-height: var(--line-height);
+      color: var(--text);
+      background: var(--body-bg);
+    }
+
+    body.sidebar-resizing {
+      cursor: col-resize;
+      user-select: none;
+    }
+
+    #app {
+      display: flex;
+      min-height: 100vh;
+    }
+
+    /* Sidebar */
+    #sidebar {
+      width: var(--sidebar-width);
+      min-width: var(--sidebar-width);
+      max-width: var(--sidebar-width);
+      background: var(--container-bg);
+      flex-shrink: 0;
+      display: flex;
+      flex-direction: column;
+      position: sticky;
+      top: 0;
+      height: 100vh;
+      border-right: 1px solid var(--dim);
+    }
+
+    #sidebar-resizer {
+      width: var(--sidebar-resizer-width);
+      flex-shrink: 0;
+      position: sticky;
+      top: 0;
+      height: 100vh;
+      cursor: col-resize;
+      touch-action: none;
+      background: transparent;
+      border-right: 1px solid transparent;
+    }
+
+    #sidebar-resizer:hover,
+    body.sidebar-resizing #sidebar-resizer {
+      background: var(--selectedBg);
+      border-right-color: var(--dim);
+    }
+
+    .sidebar-header {
+      padding: 8px 12px;
+      flex-shrink: 0;
+    }
+
+    .sidebar-controls {
+      padding: 8px 8px 4px 8px;
+    }
+
+    .sidebar-search {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 4px 8px;
+      font-size: 11px;
+      font-family: inherit;
+      background: var(--body-bg);
+      color: var(--text);
+      border: 1px solid var(--dim);
+      border-radius: 3px;
+    }
+
+    .sidebar-filters {
+      display: flex;
+      padding: 4px 8px 8px 8px;
+      gap: 4px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    .sidebar-search:focus {
+      outline: none;
+      border-color: var(--accent);
+    }
+
+    .sidebar-search::placeholder {
+      color: var(--muted);
+    }
+
+    .filter-btn {
+      padding: 3px 8px;
+      font-size: 10px;
+      font-family: inherit;
+      background: transparent;
+      color: var(--muted);
+      border: 1px solid var(--dim);
+      border-radius: 3px;
+      cursor: pointer;
+    }
+
+    .filter-btn:hover {
+      color: var(--text);
+      border-color: var(--text);
+    }
+
+    .filter-btn.active {
+      background: var(--accent);
+      color: var(--body-bg);
+      border-color: var(--accent);
+    }
+
+    .sidebar-close {
+      display: none;
+      padding: 3px 8px;
+      font-size: 12px;
+      font-family: inherit;
+      background: transparent;
+      color: var(--muted);
+      border: 1px solid var(--dim);
+      border-radius: 3px;
+      cursor: pointer;
+      margin-left: auto;
+    }
+
+    .sidebar-close:hover {
+      color: var(--text);
+      border-color: var(--text);
+    }
+
+    .tree-container {
+      flex: 1;
+      overflow: auto;
+      padding: 4px 0;
+    }
+
+    .tree-node {
+      padding: 0 8px;
+      cursor: pointer;
+      display: flex;
+      align-items: baseline;
+      font-size: 11px;
+      line-height: 13px;
+      white-space: nowrap;
+    }
+
+    .tree-node:hover {
+      background: var(--selectedBg);
+    }
+
+    .tree-node.active {
+      background: var(--selectedBg);
+    }
+
+    .tree-node.active .tree-content {
+      font-weight: bold;
+    }
+
+    .tree-node.in-path {
+      background: color-mix(in srgb, var(--accent) 10%, transparent);
+    }
+
+    .tree-node:not(.in-path) {
+      opacity: 0.5;
+    }
+
+    .tree-node:not(.in-path):hover {
+      opacity: 1;
+    }
+
+    .tree-prefix {
+      color: var(--muted);
+      flex-shrink: 0;
+      font-family: monospace;
+      white-space: pre;
+    }
+
+    .tree-marker {
+      color: var(--accent);
+      flex-shrink: 0;
+    }
+
+    .tree-content {
+      color: var(--text);
+    }
+
+    .tree-role-user {
+      color: var(--accent);
+    }
+
+    .tree-role-assistant {
+      color: var(--success);
+    }
+
+    .tree-role-tool {
+      color: var(--muted);
+    }
+
+    .tree-muted {
+      color: var(--muted);
+    }
+
+    .tree-error {
+      color: var(--error);
+    }
+
+    .tree-compaction {
+      color: var(--borderAccent);
+    }
+
+    .tree-branch-summary {
+      color: var(--warning);
+    }
+
+    .tree-custom-message {
+      color: var(--customMessageLabel);
+    }
+
+    .tree-status {
+      padding: 4px 12px;
+      font-size: 10px;
+      color: var(--muted);
+      flex-shrink: 0;
+    }
+
+    /* Main content */
+    #content {
+      flex: 1;
+      min-width: 0;
+      overflow-y: auto;
+      padding: var(--line-height) calc(var(--line-height) * 2);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #content > * {
+      width: 100%;
+      max-width: 800px;
+    }
+
+    /* Help bar */
+    .help-bar {
+      font-size: 11px;
+      color: var(--warning);
+      margin-bottom: var(--line-height);
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .download-json-btn {
+      font-size: 10px;
+      padding: 2px 8px;
+      background: var(--container-bg);
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      color: var(--text);
+      cursor: pointer;
+      font-family: inherit;
+    }
+
+    .download-json-btn:hover {
+      background: var(--hover);
+      border-color: var(--borderAccent);
+    }
+
+    /* Header */
+    .header {
+      background: var(--container-bg);
+      border-radius: 4px;
+      padding: var(--line-height);
+      margin-bottom: var(--line-height);
+    }
+
+    .header h1 {
+      font-size: 12px;
+      font-weight: bold;
+      color: var(--borderAccent);
+      margin-bottom: var(--line-height);
+    }
+
+    .header-info {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+      font-size: 11px;
+    }
+
+    .info-item {
+      color: var(--dim);
+      display: flex;
+      align-items: baseline;
+    }
+
+    .info-label {
+      font-weight: 600;
+      margin-right: 8px;
+      min-width: 100px;
+    }
+
+    .info-value {
+      color: var(--text);
+      flex: 1;
+    }
+
+    /* Messages */
+    #messages {
+      display: flex;
+      flex-direction: column;
+      gap: var(--line-height);
+    }
+
+    .message-timestamp {
+      font-size: 10px;
+      color: var(--dim);
+      opacity: 0.8;
+    }
+
+    .user-message {
+      background: var(--userMessageBg);
+      color: var(--userMessageText);
+      padding: var(--line-height);
+      border-radius: 4px;
+      position: relative;
+    }
+
+    .assistant-message {
+      padding: 0;
+      position: relative;
+    }
+
+    /* Copy link button - appears on hover */
+    .copy-link-btn {
+      position: absolute;
+      top: 8px;
+      right: 8px;
+      width: 28px;
+      height: 28px;
+      padding: 6px;
+      background: var(--container-bg);
+      border: 1px solid var(--dim);
+      border-radius: 4px;
+      color: var(--muted);
+      cursor: pointer;
+      opacity: 0;
+      transition: opacity 0.15s, background 0.15s, color 0.15s;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 10;
+    }
+
+    .user-message:hover .copy-link-btn,
+    .assistant-message:hover .copy-link-btn {
+      opacity: 1;
+    }
+
+    .copy-link-btn:hover {
+      background: var(--accent);
+      color: var(--body-bg);
+      border-color: var(--accent);
+    }
+
+    .copy-link-btn.copied {
+      background: var(--success, #22c55e);
+      color: white;
+      border-color: var(--success, #22c55e);
+    }
+
+    /* Highlight effect for deep-linked messages */
+    .user-message.highlight,
+    .assistant-message.highlight {
+      animation: highlight-pulse 2s ease-out;
+    }
+
+    @keyframes highlight-pulse {
+      0% {
+        box-shadow: 0 0 0 3px var(--accent);
+      }
+      100% {
+        box-shadow: 0 0 0 0 transparent;
+      }
+    }
+
+    .assistant-message > .message-timestamp {
+      padding-left: var(--line-height);
+    }
+
+    .assistant-text {
+      padding: var(--line-height);
+      padding-bottom: 0;
+    }
+
+    .message-timestamp + .assistant-text,
+    .message-timestamp + .thinking-block {
+      padding-top: 0;
+    }
+
+    .thinking-block + .assistant-text {
+      padding-top: 0;
+    }
+
+    .thinking-text {
+      padding: var(--line-height);
+      color: var(--thinkingText);
+      font-style: italic;
+      white-space: pre-wrap;
+    }
+
+    .message-timestamp + .thinking-block .thinking-text,
+    .message-timestamp + .thinking-block .thinking-collapsed {
+      padding-top: 0;
+    }
+
+    .thinking-collapsed {
+      display: none;
+      padding: var(--line-height);
+      color: var(--thinkingText);
+      font-style: italic;
+    }
+
+    /* Tool execution */
+    .tool-execution {
+      padding: var(--line-height);
+      border-radius: 4px;
+    }
+
+    .tool-execution + .tool-execution {
+      margin-top: var(--line-height);
+    }
+
+    .assistant-text + .tool-execution {
+      margin-top: var(--line-height);
+    }
+
+    .tool-execution.pending { background: var(--toolPendingBg); }
+    .tool-execution.success { background: var(--toolSuccessBg); }
+    .tool-execution.error { background: var(--toolErrorBg); }
+
+    .tool-header, .tool-name {
+      font-weight: bold;
+    }
+
+    .tool-path {
+      color: var(--accent);
+      word-break: break-all;
+    }
+
+    .line-numbers {
+      color: var(--warning);
+    }
+
+    .line-count {
+      color: var(--dim);
+    }
+
+    .tool-command {
+      font-weight: bold;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      overflow-wrap: break-word;
+      word-break: break-word;
+    }
+
+    .tool-output {
+      margin-top: var(--line-height);
+      color: var(--toolOutput);
+      word-wrap: break-word;
+      overflow-wrap: break-word;
+      word-break: break-word;
+      font-family: inherit;
+      overflow-x: auto;
+    }
+
+    .tool-output > div,
+    .output-preview,
+    .output-full {
+      margin: 0;
+      padding: 0;
+      line-height: var(--line-height);
+    }
+
+    .tool-output pre {
+      margin: 0;
+      padding: 0;
+      font-family: inherit;
+      color: inherit;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      overflow-wrap: break-word;
+    }
+
+    .tool-output code {
+      padding: 0;
+      background: none;
+      color: var(--text);
+    }
+
+    .tool-output.expandable {
+      cursor: pointer;
+    }
+
+    .tool-output.expandable:hover {
+      opacity: 0.9;
+    }
+
+    .tool-output.expandable .output-full {
+      display: none;
+    }
+
+    .tool-output.expandable.expanded .output-preview {
+      display: none;
+    }
+
+    .tool-output.expandable.expanded .output-full {
+      display: block;
+    }
+
+    .ansi-line {
+      white-space: pre-wrap;
+    }
+
+    .tool-images {
+    }
+
+    .tool-image {
+      max-width: 100%;
+      max-height: 500px;
+      border-radius: 4px;
+      margin: var(--line-height) 0;
+    }
+
+    .expand-hint {
+      color: var(--toolOutput);
+    }
+
+    /* Diff */
+    .tool-diff {
+      font-size: 11px;
+      overflow-x: auto;
+      white-space: pre;
+    }
+
+    .diff-added { color: var(--toolDiffAdded); }
+    .diff-removed { color: var(--toolDiffRemoved); }
+    .diff-context { color: var(--toolDiffContext); }
+
+    /* Model change */
+    .model-change {
+      padding: 0 var(--line-height);
+      color: var(--dim);
+      font-size: 11px;
+    }
+
+    .model-name {
+      color: var(--borderAccent);
+      font-weight: bold;
+    }
+
+    /* Compaction / Branch Summary - matches customMessage colors from TUI */
+    .compaction {
+      background: var(--customMessageBg);
+      border-radius: 4px;
+      padding: var(--line-height);
+      cursor: pointer;
+    }
+
+    .compaction-label {
+      color: var(--customMessageLabel);
+      font-weight: bold;
+    }
+
+    .compaction-collapsed {
+      color: var(--customMessageText);
+    }
+
+    .compaction-content {
+      display: none;
+      color: var(--customMessageText);
+      white-space: pre-wrap;
+      margin-top: var(--line-height);
+    }
+
+    .compaction.expanded .compaction-collapsed {
+      display: none;
+    }
+
+    .compaction.expanded .compaction-content {
+      display: block;
+    }
+
+    /* System prompt */
+    .system-prompt {
+      background: var(--customMessageBg);
+      padding: var(--line-height);
+      border-radius: 4px;
+      margin-bottom: var(--line-height);
+    }
+
+    .system-prompt.expandable {
+      cursor: pointer;
+    }
+
+    .system-prompt-header {
+      font-weight: bold;
+      color: var(--customMessageLabel);
+    }
+
+    .system-prompt-preview {
+      color: var(--customMessageText);
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      font-size: 11px;
+      margin-top: var(--line-height);
+    }
+
+    .system-prompt-expand-hint {
+      color: var(--muted);
+      font-style: italic;
+      margin-top: 4px;
+    }
+
+    .system-prompt-full {
+      display: none;
+      color: var(--customMessageText);
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      font-size: 11px;
+      margin-top: var(--line-height);
+    }
+
+    .system-prompt.expanded .system-prompt-preview,
+    .system-prompt.expanded .system-prompt-expand-hint {
+      display: none;
+    }
+
+    .system-prompt.expanded .system-prompt-full {
+      display: block;
+    }
+
+    .system-prompt.provider-prompt {
+      border-left: 3px solid var(--warning);
+    }
+
+    .system-prompt-note {
+      font-size: 10px;
+      font-style: italic;
+      color: var(--muted);
+      margin-top: 4px;
+    }
+
+    /* Tools list */
+    .tools-list {
+      background: var(--customMessageBg);
+      padding: var(--line-height);
+      border-radius: 4px;
+      margin-bottom: var(--line-height);
+    }
+
+    .tools-header {
+      font-weight: bold;
+      color: var(--customMessageLabel);
+      margin-bottom: var(--line-height);
+    }
+
+    .tool-item {
+      font-size: 11px;
+    }
+
+    .tool-item-name {
+      font-weight: bold;
+      color: var(--text);
+    }
+
+    .tool-item-desc {
+      color: var(--dim);
+    }
+
+    .tool-params-hint {
+      color: var(--muted);
+      font-style: italic;
+    }
+
+    .tool-item:has(.tool-params-hint) {
+      cursor: pointer;
+    }
+
+    .tool-params-hint::after {
+      content: '[click to show parameters]';
+    }
+
+    .tool-item.params-expanded .tool-params-hint::after {
+      content: '[hide parameters]';
+    }
+
+    .tool-params-content {
+      display: none;
+      margin-top: 4px;
+      margin-left: 12px;
+      padding-left: 8px;
+      border-left: 1px solid var(--dim);
+    }
+
+    .tool-item.params-expanded .tool-params-content {
+      display: block;
+    }
+
+    .tool-param {
+      margin-bottom: 4px;
+      font-size: 11px;
+    }
+
+    .tool-param-name {
+      font-weight: bold;
+      color: var(--text);
+    }
+
+    .tool-param-type {
+      color: var(--dim);
+      font-style: italic;
+    }
+
+    .tool-param-required {
+      color: var(--warning, #e8a838);
+      font-size: 10px;
+    }
+
+    .tool-param-optional {
+      color: var(--dim);
+      font-size: 10px;
+    }
+
+    .tool-param-desc {
+      color: var(--dim);
+      margin-left: 8px;
+    }
+
+    /* Hook/custom messages */
+    .hook-message {
+      background: var(--customMessageBg);
+      color: var(--customMessageText);
+      padding: var(--line-height);
+      border-radius: 4px;
+    }
+
+    .hook-type {
+      color: var(--customMessageLabel);
+      font-weight: bold;
+    }
+
+    /* Branch summary */
+    .branch-summary {
+      background: var(--customMessageBg);
+      padding: var(--line-height);
+      border-radius: 4px;
+    }
+
+    .branch-summary-header {
+      font-weight: bold;
+      color: var(--borderAccent);
+    }
+
+    /* Error */
+    .error-text {
+      color: var(--error);
+      padding: 0 var(--line-height);
+    }
+    .tool-error {
+      color: var(--error);
+    }
+
+    /* Images */
+    .message-images {
+      margin-bottom: 12px;
+    }
+
+    .message-image {
+      max-width: 100%;
+      max-height: 400px;
+      border-radius: 4px;
+      margin: var(--line-height) 0;
+    }
+
+    /* Markdown content */
+    .markdown-content h1,
+    .markdown-content h2,
+    .markdown-content h3,
+    .markdown-content h4,
+    .markdown-content h5,
+    .markdown-content h6 {
+      color: var(--mdHeading);
+      margin: var(--line-height) 0 0 0;
+      font-weight: bold;
+    }
+
+    .markdown-content h1 { font-size: 1em; }
+    .markdown-content h2 { font-size: 1em; }
+    .markdown-content h3 { font-size: 1em; }
+    .markdown-content h4 { font-size: 1em; }
+    .markdown-content h5 { font-size: 1em; }
+    .markdown-content h6 { font-size: 1em; }
+    .markdown-content p { margin: 0; }
+    .markdown-content p + p { margin-top: var(--line-height); }
+
+    .markdown-content a {
+      color: var(--mdLink);
+      text-decoration: underline;
+    }
+
+    .markdown-content code {
+      background: rgba(128, 128, 128, 0.2);
+      color: var(--mdCode);
+      padding: 0 4px;
+      border-radius: 3px;
+      font-family: inherit;
+    }
+
+    .markdown-content pre {
+      background: transparent;
+      margin: var(--line-height) 0;
+      overflow-x: auto;
+    }
+
+    .markdown-content pre code {
+      display: block;
+      background: none;
+      color: var(--text);
+    }
+
+    .markdown-content blockquote {
+      border-left: 3px solid var(--mdQuoteBorder);
+      padding-left: var(--line-height);
+      margin: var(--line-height) 0;
+      color: var(--mdQuote);
+      font-style: italic;
+    }
+
+    .markdown-content ul,
+    .markdown-content ol {
+      margin: var(--line-height) 0;
+      padding-left: calc(var(--line-height) * 2);
+    }
+
+    .markdown-content li { margin: 0; }
+    .markdown-content li::marker { color: var(--mdListBullet); }
+
+    .markdown-content hr {
+      border: none;
+      border-top: 1px solid var(--mdHr);
+      margin: var(--line-height) 0;
+    }
+
+    .markdown-content table {
+      border-collapse: collapse;
+      margin: 0.5em 0;
+      width: 100%;
+    }
+
+    .markdown-content th,
+    .markdown-content td {
+      border: 1px solid var(--mdCodeBlockBorder);
+      padding: 6px 10px;
+      text-align: left;
+    }
+
+    .markdown-content th {
+      background: rgba(128, 128, 128, 0.1);
+      font-weight: bold;
+    }
+
+    .markdown-content img {
+      max-width: 100%;
+      border-radius: 4px;
+    }
+
+    /* Syntax highlighting */
+    .hljs { background: transparent; color: var(--text); }
+    .hljs-comment, .hljs-quote { color: var(--syntaxComment); }
+    .hljs-keyword, .hljs-selector-tag { color: var(--syntaxKeyword); }
+    .hljs-number, .hljs-literal { color: var(--syntaxNumber); }
+    .hljs-string, .hljs-doctag { color: var(--syntaxString); }
+    /* Function names: hljs v11 uses .hljs-title.function_ compound class */
+    .hljs-function, .hljs-title, .hljs-title.function_, .hljs-section, .hljs-name { color: var(--syntaxFunction); }
+    /* Types: hljs v11 uses .hljs-title.class_ for class names */
+    .hljs-type, .hljs-class, .hljs-title.class_, .hljs-built_in { color: var(--syntaxType); }
+    .hljs-attr, .hljs-variable, .hljs-variable.language_, .hljs-params, .hljs-property { color: var(--syntaxVariable); }
+    .hljs-meta, .hljs-meta .hljs-keyword, .hljs-meta .hljs-string { color: var(--syntaxKeyword); }
+    .hljs-operator { color: var(--syntaxOperator); }
+    .hljs-punctuation { color: var(--syntaxPunctuation); }
+    .hljs-subst { color: var(--text); }
+
+    /* Footer */
+    .footer {
+      margin-top: 48px;
+      padding: 20px;
+      text-align: center;
+      color: var(--dim);
+      font-size: 10px;
+    }
+
+    /* Mobile */
+    #hamburger {
+      display: none;
+      position: fixed;
+      top: 10px;
+      left: 10px;
+      z-index: 100;
+      padding: 3px 8px;
+      font-size: 12px;
+      font-family: inherit;
+      background: transparent;
+      color: var(--muted);
+      border: 1px solid var(--dim);
+      border-radius: 3px;
+      cursor: pointer;
+    }
+
+    #hamburger:hover {
+      color: var(--text);
+      border-color: var(--text);
+    }
+
+
+
+    #sidebar-overlay {
+      display: none;
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(0, 0, 0, 0.5);
+      z-index: 98;
+    }
+
+    @media (max-width: 900px) {
+      #sidebar {
+        position: fixed;
+        left: 0;
+        width: min(var(--sidebar-width), 100vw);
+        min-width: min(var(--sidebar-width), 100vw);
+        max-width: min(var(--sidebar-width), 100vw);
+        top: 0;
+        bottom: 0;
+        height: 100vh;
+        z-index: 99;
+        transform: translateX(-100%);
+        transition: transform 0.3s;
+      }
+
+      #sidebar.open {
+        transform: translateX(0);
+      }
+
+      #sidebar-resizer {
+        display: none;
+      }
+
+      #sidebar-overlay.open {
+        display: block;
+      }
+
+      #hamburger {
+        display: block;
+      }
+
+      .sidebar-close {
+        display: block;
+      }
+
+      #content {
+        padding: var(--line-height) 16px;
+      }
+
+      #content > * {
+        max-width: 100%;
+      }
+    }
+
+    @media print {
+      #sidebar, #sidebar-resizer, #sidebar-toggle { display: none !important; }
+      body { background: white; color: black; }
+      #content { max-width: none; }
+    }
+
+  </style>
+</head>
+<body>
+  <button id="hamburger" title="Open sidebar"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none"><circle cx="6" cy="6" r="2.5"/><circle cx="6" cy="18" r="2.5"/><circle cx="18" cy="12" r="2.5"/><rect x="5" y="6" width="2" height="12"/><path d="M6 12h10c1 0 2 0 2-2V8"/></svg></button>
+  <div id="sidebar-overlay"></div>
+  <div id="app">
+    <aside id="sidebar">
+      <div class="sidebar-header">
+        <div class="sidebar-controls">
+          <input type="text" class="sidebar-search" id="tree-search" placeholder="Search...">
+        </div>
+        <div class="sidebar-filters">
+          <button class="filter-btn active" data-filter="default" title="Hide settings entries">Default</button>
+          <button class="filter-btn" data-filter="no-tools" title="Default minus tool results">No-tools</button>
+          <button class="filter-btn" data-filter="user-only" title="Only user messages">User</button>
+          <button class="filter-btn" data-filter="labeled-only" title="Only labeled entries">Labeled</button>
+          <button class="filter-btn" data-filter="all" title="Show everything">All</button>
+          <button class="sidebar-close" id="sidebar-close" title="Close">✕</button>
+        </div>
+      </div>
+      <div class="tree-container" id="tree-container"></div>
+      <div class="tree-status" id="tree-status"></div>
+    </aside>
+    <div id="sidebar-resizer" role="separator" aria-orientation="vertical" aria-label="Resize session tree sidebar"></div>
+    <main id="content">
+      <div id="header-container"></div>
+      <div id="messages"></div>
+    </main>
+    <div id="image-modal" class="image-modal">
+      <img id="modal-image" src="" alt="">
+    </div>
+  </div>
+
+  <script id="session-data" type="application/json">eyJoZWFkZXIiOnsidHlwZSI6InNlc3Npb24iLCJ2ZXJzaW9uIjozLCJpZCI6ImQ2ZTQ1ZDcwLWE3ODItNDcxYi04NGMzLWVkNTQ3ZDFkYmZmYiIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDI6NTIuNzYyWiIsImN3ZCI6Ii9Vc2Vycy9sbGltbGxpYi9jb2RlL2dpdC1scy9tYW5wYWdlIn0sImVudHJpZXMiOlt7InR5cGUiOiJtb2RlbF9jaGFuZ2UiLCJpZCI6Ijc4NjU4N2M0IiwicGFyZW50SWQiOm51bGwsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDI6NTIuNzkyWiIsInByb3ZpZGVyIjoic29ubmV0LWJlZHJvY2siLCJtb2RlbElkIjoiYXJuOmF3czpiZWRyb2NrOnVzLWVhc3QtMTo2ODYxNTA2ODI5Njc6YXBwbGljYXRpb24taW5mZXJlbmNlLXByb2ZpbGUvNXNpejA0eGxxcTlnIn0seyJ0eXBlIjoidGhpbmtpbmdfbGV2ZWxfY2hhbmdlIiwiaWQiOiI4YzkyNzhiNiIsInBhcmVudElkIjoiNzg2NTg3YzQiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjAyOjUyLjc5MloiLCJ0aGlua2luZ0xldmVsIjoib2ZmIn0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiZTkxYjVkMGEiLCJwYXJlbnRJZCI6IjhjOTI3OGI2IiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowMzozMS45NzdaIiwibWVzc2FnZSI6eyJyb2xlIjoidXNlciIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6ImhvdyB3b3VsZCB3ZSBnZW5lcmF0ZSBhIG1hbiBwYWdlIGZvciBnaXQtbHM/IFdoZW4gd2UgY2FsbCBpdCBhcyBgZ2l0IGxzIC0taGVscGAsIGdpdCB0cmllcyB0byBsb2FkIHRoZSBtYW4gcGFnZSBidXQgb25lIGRvZXNuJ3QgZXhpc3QuIERvZXMgYnJldyBzdXBwb3J0IGluc3RhbGxpbmcgbWFuIHBhZ2VzPyJ9XSwidGltZXN0YW1wIjoxNzc1NjEwMjExOTczfX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiNmVhODUxYWIiLCJwYXJlbnRJZCI6ImU5MWI1ZDBhIiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowMzozMi40MTNaIiwibWVzc2FnZSI6eyJyb2xlIjoiYXNzaXN0YW50IiwiY29udGVudCI6W10sImFwaSI6ImJlZHJvY2stY29udmVyc2Utc3RyZWFtIiwicHJvdmlkZXIiOiJzb25uZXQtYmVkcm9jayIsIm1vZGVsIjoiYXJuOmF3czpiZWRyb2NrOnVzLWVhc3QtMTo2ODYxNTA2ODI5Njc6YXBwbGljYXRpb24taW5mZXJlbmNlLXByb2ZpbGUvNXNpejA0eGxxcTlnIiwidXNhZ2UiOnsiaW5wdXQiOjAsIm91dHB1dCI6MCwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbFRva2VucyI6MCwiY29zdCI6eyJpbnB1dCI6MCwib3V0cHV0IjowLCJjYWNoZVJlYWQiOjAsImNhY2hlV3JpdGUiOjAsInRvdGFsIjowfX0sInN0b3BSZWFzb24iOiJlcnJvciIsInRpbWVzdGFtcCI6MTc3NTYxMDIxMjA1OCwiZXJyb3JNZXNzYWdlIjoiVG9rZW4gaXMgZXhwaXJlZC4gVG8gcmVmcmVzaCB0aGlzIFNTTyBzZXNzaW9uIHJ1biAnYXdzIHNzbyBsb2dpbicgd2l0aCB0aGUgY29ycmVzcG9uZGluZyBwcm9maWxlLiJ9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiI4NTM2NzU0YyIsInBhcmVudElkIjoiNmVhODUxYWIiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjAzOjQ4Ljk0NVoiLCJtZXNzYWdlIjp7InJvbGUiOiJ1c2VyIiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoiaG93IHdvdWxkIHdlIGdlbmVyYXRlIGEgbWFuIHBhZ2UgZm9yIGdpdC1scz8gV2hlbiB3ZSBjYWxsIGl0IGFzIGBnaXQgbHMgLS1oZWxwYCwgZ2l0IHRyaWVzIHRvIGxvYWQgdGhlIG1hbiBwYWdlIGJ1dCBvbmUgZG9lc24ndCBleGlzdC4gRG9lcyBicmV3IHN1cHBvcnQgaW5zdGFsbGluZyBtYW4gcGFnZXM/In1dLCJ0aW1lc3RhbXAiOjE3NzU2MTAyMjg5NDV9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiI3ZjkxNDA4MiIsInBhcmVudElkIjoiODUzNjc1NGMiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjAzOjUzLjk4OVoiLCJtZXNzYWdlIjp7InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiJHcmVhdCBxdWVzdGlvbiEgTGV0IG1lIGV4cGxvcmUgdGhpcyB3aXRoIHlvdS5cblxuWWVzLCBIb21lYnJldyBkb2VzIHN1cHBvcnQgaW5zdGFsbGluZyBtYW4gcGFnZXMuIExldCBtZSBjaGVjayB5b3VyIGN1cnJlbnQgc2V0dXAgYW5kIHNlZSB3aGF0IHdvdWxkIGJlIGludm9sdmVkLiJ9LHsidHlwZSI6InRvb2xDYWxsIiwiaWQiOiJ0b29sdXNlX0FTRkdPYUtaWHBQMXQweE1Sc1BLVEsiLCJuYW1lIjoiYmFzaCIsImFyZ3VtZW50cyI6eyJjb21tYW5kIjoibHMgLWxhIn19LHsidHlwZSI6InRvb2xDYWxsIiwiaWQiOiJ0b29sdXNlX0Z2N2NRR0VjSWR2WFlnMGNSSGZhMzMiLCJuYW1lIjoiYmFzaCIsImFyZ3VtZW50cyI6eyJjb21tYW5kIjoiZmluZCAuIC1uYW1lIFwiKi5yYlwiIC1vIC1uYW1lIFwiTWFrZWZpbGVcIiAtbyAtbmFtZSBcIioubWRcIiB8IGhlYWQgLTIwIn19XSwiYXBpIjoiYmVkcm9jay1jb252ZXJzZS1zdHJlYW0iLCJwcm92aWRlciI6InNvbm5ldC1iZWRyb2NrIiwibW9kZWwiOiJhcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY4NjE1MDY4Mjk2NzphcHBsaWNhdGlvbi1pbmZlcmVuY2UtcHJvZmlsZS81c2l6MDR4bHFxOWciLCJ1c2FnZSI6eyJpbnB1dCI6Mjg0OSwib3V0cHV0IjoxNTEsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWxUb2tlbnMiOjMwMDAsImNvc3QiOnsiaW5wdXQiOjAsIm91dHB1dCI6MCwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbCI6MH19LCJzdG9wUmVhc29uIjoidG9vbFVzZSIsInRpbWVzdGFtcCI6MTc3NTYxMDIyODk0NX19LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6ImYwZTZiMmEwIiwicGFyZW50SWQiOiI3ZjkxNDA4MiIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDM6NTQuMDIwWiIsIm1lc3NhZ2UiOnsicm9sZSI6InRvb2xSZXN1bHQiLCJ0b29sQ2FsbElkIjoidG9vbHVzZV9BU0ZHT2FLWlhwUDF0MHhNUnNQS1RLIiwidG9vbE5hbWUiOiJiYXNoIiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoidG90YWwgMjcyXG5kcnd4ci14ci14QCAyMyBsbGltbGxpYiAgc3RhZmYgICAgNzM2IEFwciAgNyAyMTowMiAuXG5kcnd4ci14ci14QCAgNSBsbGltbGxpYiAgc3RhZmYgICAgMTYwIEFwciAgNyAyMTowMiAuLlxuLXJ3LXItLXItLUAgIDEgbGxpbWxsaWIgIHN0YWZmICAgICA2NCBBcHIgIDcgMjE6MDIgLmdpdFxuZHJ3eHIteHIteEAgIDMgbGxpbWxsaWIgIHN0YWZmICAgICA5NiBBcHIgIDcgMjE6MDIgLmdpdGh1YlxuLXJ3LXItLXItLUAgIDEgbGxpbWxsaWIgIHN0YWZmICAgICA0MSBBcHIgIDcgMjE6MDIgLmdpdGlnbm9yZVxuLXJ3LXItLXItLUAgIDEgbGxpbWxsaWIgIHN0YWZmICAgIDEyNSBBcHIgIDcgMjE6MDIgLmdvbGFuZ2NpLnltbFxuLXJ3LXItLXItLUAgIDEgbGxpbWxsaWIgIHN0YWZmICAgMTQ4NSBBcHIgIDcgMjE6MDIgLmdvcmVsZWFzZXIueWFtbFxuLXJ3LXItLXItLUAgIDEgbGxpbWxsaWIgIHN0YWZmICAgIDE3MyBBcHIgIDcgMjE6MDIgQUdFTlRTLm1kXG5kcnd4ci14ci14QCAgMyBsbGltbGxpYiAgc3RhZmYgICAgIDk2IEFwciAgNyAyMTowMiBiaW5cbi1ydy1yLS1yLS1AICAxIGxsaW1sbGliICBzdGFmZiAgMTM5NjQgQXByICA3IDIxOjAyIGNvbHVtbnNfdGVzdC5nb1xuLXJ3LXItLXItLUAgIDEgbGxpbWxsaWIgIHN0YWZmICAxMzE4MCBBcHIgIDcgMjE6MDIgY29sdW1ucy5nb1xuZHJ3eHIteHIteEAgIDMgbGxpbWxsaWIgIHN0YWZmICAgICA5NiBBcHIgIDcgMjE6MDIgZG9jc1xuLXJ3LXItLXItLUAgIDEgbGxpbWxsaWIgIHN0YWZmICAgIDE1MyBBcHIgIDcgMjE6MDIgZ28ubW9kXG4tcnctci0tci0tQCAgMSBsbGltbGxpYiAgc3RhZmYgICAgMzYyIEFwciAgNyAyMTowMiBnby5zdW1cbi1ydy1yLS1yLS1AICAxIGxsaW1sbGliICBzdGFmZiAgIDEyMTEgQXByICA3IDIxOjAyIExJQ0VOU0Vcbi1ydy1yLS1yLS1AICAxIGxsaW1sbGliICBzdGFmZiAgMjg4OTAgQXByICA3IDIxOjAyIG1haW5fdGVzdC5nb1xuLXJ3LXItLXItLUAgIDEgbGxpbWxsaWIgIHN0YWZmICAyNzUzNCBBcHIgIDcgMjE6MDIgbWFpbi5nb1xuLXJ3LXItLXItLUAgIDEgbGxpbWxsaWIgIHN0YWZmICAgIDY2MCBBcHIgIDcgMjE6MDIgTWFrZWZpbGVcbi1ydy1yLS1yLS1AICAxIGxsaW1sbGliICBzdGFmZiAgICAxNDMgTWFyIDMxIDEwOjIxIG1pc2UudG9tbFxuLXJ3LXItLXItLUAgIDEgbGxpbWxsaWIgIHN0YWZmICAgMTIyNyBBcHIgIDcgMjE6MDIgUkVBRE1FLm1kXG5kcnd4ci14ci14QCAgMyBsbGltbGxpYiAgc3RhZmYgICAgIDk2IEFwciAgNyAyMTowMiBzdGF0aWNcbmRyd3hyLXhyLXhAICAzIGxsaW1sbGliICBzdGFmZiAgICAgOTYgQXByICA3IDIxOjAyIHRvb2xzXG5kcnd4ci14ci14QCAxMiBsbGltbGxpYiAgc3RhZmYgICAgMzg0IEFwciAgNyAyMTowMiB0cmFuc2NyaXB0c1xuIn1dLCJpc0Vycm9yIjpmYWxzZSwidGltZXN0YW1wIjoxNzc1NjEwMjM0MDIwfX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiZTljYmEyMTgiLCJwYXJlbnRJZCI6ImYwZTZiMmEwIiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowMzo1NC4wMjBaIiwibWVzc2FnZSI6eyJyb2xlIjoidG9vbFJlc3VsdCIsInRvb2xDYWxsSWQiOiJ0b29sdXNlX0Z2N2NRR0VjSWR2WFlnMGNSSGZhMzMiLCJ0b29sTmFtZSI6ImJhc2giLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiIuL01ha2VmaWxlXG4uL2RvY3MvZ2l0LWxvZy1zdHJlYW1pbmcubWRcbi4vUkVBRE1FLm1kXG4uL0FHRU5UUy5tZFxuIn1dLCJpc0Vycm9yIjpmYWxzZSwidGltZXN0YW1wIjoxNzc1NjEwMjM0MDIwfX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiMDg4YzM5ODIiLCJwYXJlbnRJZCI6ImU5Y2JhMjE4IiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowMzo1OC4yNzFaIiwibWVzc2FnZSI6eyJyb2xlIjoiYXNzaXN0YW50IiwiY29udGVudCI6W3sidHlwZSI6InRvb2xDYWxsIiwiaWQiOiJ0b29sdXNlX05ISTV0alFvYVcxQVAya2pvUVZDaDEiLCJuYW1lIjoicmVhZCIsImFyZ3VtZW50cyI6eyJwYXRoIjoiLmdvcmVsZWFzZXIueWFtbCJ9fSx7InR5cGUiOiJ0b29sQ2FsbCIsImlkIjoidG9vbHVzZV9SdzdGaDV2MUN5VzF1ZVVuNGhYN2RPIiwibmFtZSI6ImJhc2giLCJhcmd1bWVudHMiOnsiY29tbWFuZCI6ImxzIC1sYSBkb2NzLyJ9fSx7InR5cGUiOiJ0b29sQ2FsbCIsImlkIjoidG9vbHVzZV9YeDR1RlNKVWo5WmFQRklyc3dqcmR3IiwibmFtZSI6InJlYWQiLCJhcmd1bWVudHMiOnsicGF0aCI6Ik1ha2VmaWxlIn19XSwiYXBpIjoiYmVkcm9jay1jb252ZXJzZS1zdHJlYW0iLCJwcm92aWRlciI6InNvbm5ldC1iZWRyb2NrIiwibW9kZWwiOiJhcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY4NjE1MDY4Mjk2NzphcHBsaWNhdGlvbi1pbmZlcmVuY2UtcHJvZmlsZS81c2l6MDR4bHFxOWciLCJ1c2FnZSI6eyJpbnB1dCI6MzgzNywib3V0cHV0IjoxMzAsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWxUb2tlbnMiOjM5NjcsImNvc3QiOnsiaW5wdXQiOjAsIm91dHB1dCI6MCwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbCI6MH19LCJzdG9wUmVhc29uIjoidG9vbFVzZSIsInRpbWVzdGFtcCI6MTc3NTYxMDIzNDAyMX19LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6IjJhY2I1MmQ0IiwicGFyZW50SWQiOiIwODhjMzk4MiIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDM6NTguMjkwWiIsIm1lc3NhZ2UiOnsicm9sZSI6InRvb2xSZXN1bHQiLCJ0b29sQ2FsbElkIjoidG9vbHVzZV9OSEk1dGpRb2FXMUFQMmtqb1FWQ2gxIiwidG9vbE5hbWUiOiJyZWFkIiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoiIyBUaGlzIGlzIGFuIGV4YW1wbGUgLmdvcmVsZWFzZXIueW1sIGZpbGUgd2l0aCBzb21lIHNlbnNpYmxlIGRlZmF1bHRzLlxuIyBNYWtlIHN1cmUgdG8gY2hlY2sgdGhlIGRvY3VtZW50YXRpb24gYXQgaHR0cHM6Ly9nb3JlbGVhc2VyLmNvbVxuXG4jIFRoZSBsaW5lcyBiZWxvdyBhcmUgY2FsbGVkIGBtb2RlbGluZXNgLiBTZWUgYDpoZWxwIG1vZGVsaW5lYFxuIyBGZWVsIGZyZWUgdG8gcmVtb3ZlIHRob3NlIGlmIHlvdSBkb24ndCB3YW50L25lZWQgdG8gdXNlIHRoZW0uXG4jIHlhbWwtbGFuZ3VhZ2Utc2VydmVyOiAkc2NoZW1hPWh0dHBzOi8vZ29yZWxlYXNlci5jb20vc3RhdGljL3NjaGVtYS5qc29uXG4jIHZpbTogc2V0IHRzPTIgc3c9MiB0dz0wIGZvPWNucW9qXG5cbnZlcnNpb246IDJcblxuYmVmb3JlOlxuICBob29rczpcbiAgICAjIFlvdSBtYXkgcmVtb3ZlIHRoaXMgaWYgeW91IGRvbid0IHVzZSBnbyBtb2R1bGVzLlxuICAgIC0gZ28gbW9kIHRpZHlcblxuYnVpbGRzOlxuICAtIGVudjpcbiAgICAgIC0gQ0dPX0VOQUJMRUQ9MFxuICAgIGdvb3M6XG4gICAgICAtIGxpbnV4XG4gICAgICAtIGRhcndpblxuICAgICAgIyB3aW5kb3dzIHN1cHBvcnQgdGlja2V0OiBodHRwczovL2dpdGh1Yi5jb20vbGxpbWxsaWIvZ2l0LWxzL2lzc3Vlcy8xNFxuICAgICAgIyAtIHdpbmRvd3NcblxuYXJjaGl2ZXM6XG4gIC0gZm9ybWF0czogW1widGFyLmd6XCJdXG4gICAgIyB0aGlzIG5hbWUgdGVtcGxhdGUgbWFrZXMgdGhlIE9TIGFuZCBBcmNoIGNvbXBhdGlibGUgd2l0aCB0aGUgcmVzdWx0cyBvZiBgdW5hbWVgLlxuICAgIG5hbWVfdGVtcGxhdGU6ID4tXG4gICAgICB7eyAuUHJvamVjdE5hbWUgfX1fXG4gICAgICB7ey0gdGl0bGUgLk9zIH19X1xuICAgICAge3stIGlmIGVxIC5BcmNoIFwiYW1kNjRcIiB9fXg4Nl82NFxuICAgICAge3stIGVsc2UgaWYgZXEgLkFyY2ggXCIzODZcIiB9fWkzODZcbiAgICAgIHt7LSBlbHNlIH19e3sgLkFyY2ggfX17eyBlbmQgfX1cbiAgICAgIHt7LSBpZiAuQXJtIH19dnt7IC5Bcm0gfX17eyBlbmQgfX1cbiAgICAjIHVzZSB6aXAgZm9yIHdpbmRvd3MgYXJjaGl2ZXNcbiAgICBmb3JtYXRfb3ZlcnJpZGVzOlxuICAgICAgLSBnb29zOiB3aW5kb3dzXG4gICAgICAgIGZvcm1hdHM6IFtcInppcFwiXVxuXG5jaGFuZ2Vsb2c6XG4gIHNvcnQ6IGFzY1xuICBmaWx0ZXJzOlxuICAgIGV4Y2x1ZGU6XG4gICAgICAtIFwiXmRvY3M6XCJcbiAgICAgIC0gXCJedGVzdDpcIlxuXG5icmV3czpcbiAgLSBuYW1lOiBnaXQtbHNcbiAgICBob21lcGFnZTogXCJodHRwczovL2dpdGh1Yi5jb20vbGxpbWxsaWIvZ2l0LWxzXCJcbiAgICBkZXNjcmlwdGlvbjogXCJsaXN0IHRoZSBmaWxlcyBpbiB0aGUgY3VycmVudCBkaXJlY3RvcnkgYWxvbmcgd2l0aCBhIHVzZWZ1bCBzdW1tYXJ5IGFuZCBoZWxwZnVsIGh5cGVybGlua3MuXCJcbiAgICBsaWNlbnNlOiBcIlVubGljZW5zZVwiXG4gICAgcmVwb3NpdG9yeTpcbiAgICAgIG93bmVyOiBsbGltbGxpYlxuICAgICAgbmFtZTogaG9tZWJyZXctZ2l0LWxzXG4gICAgICBicmFuY2g6IG1haW5cbiJ9XSwiaXNFcnJvciI6ZmFsc2UsInRpbWVzdGFtcCI6MTc3NTYxMDIzODI4MH19LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6ImE4YWMzNWY0IiwicGFyZW50SWQiOiIyYWNiNTJkNCIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDM6NTguMjkyWiIsIm1lc3NhZ2UiOnsicm9sZSI6InRvb2xSZXN1bHQiLCJ0b29sQ2FsbElkIjoidG9vbHVzZV9SdzdGaDV2MUN5VzF1ZVVuNGhYN2RPIiwidG9vbE5hbWUiOiJiYXNoIiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoidG90YWwgMTZcbmRyd3hyLXhyLXhAICAzIGxsaW1sbGliICBzdGFmZiAgICA5NiBBcHIgIDcgMjE6MDIgLlxuZHJ3eHIteHIteEAgMjMgbGxpbWxsaWIgIHN0YWZmICAgNzM2IEFwciAgNyAyMTowMiAuLlxuLXJ3LXItLXItLUAgIDEgbGxpbWxsaWIgIHN0YWZmICA1NTgyIEFwciAgNyAyMTowMiBnaXQtbG9nLXN0cmVhbWluZy5tZFxuIn1dLCJpc0Vycm9yIjpmYWxzZSwidGltZXN0YW1wIjoxNzc1NjEwMjM4MjkyfX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiNDI4NzVhMzciLCJwYXJlbnRJZCI6ImE4YWMzNWY0IiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowMzo1OC4yOTZaIiwibWVzc2FnZSI6eyJyb2xlIjoidG9vbFJlc3VsdCIsInRvb2xDYWxsSWQiOiJ0b29sdXNlX1h4NHVGU0pVajlaYVBGSXJzd2pyZHciLCJ0b29sTmFtZSI6InJlYWQiLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiJTUkMgOj0gJChzaGVsbCBnaXQgbHMtZmlsZXMgJyouZ28nKVxuVFJBTlNDUklQVFMgOj0gJCh3aWxkY2FyZCB0cmFuc2NyaXB0cy8qKVxuU1RBVElDIDo9ICQod2lsZGNhcmQgc3RhdGljLyopXG5cbi5QSE9OWTogYWxsXG5hbGw6IGdpdC1sc1xuXG5naXQtbHM6ICQoU1JDKVxuXHRnbyBidWlsZFxuXG4jIGRlcGVuZHMgb24gZ29sYW5nY2ktbGludDpcbiMgaHR0cHM6Ly9nb2xhbmdjaS1saW50LnJ1bi93ZWxjb21lL2luc3RhbGwvI2xvY2FsLWluc3RhbGxhdGlvblxuLlBIT05ZOiBsaW50XG5saW50OlxuXHRAaWYgWyAtbiBcIiQkKGdvIGZtdCAuLy4uLilcIiBdOyB0aGVuIFxcXG5cdFx0ZWNobyBcIkVycm9yOiBUaGUgZm9sbG93aW5nIGZpbGVzIHdlcmUgcmVmb3JtYXR0ZWQuIFBsZWFzZSBjb21taXQgdGhlIGNoYW5nZXM6XCI7IFxcXG5cdFx0Z28gZm10IC4vLi4uOyBcXFxuXHRcdGV4aXQgMTsgXFxcblx0Zmlcblx0Z29sYW5nY2ktbGludCBydW5cblxuLlBIT05ZOiBwdWJsaXNoXG5wdWJsaXNoOlxuXHRtYWtlIGxpbnQgJiYgZ28gdGVzdCAmJiBiaW4vcmVsZWFzZS5zaFxuXG5fc2l0ZS9pbmRleC5odG1sOiBSRUFETUUubWQgJChUUkFOU0NSSVBUUykgJChTVEFUSUMpXG5cdEAuL3Rvb2xzL2J1aWxkLXNpdGUuc2hcblxuLlBIT05ZOiBzZXJ2ZS1zaXRlXG5zZXJ2ZS1zaXRlOiBfc2l0ZS9pbmRleC5odG1sXG5cdGRldmQgLW9sIC4vX3NpdGUvXG5cbiJ9XSwiaXNFcnJvciI6ZmFsc2UsInRpbWVzdGFtcCI6MTc3NTYxMDIzODI5M319LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6Ijg5ZjZkNTUwIiwicGFyZW50SWQiOiI0Mjg3NWEzNyIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDQ6MDIuMDMxWiIsIm1lc3NhZ2UiOnsicm9sZSI6ImFzc2lzdGFudCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6Ik5vdyBsZXQgbWUgY2hlY2sgd2hhdCBnaXQgZG9lcyB3aGVuIHlvdSBydW4gYGdpdCBscyAtLWhlbHBgOiJ9LHsidHlwZSI6InRvb2xDYWxsIiwiaWQiOiJ0b29sdXNlX2VZeUFoclZYQkhVNDZ0eVRzUnlOT2wiLCJuYW1lIjoiYmFzaCIsImFyZ3VtZW50cyI6eyJjb21tYW5kIjoiZ2l0IGxzIC0taGVscCAyPiYxIHx8IHRydWUifX0seyJ0eXBlIjoidG9vbENhbGwiLCJpZCI6InRvb2x1c2VfbElqTnNPaEI5OHBiZVlOcHc1RnpySiIsIm5hbWUiOiJiYXNoIiwiYXJndW1lbnRzIjp7ImNvbW1hbmQiOiJ3aGljaCBnaXQtbHMifX1dLCJhcGkiOiJiZWRyb2NrLWNvbnZlcnNlLXN0cmVhbSIsInByb3ZpZGVyIjoic29ubmV0LWJlZHJvY2siLCJtb2RlbCI6ImFybjphd3M6YmVkcm9jazp1cy1lYXN0LTE6Njg2MTUwNjgyOTY3OmFwcGxpY2F0aW9uLWluZmVyZW5jZS1wcm9maWxlLzVzaXowNHhscXE5ZyIsInVzYWdlIjp7ImlucHV0Ijo0ODg2LCJvdXRwdXQiOjExNSwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbFRva2VucyI6NTAwMSwiY29zdCI6eyJpbnB1dCI6MCwib3V0cHV0IjowLCJjYWNoZVJlYWQiOjAsImNhY2hlV3JpdGUiOjAsInRvdGFsIjowfX0sInN0b3BSZWFzb24iOiJ0b29sVXNlIiwidGltZXN0YW1wIjoxNzc1NjEwMjM4Mjk3fX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiZTU0ODYwNWIiLCJwYXJlbnRJZCI6Ijg5ZjZkNTUwIiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowNDowMi4yMDNaIiwibWVzc2FnZSI6eyJyb2xlIjoidG9vbFJlc3VsdCIsInRvb2xDYWxsSWQiOiJ0b29sdXNlX2VZeUFoclZYQkhVNDZ0eVRzUnlOT2wiLCJ0b29sTmFtZSI6ImJhc2giLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiJObyBtYW51YWwgZW50cnkgZm9yIGdpdC1sc1xuIn1dLCJpc0Vycm9yIjpmYWxzZSwidGltZXN0YW1wIjoxNzc1NjEwMjQyMjAzfX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiODg2ZTJlNTciLCJwYXJlbnRJZCI6ImU1NDg2MDViIiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowNDowMi4yMDNaIiwibWVzc2FnZSI6eyJyb2xlIjoidG9vbFJlc3VsdCIsInRvb2xDYWxsSWQiOiJ0b29sdXNlX2xJak5zT2hCOThwYmVZTnB3NUZ6ckoiLCJ0b29sTmFtZSI6ImJhc2giLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiIvb3B0L2hvbWVicmV3L2Jpbi9naXQtbHNcbiJ9XSwiaXNFcnJvciI6ZmFsc2UsInRpbWVzdGFtcCI6MTc3NTYxMDI0MjIwM319LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6IjFiZTg2NThlIiwicGFyZW50SWQiOiI4ODZlMmU1NyIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDQ6MDYuMzk3WiIsIm1lc3NhZ2UiOnsicm9sZSI6ImFzc2lzdGFudCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6IlBlcmZlY3QhIE5vdyBsZXQgbWUgY2hlY2sgaG93IG90aGVyIEhvbWVicmV3IGZvcm11bGFzIGhhbmRsZSBtYW4gcGFnZXM6In0seyJ0eXBlIjoidG9vbENhbGwiLCJpZCI6InRvb2x1c2VfVXZDOGtDUHdiQnJkcXhZRVhFM3ZmdyIsIm5hbWUiOiJiYXNoIiwiYXJndW1lbnRzIjp7ImNvbW1hbmQiOiJtYW4gLXcgZ2l0LWxmcyAyPi9kZXYvbnVsbCB8fCBlY2hvIFwibm8gZ2l0LWxmc1wiIn19LHsidHlwZSI6InRvb2xDYWxsIiwiaWQiOiJ0b29sdXNlXzNibmgxTU55WEtQTUhaQVZ6TGt4aDIiLCJuYW1lIjoiYmFzaCIsImFyZ3VtZW50cyI6eyJjb21tYW5kIjoibHMgL29wdC9ob21lYnJldy9zaGFyZS9tYW4vbWFuMS8gfCBncmVwIGdpdCB8IGhlYWQgLTEwIn19XSwiYXBpIjoiYmVkcm9jay1jb252ZXJzZS1zdHJlYW0iLCJwcm92aWRlciI6InNvbm5ldC1iZWRyb2NrIiwibW9kZWwiOiJhcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY4NjE1MDY4Mjk2NzphcHBsaWNhdGlvbi1pbmZlcmVuY2UtcHJvZmlsZS81c2l6MDR4bHFxOWciLCJ1c2FnZSI6eyJpbnB1dCI6NTA3OSwib3V0cHV0IjoxNDQsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWxUb2tlbnMiOjUyMjMsImNvc3QiOnsiaW5wdXQiOjAsIm91dHB1dCI6MCwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbCI6MH19LCJzdG9wUmVhc29uIjoidG9vbFVzZSIsInRpbWVzdGFtcCI6MTc3NTYxMDI0MjIwM319LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6ImVkMTFkOWFiIiwicGFyZW50SWQiOiIxYmU4NjU4ZSIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDQ6MDYuNTI0WiIsIm1lc3NhZ2UiOnsicm9sZSI6InRvb2xSZXN1bHQiLCJ0b29sQ2FsbElkIjoidG9vbHVzZV9VdkM4a0NQd2JCcmRxeFlFWEUzdmZ3IiwidG9vbE5hbWUiOiJiYXNoIiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0Ijoibm8gZ2l0LWxmc1xuIn1dLCJpc0Vycm9yIjpmYWxzZSwidGltZXN0YW1wIjoxNzc1NjEwMjQ2NTI0fX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiMTE2ZTEzOTgiLCJwYXJlbnRJZCI6ImVkMTFkOWFiIiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowNDowNi41MjRaIiwibWVzc2FnZSI6eyJyb2xlIjoidG9vbFJlc3VsdCIsInRvb2xDYWxsSWQiOiJ0b29sdXNlXzNibmgxTU55WEtQTUhaQVZ6TGt4aDIiLCJ0b29sTmFtZSI6ImJhc2giLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiJnaC1hdXRoLXNldHVwLWdpdC4xXG5naC1yZXBvLWdpdGlnbm9yZS1saXN0LjFcbmdoLXJlcG8tZ2l0aWdub3JlLXZpZXcuMVxuZ2gtcmVwby1naXRpZ25vcmUuMVxuZ2l0LWFkZC4xXG5naXQtYW0uMVxuZ2l0LWFubm90YXRlLjFcbmdpdC1hcHBseS4xXG5naXQtYXJjaGltcG9ydC4xXG5naXQtYXJjaGl2ZS4xXG4ifV0sImlzRXJyb3IiOmZhbHNlLCJ0aW1lc3RhbXAiOjE3NzU2MTAyNDY1MjR9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiJhZWE4NmY4MSIsInBhcmVudElkIjoiMTE2ZTEzOTgiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjA0OjE2LjA3NVoiLCJtZXNzYWdlIjp7InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiJHcmVhdCEgU28gSG9tZWJyZXcgZG9lcyBpbnN0YWxsIG1hbiBwYWdlcyB0byBgL29wdC9ob21lYnJldy9zaGFyZS9tYW4vbWFuMS9gLiBOb3cgbGV0IG1lIGxvb2sgYXQgaG93IHRvIGdlbmVyYXRlIGFuZCBpbnN0YWxsIHRoZW0uIEhlcmUncyB3aGF0IEkndmUgZm91bmQ6XG5cbiMjIFN1bW1hcnlcblxuKipZZXMsIEhvbWVicmV3IGZ1bGx5IHN1cHBvcnRzIGluc3RhbGxpbmcgbWFuIHBhZ2VzISoqIEhlcmUncyB0aGUgYXBwcm9hY2g6XG5cbiMjIyAxLiAqKkdlbmVyYXRlIHRoZSBtYW4gcGFnZSoqXG5cbllvdSBoYXZlIHNldmVyYWwgb3B0aW9uczpcblxuLSAqKldyaXRlIGl0IG1hbnVhbGx5KiogaW4gcm9mZiBmb3JtYXQgKHRyYWRpdGlvbmFsIGJ1dCB0ZWRpb3VzKVxuLSAqKlVzZSBhIHRvb2wgbGlrZSBgc2Nkb2NgKiogKHNpbXBsZSBtYW4gcGFnZSBnZW5lcmF0b3IgZnJvbSBtYXJrZG93bi1saWtlIHN5bnRheClcbi0gKipVc2UgR28tc3BlY2lmaWMgdG9vbHMqKiBsaWtlIGBjb2JyYWAgKGlmIHlvdSdyZSB1c2luZyBpdCkgd2hpY2ggY2FuIGdlbmVyYXRlIG1hbiBwYWdlc1xuLSAqKlVzZSBgcGFuZG9jYCoqIHRvIGNvbnZlcnQgZnJvbSBNYXJrZG93blxuXG4jIyMgMi4gKipIb21lYnJldyBpbnN0YWxsYXRpb24qKlxuXG5Hb1JlbGVhc2VyICh3aGljaCB5b3UncmUgYWxyZWFkeSB1c2luZykgc3VwcG9ydHMgbWFuIHBhZ2VzISBZb3UgY2FuIGFkZCB0aGVtIHRvIHlvdXIgYC5nb3JlbGVhc2VyLnlhbWxgOlxuXG5gYGB5YW1sXG5icmV3czpcbiAgLSBuYW1lOiBnaXQtbHNcbiAgICBob21lcGFnZTogXCJodHRwczovL2dpdGh1Yi5jb20vbGxpbWxsaWIvZ2l0LWxzXCJcbiAgICBkZXNjcmlwdGlvbjogXCIuLi5cIlxuICAgIGxpY2Vuc2U6IFwiVW5saWNlbnNlXCJcbiAgICByZXBvc2l0b3J5OlxuICAgICAgb3duZXI6IGxsaW1sbGliXG4gICAgICBuYW1lOiBob21lYnJldy1naXQtbHNcbiAgICAgIGJyYW5jaDogbWFpblxuICAgIGluc3RhbGw6IHxcbiAgICAgIGJpbi5pbnN0YWxsIFwiZ2l0LWxzXCJcbiAgICAgIG1hbjEuaW5zdGFsbCBcImdpdC1scy4xXCIgICMgPC0tIEFkZCB0aGlzXG5gYGBcblxuIyMjIFJlY29tbWVuZGVkIEFwcHJvYWNoXG5cbkknZCBzdWdnZXN0IHVzaW5nICoqYHNjZG9jYCoqIGJlY2F1c2U6XG4xLiBJdCdzIHNpbXBsZSBhbmQgbGlnaHR3ZWlnaHRcbjIuIFRoZSBzeW50YXggaXMgZWFzeSB0byB3cml0ZSBhbmQgbWFpbnRhaW5cbjMuIEl0IHByb2R1Y2VzIHByb3BlciByb2ZmIG1hbiBwYWdlc1xuNC4gSXQncyBjb21tb25seSB1c2VkIGluIHRoZSBHbyBlY29zeXN0ZW1cblxuV291bGQgeW91IGxpa2UgbWUgdG86XG4xLiBDcmVhdGUgYSBtYW4gcGFnZSBzb3VyY2UgZmlsZSAoZWl0aGVyIHVzaW5nIHNjZG9jIGZvcm1hdCBvciB3cml0aW5nIGRpcmVjdGx5IGluIHJvZmYpP1xuMi4gU2V0IHVwIHRoZSBNYWtlZmlsZSB0byBidWlsZCBpdD9cbjMuIENvbmZpZ3VyZSBnb3JlbGVhc2VyIHRvIGluY2x1ZGUgaXQgaW4gdGhlIEhvbWVicmV3IGZvcm11bGE/XG5cbldoYXQgZm9ybWF0IHdvdWxkIHlvdSBwcmVmZXIgZm9yIGF1dGhvcmluZyB0aGUgbWFuIHBhZ2U/In1dLCJhcGkiOiJiZWRyb2NrLWNvbnZlcnNlLXN0cmVhbSIsInByb3ZpZGVyIjoic29ubmV0LWJlZHJvY2siLCJtb2RlbCI6ImFybjphd3M6YmVkcm9jazp1cy1lYXN0LTE6Njg2MTUwNjgyOTY3OmFwcGxpY2F0aW9uLWluZmVyZW5jZS1wcm9maWxlLzVzaXowNHhscXE5ZyIsInVzYWdlIjp7ImlucHV0Ijo1MzcxLCJvdXRwdXQiOjQ1MCwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbFRva2VucyI6NTgyMSwiY29zdCI6eyJpbnB1dCI6MCwib3V0cHV0IjowLCJjYWNoZVJlYWQiOjAsImNhY2hlV3JpdGUiOjAsInRvdGFsIjowfX0sInN0b3BSZWFzb24iOiJzdG9wIiwidGltZXN0YW1wIjoxNzc1NjEwMjQ2NTI0fX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiZjc2YTlmYTciLCJwYXJlbnRJZCI6ImFlYTg2ZjgxIiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowNjo1My4yODJaIiwibWVzc2FnZSI6eyJyb2xlIjoidXNlciIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6IkkgZHVubm8sIGxldCdzIGp1c3Qgc3RhcnQgd2l0aCByb2ZmIGl0J3Mgbm90IHJvY2tldCBzY2llbmNlIHJpZ2h0In1dLCJ0aW1lc3RhbXAiOjE3NzU2MTA0MTMyODF9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiI0YjZmZTQzNiIsInBhcmVudElkIjoiZjc2YTlmYTciLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjA2OjU3LjMzM1oiLCJtZXNzYWdlIjp7InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbeyJ0eXBlIjoidG9vbENhbGwiLCJpZCI6InRvb2x1c2VfZjhyUUp6MVhVRkU1UU8xMmRnY1JXRiIsIm5hbWUiOiJiYXNoIiwiYXJndW1lbnRzIjp7ImNvbW1hbmQiOiIuL2dpdC1scyAtLWhlbHAgMj4mMSB8IGhlYWQgLTUwIn19LHsidHlwZSI6InRvb2xDYWxsIiwiaWQiOiJ0b29sdXNlX3poV3Q4WG9VN29mZVNJUWVkVVFmengiLCJuYW1lIjoicmVhZCIsImFyZ3VtZW50cyI6eyJwYXRoIjoiUkVBRE1FLm1kIn19XSwiYXBpIjoiYmVkcm9jay1jb252ZXJzZS1zdHJlYW0iLCJwcm92aWRlciI6InNvbm5ldC1iZWRyb2NrIiwibW9kZWwiOiJhcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY4NjE1MDY4Mjk2NzphcHBsaWNhdGlvbi1pbmZlcmVuY2UtcHJvZmlsZS81c2l6MDR4bHFxOWciLCJ1c2FnZSI6eyJpbnB1dCI6NTg0MSwib3V0cHV0IjoxMDEsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWxUb2tlbnMiOjU5NDIsImNvc3QiOnsiaW5wdXQiOjAsIm91dHB1dCI6MCwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbCI6MH19LCJzdG9wUmVhc29uIjoidG9vbFVzZSIsInRpbWVzdGFtcCI6MTc3NTYxMDQxMzI4M319LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6ImZiMTQ1Yzc3IiwicGFyZW50SWQiOiI0YjZmZTQzNiIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDY6NTcuMzg3WiIsIm1lc3NhZ2UiOnsicm9sZSI6InRvb2xSZXN1bHQiLCJ0b29sQ2FsbElkIjoidG9vbHVzZV9mOHJRSnoxWFVGRTVRTzEyZGdjUldGIiwidG9vbE5hbWUiOiJiYXNoIiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoiL2Jpbi9iYXNoOiAuL2dpdC1sczogTm8gc3VjaCBmaWxlIG9yIGRpcmVjdG9yeVxuIn1dLCJpc0Vycm9yIjpmYWxzZSwidGltZXN0YW1wIjoxNzc1NjEwNDE3Mzg3fX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiODU2NzY1YzAiLCJwYXJlbnRJZCI6ImZiMTQ1Yzc3IiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowNjo1Ny4zOTFaIiwibWVzc2FnZSI6eyJyb2xlIjoidG9vbFJlc3VsdCIsInRvb2xDYWxsSWQiOiJ0b29sdXNlX3poV3Q4WG9VN29mZVNJUWVkVVFmengiLCJ0b29sTmFtZSI6InJlYWQiLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiIjIGdpdC1sc1xuXG5saXN0IHRoZSBmaWxlcyBpbiB0aGUgY3VycmVudCBkaXJlY3RvcnkgYWxvbmcgd2l0aCBhIHVzZWZ1bCBzdW1tYXJ5IG9mIHRoZWlyIGdpdCBzdGF0dXMgYW5kIGhlbHBmdWwgaHlwZXJsaW5rcy5cblxuVGhlIG91dHB1dCBpcyBuaWNlbHkgY29sb3JlZDpcblxuIVtdKHN0YXRpYy9naXRscy5wbmcpXG5cbkluIGEgdGVybWluYWwgdGhhdCBzdXBwb3J0cyBbT1NDOCBsaW5rc10oaHR0cHM6Ly9naXN0LmdpdGh1Yi5jb20vZWdtb250a29iL2ViMTE0Mjk0ZWZiY2Q1YWRiMTk0NGM5ZjNjYjVmZWRhKSBzdWNoIGFzIGtpdHR5LCBpdGVybSBvciB3ZXp0ZXJtLCBgZ2l0IGxzYCB3aWxsIHByb3ZpZGUgaGVscGZ1bCBoeXBlcmxpbmtzLlxuXG4tIGZpbGUgbmFtZXMgYXJlIGxpbmtlZCB0byBmaWxlc1xuLSBjb21taXQgbWVzc2FnZXMgYXJlIGxpbmtlZCB0byB0aGUgY29tbWl0c1xuLSBjb21taXQgYXV0aG9ycyBhcmUgbGlua2VkIHRvIHRoZWlyIGxpc3Qgb2YgY29tbWl0c1xuLSBQUiBudW1iZXJzIGFyZSBsaW5rZWQgdG8gdGhlIFBSXG5cbkluIGEgcHJvcGVybHktY29uZmlndXJlZCB0ZXJtaW5hbCwgdGhpcyBtZWFucyB0aGF0IHlvdSBjYW4gY2xpY2sgb24gZmlsZW5hbWVzIHRvIG9wZW4gdGhlbSBpbiB5b3VyIHByZWZlcnJlZCBlZGl0b3IsIG9yIGNsaWNrIG9uIGEgUFIgbnVtYmVyIGluIGEgY29tbWl0IHN0YXR1cyB0byBnbyBzdHJhaWdodCB0byB0aGF0IFBSIGluIHlvdXIgYnJvd3Nlci5cblxuIyMgaW5zdGFsbGluZ1xuXG4tIG9uIGEgbWFjOiBgYnJldyBpbnN0YWxsIGxsaW1sbGliL2dpdC1scy9naXQtbHNgXG4tIGV2ZXJ5d2hlcmUgZWxzZTogZG93bmxvYWQgdGhlIFtsYXRlc3QgcmVsZWFzZV0oaHR0cHM6Ly9naXRodWIuY29tL2xsaW1sbGliL2dpdC1scy9yZWxlYXNlcykgZm9yIHlvdXIgcGxhdGZvcm1cbiAgLSBQdXQgYGdpdC1sc2AgYW55d2hlcmUgb24geW91ciBwYXRoLCBhbmQgeW91IGNhbiB0aGVuIGNhbGwgaXQgYXMgYGdpdCBsc2BcbiAgLSBXaW5kb3dzIHVzZXJzOiBJJ2QgbG92ZSB5b3VyIGhlbHAgdG8gbWFrZSB0aGlzIHdvcmsgb24gd2luZG93cyEgUGxlYXNlIGxlYXZlIGEgY29tbWVudCBhdCBpc3N1ZSBbIzE0XShodHRwczovL2dpdGh1Yi5jb20vbGxpbWxsaWIvZ2l0LWxzL2lzc3Vlcy8xNClcblxuIyMgYnVpbGRpbmdcblxuUnVuIGBtYWtlYCwgd2hpY2ggd2lsbCByZXN1bHQgaW4gYSBgZ2l0LWxzYCBiaW5hcnkgaW4gdGhlIGN1cnJlbnQgZGlyZWN0b3J5XG4ifV0sImlzRXJyb3IiOmZhbHNlLCJ0aW1lc3RhbXAiOjE3NzU2MTA0MTczODd9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiJlMGY4ZTEyNCIsInBhcmVudElkIjoiODU2NzY1YzAiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjA3OjAwLjY5OVoiLCJtZXNzYWdlIjp7InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbeyJ0eXBlIjoidG9vbENhbGwiLCJpZCI6InRvb2x1c2VfSzlhUUhReWxLY3M1MU1hcVBzS0VFMyIsIm5hbWUiOiJiYXNoIiwiYXJndW1lbnRzIjp7ImNvbW1hbmQiOiJtYWtlICYmIC4vZ2l0LWxzIC0taGVscCAyPiYxIHwgaGVhZCAtODAifX1dLCJhcGkiOiJiZWRyb2NrLWNvbnZlcnNlLXN0cmVhbSIsInByb3ZpZGVyIjoic29ubmV0LWJlZHJvY2siLCJtb2RlbCI6ImFybjphd3M6YmVkcm9jazp1cy1lYXN0LTE6Njg2MTUwNjgyOTY3OmFwcGxpY2F0aW9uLWluZmVyZW5jZS1wcm9maWxlLzVzaXowNHhscXE5ZyIsInVzYWdlIjp7ImlucHV0Ijo2MzYwLCJvdXRwdXQiOjY3LCJjYWNoZVJlYWQiOjAsImNhY2hlV3JpdGUiOjAsInRvdGFsVG9rZW5zIjo2NDI3LCJjb3N0Ijp7ImlucHV0IjowLCJvdXRwdXQiOjAsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWwiOjB9fSwic3RvcFJlYXNvbiI6InRvb2xVc2UiLCJ0aW1lc3RhbXAiOjE3NzU2MTA0MTczOTF9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiJmYTY5ZjgwMCIsInBhcmVudElkIjoiZTBmOGUxMjQiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjA3OjAyLjcwMloiLCJtZXNzYWdlIjp7InJvbGUiOiJ0b29sUmVzdWx0IiwidG9vbENhbGxJZCI6InRvb2x1c2VfSzlhUUhReWxLY3M1MU1hcVBzS0VFMyIsInRvb2xOYW1lIjoiYmFzaCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6ImdvIGJ1aWxkXG5HSVQtTFMoMSlcblxuTkFNRVxuICAgIGdpdC1scyAtIHNob3cgdGhlIGN1cnJlbnQgZGlyZWN0b3J5IGFubm90YXRlZCB3aXRoIGxpbmtzIGFuZCBnaXQgaW5mb1xuXG5TWU5PUFNJU1xuICAgIGdpdCBscyBbPGRpcj5dXG5cbkRFU0NSSVBUSU9OXG4gICAgRGlzcGxheXMgdGhlIGZpbGVzIGluIHRoZSBjdXJyZW50IGRpcmVjdG9yeSwgdGhlaXIgY3VycmVudCBnaXQgc3RhdHVzLCBhIHNob3J0IGRpZmZzdGF0LCB0aGVpciBsYXN0IG1vZGlmaWVkIGRhdGUsIHRoZSBhdXRob3IgYW5kIGEgcG9ydGlvbiBvZiB0aGUgbGFzdCBjb21taXQgbWVzc2FnZSBmb3IgdGhhdCBmaWxlLlxuXG4gICAgQWxsIGZpbGVzIGFyZSBoeXBlcmxpbmtlZCB3aXRoIE9TQzggaHlwZXJsaW5rcywgc28geW91IHNob3VsZCBiZSBhYmxlIHRvIG9wZW4gdGhlbSBieSBjbGlja2luZyBvbiB0aGVtIGluIGEgcHJvcGVybHktY29uZmlndXJlZCB0ZXJtaW5hbC4gVGhlIGF1dGhvciBuYW1lcyBhcmUgaHlwZXJsaW5rZWQgdG8gZ2l0aHViIGlmIHRoZSByZXBvc2l0b3J5IGhhcyBhIGdpdGh1YiByZW1vdGUsIGFzIGFyZSBjb21taXQgbWVzc2FnZXMuXG5cbk9QVElPTlNcbiAgICAtLXZlcnNpb25cbiAgICAgICAgUHJpbnQgdGhlIHZlcnNpb24gbnVtYmVyIGFuZCBleGl0XG5cbiAgICAtLWhlbHBcbiAgICAgICAgUHJpbnQgdGhpcyBtZXNzYWdlIGFuZCBleGl0XG5cbiAgICAtLWRpZmZXaWR0aD1uXG4gICAgICAgIFByaW50IHRoZSBkaWZmU3RhdCBncmFwaCB3aXRoIHRoZSBnaXZlbiB3aWR0aC4gRGVmYXVsdCBpcyA0XG5cbiAgICAtLWZvcm1hdD1jb2wxLGNvbDIsLi4uXG4gICAgICAgIFNwZWNpZnkgd2hpY2ggY29sdW1ucyB0byBkaXNwbGF5IGFuZCBpbiB3aGF0IG9yZGVyLiBWYWxpZCBjb2x1bW5zOlxuICAgICAgICBzdGF0dXMsIGRpZmYsIGZpbGVuYW1lLCBzaG9ydGhhc2gsIGhhc2gsIGRhdGUsIGF1dGhvciwgZW1haWwsXG4gICAgICAgIG51bXN0YXQsIGNvbW1pdG1lc3NhZ2VcbiAgICAgICAgRGVmYXVsdDogc3RhdHVzLGRpZmYsZmlsZW5hbWUsc2hvcnRoYXNoLGRhdGUsYXV0aG9yLGNvbW1pdG1lc3NhZ2VcblxuICAgIC0tbW9uby1oYXNoXG4gICAgICAgIFVzZSBhIHNpbmdsZSBjb2xvciAoY3lhbikgZm9yIGFsbCBjb21taXQgaGFzaGVzIGluc3RlYWQgb2YgY29sb3JpbmdcbiAgICAgICAgZWFjaCBoYXNoIHVuaXF1ZWx5IGJhc2VkIG9uIGl0cyB2YWx1ZVxuXG4gICAgLS1uZXJkZm9udFxuICAgICAgICBSZXBsYWNlIGdpdCBzdGF0dXMgbGV0dGVycyB3aXRoIE5lcmQgRm9udCBpY29ucyAocmVxdWlyZXMgYSBOZXJkXG4gICAgICAgIEZvbnQtcGF0Y2hlZCB0ZXJtaW5hbCBmb250KVxuXG4gICAgLWMsIC0tY2hhbmdlZC1vbmx5XG4gICAgICAgIE9ubHkgc2hvdyBmaWxlcyB0aGF0IGhhdmUgY2hhbmdlcyAoYXBwZWFyIGluIGdpdCBzdGF0dXMpLiBUaGlzXG4gICAgICAgIGZpbHRlcnMgb3V0IHVubW9kaWZpZWQgdHJhY2tlZCBmaWxlcyBhbmQgc2hvd3Mgb25seSBmaWxlcyB3aXRoXG4gICAgICAgIHN0YXR1cyBpbmRpY2F0b3JzIChtb2RpZmllZCwgYWRkZWQsIGRlbGV0ZWQsIHJlbmFtZWQsIGV0Yy4pXG5cblx1MDAxYl04OztodHRwczovL2dpdGh1Yi5jb20vbGxpbWxsaWIvZ2l0LWxzXHUwMDFiXFxodHRwczovL2dpdGh1Yi5jb20vbGxpbWxsaWIvZ2l0LWxzXHUwMDFiXTg7O1x1MDAxYlxcXG4ifV0sImlzRXJyb3IiOmZhbHNlLCJ0aW1lc3RhbXAiOjE3NzU2MTA0MjI3MDJ9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiI2NjBhMmJkZCIsInBhcmVudElkIjoiZmE2OWY4MDAiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjA3OjA2LjkzMloiLCJtZXNzYWdlIjp7InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiJQZXJmZWN0ISBJIGNhbiBzZWUgeW91IGFscmVhZHkgaGF2ZSBoZWxwIHRleHQgaW4gdGhlIHByb2dyYW0uIExldCBtZSBjaGVjayB0aGUgc291cmNlIHRvIHNlZSB0aGUgZnVsbCBoZWxwOiJ9LHsidHlwZSI6InRvb2xDYWxsIiwiaWQiOiJ0b29sdXNlX2VEZkN2bG9CSWFQSG9pY3kzMTJ1dksiLCJuYW1lIjoiYmFzaCIsImFyZ3VtZW50cyI6eyJjb21tYW5kIjoiZ3JlcCAtQSAxMDAgXCJOQU1FXCIgbWFpbi5nbyB8IGhlYWQgLTgwIn19XSwiYXBpIjoiYmVkcm9jay1jb252ZXJzZS1zdHJlYW0iLCJwcm92aWRlciI6InNvbm5ldC1iZWRyb2NrIiwibW9kZWwiOiJhcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY4NjE1MDY4Mjk2NzphcHBsaWNhdGlvbi1pbmZlcmVuY2UtcHJvZmlsZS81c2l6MDR4bHFxOWciLCJ1c2FnZSI6eyJpbnB1dCI6Njg2NCwib3V0cHV0Ijo5MiwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbFRva2VucyI6Njk1NiwiY29zdCI6eyJpbnB1dCI6MCwib3V0cHV0IjowLCJjYWNoZVJlYWQiOjAsImNhY2hlV3JpdGUiOjAsInRvdGFsIjowfX0sInN0b3BSZWFzb24iOiJ0b29sVXNlIiwidGltZXN0YW1wIjoxNzc1NjEwNDIyNzAyfX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiMjI0MGU3ZDAiLCJwYXJlbnRJZCI6IjY2MGEyYmRkIiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowNzowNi45NTVaIiwibWVzc2FnZSI6eyJyb2xlIjoidG9vbFJlc3VsdCIsInRvb2xDYWxsSWQiOiJ0b29sdXNlX2VEZkN2bG9CSWFQSG9pY3kzMTJ1dksiLCJ0b29sTmFtZSI6ImJhc2giLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiJOQU1FXG4gICAgZ2l0LWxzIC0gc2hvdyB0aGUgY3VycmVudCBkaXJlY3RvcnkgYW5ub3RhdGVkIHdpdGggbGlua3MgYW5kIGdpdCBpbmZvXG5cblNZTk9QU0lTXG4gICAgZ2l0IGxzIFs8ZGlyPl1cblxuREVTQ1JJUFRJT05cbiAgICBEaXNwbGF5cyB0aGUgZmlsZXMgaW4gdGhlIGN1cnJlbnQgZGlyZWN0b3J5LCB0aGVpciBjdXJyZW50IGdpdCBzdGF0dXMsIGEgc2hvcnQgZGlmZnN0YXQsIHRoZWlyIGxhc3QgbW9kaWZpZWQgZGF0ZSwgdGhlIGF1dGhvciBhbmQgYSBwb3J0aW9uIG9mIHRoZSBsYXN0IGNvbW1pdCBtZXNzYWdlIGZvciB0aGF0IGZpbGUuXG5cbiAgICBBbGwgZmlsZXMgYXJlIGh5cGVybGlua2VkIHdpdGggT1NDOCBoeXBlcmxpbmtzLCBzbyB5b3Ugc2hvdWxkIGJlIGFibGUgdG8gb3BlbiB0aGVtIGJ5IGNsaWNraW5nIG9uIHRoZW0gaW4gYSBwcm9wZXJseS1jb25maWd1cmVkIHRlcm1pbmFsLiBUaGUgYXV0aG9yIG5hbWVzIGFyZSBoeXBlcmxpbmtlZCB0byBnaXRodWIgaWYgdGhlIHJlcG9zaXRvcnkgaGFzIGEgZ2l0aHViIHJlbW90ZSwgYXMgYXJlIGNvbW1pdCBtZXNzYWdlcy5cblxuT1BUSU9OU1xuICAgIC0tdmVyc2lvblxuICAgICAgICBQcmludCB0aGUgdmVyc2lvbiBudW1iZXIgYW5kIGV4aXRcblxuICAgIC0taGVscFxuICAgICAgICBQcmludCB0aGlzIG1lc3NhZ2UgYW5kIGV4aXRcblxuICAgIC0tZGlmZldpZHRoPW5cbiAgICAgICAgUHJpbnQgdGhlIGRpZmZTdGF0IGdyYXBoIHdpdGggdGhlIGdpdmVuIHdpZHRoLiBEZWZhdWx0IGlzIDRcblxuICAgIC0tZm9ybWF0PWNvbDEsY29sMiwuLi5cbiAgICAgICAgU3BlY2lmeSB3aGljaCBjb2x1bW5zIHRvIGRpc3BsYXkgYW5kIGluIHdoYXQgb3JkZXIuIFZhbGlkIGNvbHVtbnM6XG4gICAgICAgIHN0YXR1cywgZGlmZiwgZmlsZW5hbWUsIHNob3J0aGFzaCwgaGFzaCwgZGF0ZSwgYXV0aG9yLCBlbWFpbCxcbiAgICAgICAgbnVtc3RhdCwgY29tbWl0bWVzc2FnZVxuICAgICAgICBEZWZhdWx0OiBzdGF0dXMsZGlmZixmaWxlbmFtZSxzaG9ydGhhc2gsZGF0ZSxhdXRob3IsY29tbWl0bWVzc2FnZVxuXG4gICAgLS1tb25vLWhhc2hcbiAgICAgICAgVXNlIGEgc2luZ2xlIGNvbG9yIChjeWFuKSBmb3IgYWxsIGNvbW1pdCBoYXNoZXMgaW5zdGVhZCBvZiBjb2xvcmluZ1xuICAgICAgICBlYWNoIGhhc2ggdW5pcXVlbHkgYmFzZWQgb24gaXRzIHZhbHVlXG5cbiAgICAtLW5lcmRmb250XG4gICAgICAgIFJlcGxhY2UgZ2l0IHN0YXR1cyBsZXR0ZXJzIHdpdGggTmVyZCBGb250IGljb25zIChyZXF1aXJlcyBhIE5lcmRcbiAgICAgICAgRm9udC1wYXRjaGVkIHRlcm1pbmFsIGZvbnQpXG5cbiAgICAtYywgLS1jaGFuZ2VkLW9ubHlcbiAgICAgICAgT25seSBzaG93IGZpbGVzIHRoYXQgaGF2ZSBjaGFuZ2VzIChhcHBlYXIgaW4gZ2l0IHN0YXR1cykuIFRoaXNcbiAgICAgICAgZmlsdGVycyBvdXQgdW5tb2RpZmllZCB0cmFja2VkIGZpbGVzIGFuZCBzaG93cyBvbmx5IGZpbGVzIHdpdGhcbiAgICAgICAgc3RhdHVzIGluZGljYXRvcnMgKG1vZGlmaWVkLCBhZGRlZCwgZGVsZXRlZCwgcmVuYW1lZCwgZXRjLilcblxuJXNcbmAsIGxpbmsoXCJodHRwczovL2dpdGh1Yi5jb20vbGxpbWxsaWIvZ2l0LWxzXCIsIFwiaHR0cHM6Ly9naXRodWIuY29tL2xsaW1sbGliL2dpdC1sc1wiKSlcbn1cblxuZnVuYyBtYWluKCkge1xuXHRhcmd2IDo9IG9zLkFyZ3NbMTpdXG5cdGRpZmZXaWR0aCA6PSA0XG5cdG1vbm9IYXNoIDo9IGZhbHNlXG5cdG5lcmRGb250IDo9IGZhbHNlXG5cdGNoYW5nZWRPbmx5IDo9IGZhbHNlXG5cdGRlYnVnIDo9IGZhbHNlXG5cdHZhciBmb3JtYXRDb2x1bW5zIFtdQ29sdW1uXG5cdGZvciBsZW4oYXJndikgPiAwIHtcblx0XHRpZiBhcmd2WzBdID09IFwiLS12ZXJzaW9uXCIge1xuXHRcdFx0cHJpbnRWZXJzaW9uKClcblx0XHRcdG9zLkV4aXQoMClcblx0XHR9XG5cdFx0aWYgYXJndlswXSA9PSBcIi0taGVscFwiIHx8IGFyZ3ZbMF0gPT0gXCItaFwiIHtcblx0XHRcdHVzYWdlKClcblx0XHRcdG9zLkV4aXQoMClcblx0XHR9XG5cdFx0aWYgYXJndlswXSA9PSBcIi0tbW9uby1oYXNoXCIge1xuXHRcdFx0bW9ub0hhc2ggPSB0cnVlXG5cdFx0XHRhcmd2ID0gYXJndlsxOl1cblx0XHR9IGVsc2UgaWYgYXJndlswXSA9PSBcIi0tbmVyZGZvbnRcIiB7XG5cdFx0XHRuZXJkRm9udCA9IHRydWVcblx0XHRcdGFyZ3YgPSBhcmd2WzE6XVxuXHRcdH0gZWxzZSBpZiBhcmd2WzBdID09IFwiLS1jaGFuZ2VkLW9ubHlcIiB8fCBhcmd2WzBdID09IFwiLWNcIiB7XG5cdFx0XHRjaGFuZ2VkT25seSA9IHRydWVcblx0XHRcdGFyZ3YgPSBhcmd2WzE6XVxuXHRcdH0gZWxzZSBpZiBzdHJpbmdzLkhhc1ByZWZpeChhcmd2WzBdLCBcIi0tZGlmZldpZHRoXCIpIHtcblx0XHRcdGlmIGxlbihhcmd2KSA9PSAxIHtcblx0XHRcdFx0aWYgc3RyaW5ncy5Db250YWlucyhhcmd2WzBdLCBcIj1cIikge1xuXHRcdFx0XHRcdHBhcnRzIDo9IHN0cmluZ3MuU3BsaXROKGFyZ3ZbMF0sIFwiPVwiLCAyKVxuXHRcdFx0XHRcdGRpZmZXaWR0aCA9IG11c3Qoc3RyY29udi5BdG9pKHBhcnRzWzFdKSlcblx0XHRcdFx0fSBlbHNlIHtcblx0XHRcdFx0XHRsb2cuRmF0YWxmKFwiLS1kaWZmV2lkdGggcmVxdWlyZXMgYW4gYXJndW1lbnRcIilcblx0XHRcdFx0fVxuXHRcdFx0XHRhcmd2ID0gYXJndlsxOl1cblx0XHRcdH0gZWxzZSB7XG4ifV0sImlzRXJyb3IiOmZhbHNlLCJ0aW1lc3RhbXAiOjE3NzU2MTA0MjY5NTR9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiI0NzNkOTQxMiIsInBhcmVudElkIjoiMjI0MGU3ZDAiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjA3OjE5LjA1N1oiLCJtZXNzYWdlIjp7InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiJOaWNlISBZb3UgYWxyZWFkeSBoYXZlIG1vc3Qgb2YgdGhlIGNvbnRlbnQgd3JpdHRlbiBpbiBhIG1hbi1wYWdlLWxpa2UgZm9ybWF0LiBMZXQgbWUgY3JlYXRlIGEgcHJvcGVyIHJvZmYgbWFuIHBhZ2UgZnJvbSB0aGlzOiJ9LHsidHlwZSI6InRvb2xDYWxsIiwiaWQiOiJ0b29sdXNlX0d6aFAxUDF3c2NRVmtmcUZ1SE9QRkciLCJuYW1lIjoid3JpdGUiLCJhcmd1bWVudHMiOnsicGF0aCI6ImdpdC1scy4xIiwiY29udGVudCI6Ii5USCBHSVQtTFMgMSBcIjIwMjYtMDQtMDhcIiBcImdpdC1sc1wiIFwiVXNlciBDb21tYW5kc1wiXG4uU0ggTkFNRVxuZ2l0LWxzIFxcLSBzaG93IHRoZSBjdXJyZW50IGRpcmVjdG9yeSBhbm5vdGF0ZWQgd2l0aCBsaW5rcyBhbmQgZ2l0IGluZm9cbi5TSCBTWU5PUFNJU1xuLkIgZ2l0IGxzXG4uUkkgWyA8ZGlyPiBdXG4uU0ggREVTQ1JJUFRJT05cbi5CIGdpdC1sc1xuZGlzcGxheXMgdGhlIGZpbGVzIGluIHRoZSBjdXJyZW50IGRpcmVjdG9yeSwgdGhlaXIgY3VycmVudCBnaXQgc3RhdHVzLCBhIHNob3J0XG5kaWZmc3RhdCwgdGhlaXIgbGFzdCBtb2RpZmllZCBkYXRlLCB0aGUgYXV0aG9yIGFuZCBhIHBvcnRpb24gb2YgdGhlIGxhc3QgY29tbWl0XG5tZXNzYWdlIGZvciB0aGF0IGZpbGUuXG4uUFBcbkFsbCBmaWxlcyBhcmUgaHlwZXJsaW5rZWQgd2l0aCBPU0M4IGh5cGVybGlua3MsIHNvIHlvdSBzaG91bGQgYmUgYWJsZSB0byBvcGVuXG50aGVtIGJ5IGNsaWNraW5nIG9uIHRoZW0gaW4gYSBwcm9wZXJseS1jb25maWd1cmVkIHRlcm1pbmFsLiBUaGUgYXV0aG9yIG5hbWVzIGFyZVxuaHlwZXJsaW5rZWQgdG8gR2l0SHViIGlmIHRoZSByZXBvc2l0b3J5IGhhcyBhIEdpdEh1YiByZW1vdGUsIGFzIGFyZSBjb21taXQgbWVzc2FnZXMuXG4uU0ggT1BUSU9OU1xuLlRQXG4uQiBcXC1cXC12ZXJzaW9uXG5QcmludCB0aGUgdmVyc2lvbiBudW1iZXIgYW5kIGV4aXQuXG4uVFBcbi5CUiBcXC1cXC1oZWxwIFwiLCBcIiBcXC1oXG5QcmludCB0aGUgaGVscCBtZXNzYWdlIGFuZCBleGl0LlxuLlRQXG4uQkkgXFwtXFwtZGlmZldpZHRoPSBuXG5QcmludCB0aGUgZGlmZlN0YXQgZ3JhcGggd2l0aCB0aGUgZ2l2ZW4gd2lkdGguIERlZmF1bHQgaXMgNC5cbi5UUFxuLkJJIFxcLVxcLWZvcm1hdD0gY29sMSxjb2wyLC4uLlxuU3BlY2lmeSB3aGljaCBjb2x1bW5zIHRvIGRpc3BsYXkgYW5kIGluIHdoYXQgb3JkZXIuIFZhbGlkIGNvbHVtbnM6XG4uQlIgc3RhdHVzIFwiLCBcIiBkaWZmIFwiLCBcIiBmaWxlbmFtZSBcIiwgXCIgc2hvcnRoYXNoIFwiLCBcIiBoYXNoIFwiLCBcIiBkYXRlIFwiLCBcIiBhdXRob3IgXCIsIFwiXG4uQlIgZW1haWwgXCIsIFwiIG51bXN0YXQgXCIsIFwiIGNvbW1pdG1lc3NhZ2UgLlxuLmJyXG5EZWZhdWx0OlxuLkJSIHN0YXR1cyxkaWZmLGZpbGVuYW1lLHNob3J0aGFzaCxkYXRlLGF1dGhvcixjb21taXRtZXNzYWdlIC5cbi5UUFxuLkIgXFwtXFwtbW9ub1xcLWhhc2hcblVzZSBhIHNpbmdsZSBjb2xvciAoY3lhbikgZm9yIGFsbCBjb21taXQgaGFzaGVzIGluc3RlYWQgb2YgY29sb3JpbmcgZWFjaCBoYXNoXG51bmlxdWVseSBiYXNlZCBvbiBpdHMgdmFsdWUuXG4uVFBcbi5CIFxcLVxcLW5lcmRmb250XG5SZXBsYWNlIGdpdCBzdGF0dXMgbGV0dGVycyB3aXRoIE5lcmQgRm9udCBpY29ucyAocmVxdWlyZXMgYSBOZXJkIEZvbnQtcGF0Y2hlZFxudGVybWluYWwgZm9udCkuXG4uVFBcbi5CUiBcXC1jIFwiLCBcIiBcXC1cXC1jaGFuZ2VkXFwtb25seVxuT25seSBzaG93IGZpbGVzIHRoYXQgaGF2ZSBjaGFuZ2VzIChhcHBlYXIgaW4gZ2l0IHN0YXR1cykuIFRoaXMgZmlsdGVycyBvdXRcbnVubW9kaWZpZWQgdHJhY2tlZCBmaWxlcyBhbmQgc2hvd3Mgb25seSBmaWxlcyB3aXRoIHN0YXR1cyBpbmRpY2F0b3JzIChtb2RpZmllZCxcbmFkZGVkLCBkZWxldGVkLCByZW5hbWVkLCBldGMuKS5cbi5TSCBFWEFNUExFU1xuLlRQXG4uQiBnaXQgbHNcblNob3cgYWxsIGZpbGVzIGluIHRoZSBjdXJyZW50IGRpcmVjdG9yeSB3aXRoIGdpdCBpbmZvcm1hdGlvbi5cbi5UUFxuLkIgZ2l0IGxzIFxcLVxcLWNoYW5nZWRcXC1vbmx5XG5TaG93IG9ubHkgZmlsZXMgdGhhdCBoYXZlIHVuY29tbWl0dGVkIGNoYW5nZXMuXG4uVFBcbi5CIGdpdCBscyBcXC1cXC1mb3JtYXQ9ZmlsZW5hbWUsc3RhdHVzLGF1dGhvclxuU2hvdyBjdXN0b20gY29sdW1uczogZmlsZW5hbWUsIHN0YXR1cywgYW5kIGF1dGhvciBvbmx5LlxuLlRQXG4uQiBnaXQgbHMgXFwtXFwtZGlmZldpZHRoPThcblNob3cgYSB3aWRlciBkaWZmc3RhdCBncmFwaCAoOCBjaGFyYWN0ZXJzIGluc3RlYWQgb2YgNCkuXG4uU0ggVEVSTUlOQUwgU1VQUE9SVFxuRm9yIHRoZSBiZXN0IGV4cGVyaWVuY2UsIHVzZSBhIHRlcm1pbmFsIHRoYXQgc3VwcG9ydHMgT1NDOCBoeXBlcmxpbmtzLCBzdWNoIGFzOlxuLklQIFxcKGJ1IDJcbmtpdHR5XG4uSVAgXFwoYnUgMlxuaVRlcm0yXG4uSVAgXFwoYnUgMlxuV2V6VGVybVxuLlBQXG5JbiB0aGVzZSB0ZXJtaW5hbHMsIHlvdSBjYW4gY2xpY2sgb24gZmlsZW5hbWVzIHRvIG9wZW4gdGhlbSBpbiB5b3VyIHByZWZlcnJlZFxuZWRpdG9yLCBvciBjbGljayBvbiBhIFBSIG51bWJlciBpbiBhIGNvbW1pdCBzdGF0dXMgdG8gZ28gc3RyYWlnaHQgdG8gdGhhdCBQUiBpblxueW91ciBicm93c2VyLlxuLlNIIEFVVEhPUlxuV3JpdHRlbiBieSBCaWxsIE1pbGwuXG4uU0ggQlVHU1xuUmVwb3J0IGJ1Z3MgYXQ6IGh0dHBzOi8vZ2l0aHViLmNvbS9sbGltbGxpYi9naXQtbHMvaXNzdWVzXG4uU0ggU0VFIEFMU09cbi5CUiBnaXQgKDEpLFxuLkJSIGdpdC1zdGF0dXMgKDEpLFxuLkJSIGdpdC1sb2cgKDEpXG4uUFBcbkZ1bGwgZG9jdW1lbnRhdGlvbiBhdDogaHR0cHM6Ly9naXRodWIuY29tL2xsaW1sbGliL2dpdC1sc1xuIn19XSwiYXBpIjoiYmVkcm9jay1jb252ZXJzZS1zdHJlYW0iLCJwcm92aWRlciI6InNvbm5ldC1iZWRyb2NrIiwibW9kZWwiOiJhcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY4NjE1MDY4Mjk2NzphcHBsaWNhdGlvbi1pbmZlcmVuY2UtcHJvZmlsZS81c2l6MDR4bHFxOWciLCJ1c2FnZSI6eyJpbnB1dCI6NzczNiwib3V0cHV0Ijo5MzcsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWxUb2tlbnMiOjg2NzMsImNvc3QiOnsiaW5wdXQiOjAsIm91dHB1dCI6MCwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbCI6MH19LCJzdG9wUmVhc29uIjoidG9vbFVzZSIsInRpbWVzdGFtcCI6MTc3NTYxMDQyNjk1NX19LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6IjhkZGIwNzYzIiwicGFyZW50SWQiOiI0NzNkOTQxMiIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDc6MTkuMDYyWiIsIm1lc3NhZ2UiOnsicm9sZSI6InRvb2xSZXN1bHQiLCJ0b29sQ2FsbElkIjoidG9vbHVzZV9HemhQMVAxd3NjUVZrZnFGdUhPUEZHIiwidG9vbE5hbWUiOiJ3cml0ZSIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6IlN1Y2Nlc3NmdWxseSB3cm90ZSAyNTIyIGJ5dGVzIHRvIGdpdC1scy4xIn1dLCJpc0Vycm9yIjpmYWxzZSwidGltZXN0YW1wIjoxNzc1NjEwNDM5MDYyfX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiYjM0Nzc3YjEiLCJwYXJlbnRJZCI6IjhkZGIwNzYzIiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowNzoyMi4xMjFaIiwibWVzc2FnZSI6eyJyb2xlIjoiYXNzaXN0YW50IiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoiTm93IGxldCdzIHRlc3QgaXQ6In0seyJ0eXBlIjoidG9vbENhbGwiLCJpZCI6InRvb2x1c2VfbWZORWJwSHZ6d3VQb0E3bXlEYUpUQiIsIm5hbWUiOiJiYXNoIiwiYXJndW1lbnRzIjp7ImNvbW1hbmQiOiJtYW4gLi9naXQtbHMuMSJ9fV0sImFwaSI6ImJlZHJvY2stY29udmVyc2Utc3RyZWFtIiwicHJvdmlkZXIiOiJzb25uZXQtYmVkcm9jayIsIm1vZGVsIjoiYXJuOmF3czpiZWRyb2NrOnVzLWVhc3QtMTo2ODYxNTA2ODI5Njc6YXBwbGljYXRpb24taW5mZXJlbmNlLXByb2ZpbGUvNXNpejA0eGxxcTlnIiwidXNhZ2UiOnsiaW5wdXQiOjg2OTgsIm91dHB1dCI6NjQsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWxUb2tlbnMiOjg3NjIsImNvc3QiOnsiaW5wdXQiOjAsIm91dHB1dCI6MCwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbCI6MH19LCJzdG9wUmVhc29uIjoidG9vbFVzZSIsInRpbWVzdGFtcCI6MTc3NTYxMDQzOTA2Mn19LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6IjczMjQ0M2M3IiwicGFyZW50SWQiOiJiMzQ3NzdiMSIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDc6MjIuMzgyWiIsIm1lc3NhZ2UiOnsicm9sZSI6InRvb2xSZXN1bHQiLCJ0b29sQ2FsbElkIjoidG9vbHVzZV9tZk5FYnBIdnp3dVBvQTdteURhSlRCIiwidG9vbE5hbWUiOiJiYXNoIiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoiR0lULUxTKDEpICAgICAgICAgICAgICAgICAgICAgICAgVXNlciBDb21tYW5kcyAgICAgICAgICAgICAgICAgICAgICAgR0lULUxTKDEpXG5cbk5BTUVcbiAgICAgICBnaXQtbHMgLSBzaG93IHRoZSBjdXJyZW50IGRpcmVjdG9yeSBhbm5vdGF0ZWQgd2l0aCBsaW5rcyBhbmQgZ2l0IGluZm9cblxuU1lOT1BTSVNcbiAgICAgICBnaXQgbHMgWzxkaXI+XVxuXG5ERVNDUklQVElPTlxuICAgICAgIGdpdC1scyBkaXNwbGF5cyB0aGUgZmlsZXMgaW4gdGhlIGN1cnJlbnQgZGlyZWN0b3J5LCB0aGVpciBjdXJyZW50IGdpdFxuICAgICAgIHN0YXR1cywgYSBzaG9ydCBkaWZmc3RhdCwgdGhlaXIgbGFzdCBtb2RpZmllZCBkYXRlLCB0aGUgYXV0aG9yIGFuZCBhXG4gICAgICAgcG9ydGlvbiBvZiB0aGUgbGFzdCBjb21taXQgbWVzc2FnZSBmb3IgdGhhdCBmaWxlLlxuXG4gICAgICAgQWxsIGZpbGVzIGFyZSBoeXBlcmxpbmtlZCB3aXRoIE9TQzggaHlwZXJsaW5rcywgc28geW91IHNob3VsZCBiZSBhYmxlXG4gICAgICAgdG8gb3BlbiB0aGVtIGJ5IGNsaWNraW5nIG9uIHRoZW0gaW4gYSBwcm9wZXJseS1jb25maWd1cmVkIHRlcm1pbmFsLiBUaGVcbiAgICAgICBhdXRob3IgbmFtZXMgYXJlIGh5cGVybGlua2VkIHRvIEdpdEh1YiBpZiB0aGUgcmVwb3NpdG9yeSBoYXMgYSBHaXRIdWJcbiAgICAgICByZW1vdGUsIGFzIGFyZSBjb21taXQgbWVzc2FnZXMuXG5cbk9QVElPTlNcbiAgICAgICAtLXZlcnNpb25cbiAgICAgICAgICAgICAgUHJpbnQgdGhlIHZlcnNpb24gbnVtYmVyIGFuZCBleGl0LlxuXG4gICAgICAgLS1oZWxwLCAtaFxuICAgICAgICAgICAgICBQcmludCB0aGUgaGVscCBtZXNzYWdlIGFuZCBleGl0LlxuXG4gICAgICAgLS1kaWZmV2lkdGg9blxuICAgICAgICAgICAgICBQcmludCB0aGUgZGlmZlN0YXQgZ3JhcGggd2l0aCB0aGUgZ2l2ZW4gd2lkdGguIERlZmF1bHQgaXMgNC5cblxuICAgICAgIC0tZm9ybWF0PWNvbDEsY29sMiwuLi5cbiAgICAgICAgICAgICAgU3BlY2lmeSB3aGljaCBjb2x1bW5zIHRvIGRpc3BsYXkgYW5kIGluIHdoYXQgb3JkZXIuIFZhbGlkXG4gICAgICAgICAgICAgIGNvbHVtbnM6IHN0YXR1cywgZGlmZiwgZmlsZW5hbWUsIHNob3J0aGFzaCwgaGFzaCwgZGF0ZSwgYXV0aG9yLFxuICAgICAgICAgICAgICBlbWFpbCwgbnVtc3RhdCwgY29tbWl0bWVzc2FnZS5cbiAgICAgICAgICAgICAgRGVmYXVsdDpcbiAgICAgICAgICAgICAgc3RhdHVzLGRpZmYsZmlsZW5hbWUsc2hvcnRoYXNoLGRhdGUsYXV0aG9yLGNvbW1pdG1lc3NhZ2UuXG5cbiAgICAgICAtLW1vbm8taGFzaFxuICAgICAgICAgICAgICBVc2UgYSBzaW5nbGUgY29sb3IgKGN5YW4pIGZvciBhbGwgY29tbWl0IGhhc2hlcyBpbnN0ZWFkIG9mXG4gICAgICAgICAgICAgIGNvbG9yaW5nIGVhY2ggaGFzaCB1bmlxdWVseSBiYXNlZCBvbiBpdHMgdmFsdWUuXG5cbiAgICAgICAtLW5lcmRmb250XG4gICAgICAgICAgICAgIFJlcGxhY2UgZ2l0IHN0YXR1cyBsZXR0ZXJzIHdpdGggTmVyZCBGb250IGljb25zIChyZXF1aXJlcyBhIE5lcmRcbiAgICAgICAgICAgICAgRm9udC1wYXRjaGVkIHRlcm1pbmFsIGZvbnQpLlxuXG4gICAgICAgLWMsIC0tY2hhbmdlZC1vbmx5XG4gICAgICAgICAgICAgIE9ubHkgc2hvdyBmaWxlcyB0aGF0IGhhdmUgY2hhbmdlcyAoYXBwZWFyIGluIGdpdCBzdGF0dXMpLiBUaGlzXG4gICAgICAgICAgICAgIGZpbHRlcnMgb3V0IHVubW9kaWZpZWQgdHJhY2tlZCBmaWxlcyBhbmQgc2hvd3Mgb25seSBmaWxlcyB3aXRoXG4gICAgICAgICAgICAgIHN0YXR1cyBpbmRpY2F0b3JzIChtb2RpZmllZCwgYWRkZWQsIGRlbGV0ZWQsIHJlbmFtZWQsIGV0Yy4pLlxuXG5FWEFNUExFU1xuICAgICAgIGdpdCBscyBTaG93IGFsbCBmaWxlcyBpbiB0aGUgY3VycmVudCBkaXJlY3Rvcnkgd2l0aCBnaXQgaW5mb3JtYXRpb24uXG5cbiAgICAgICBnaXQgbHMgLS1jaGFuZ2VkLW9ubHlcbiAgICAgICAgICAgICAgU2hvdyBvbmx5IGZpbGVzIHRoYXQgaGF2ZSB1bmNvbW1pdHRlZCBjaGFuZ2VzLlxuXG4gICAgICAgZ2l0IGxzIC0tZm9ybWF0PWZpbGVuYW1lLHN0YXR1cyxhdXRob3JcbiAgICAgICAgICAgICAgU2hvdyBjdXN0b20gY29sdW1uczogZmlsZW5hbWUsIHN0YXR1cywgYW5kIGF1dGhvciBvbmx5LlxuXG4gICAgICAgZ2l0IGxzIC0tZGlmZldpZHRoPThcbiAgICAgICAgICAgICAgU2hvdyBhIHdpZGVyIGRpZmZzdGF0IGdyYXBoICg4IGNoYXJhY3RlcnMgaW5zdGVhZCBvZiA0KS5cblxuVEVSTUlOQUwgU1VQUE9SVFxuICAgICAgIEZvciB0aGUgYmVzdCBleHBlcmllbmNlLCB1c2UgYSB0ZXJtaW5hbCB0aGF0IHN1cHBvcnRzIE9TQzggaHlwZXJsaW5rcyxcbiAgICAgICBzdWNoIGFzOlxuXG4gICAgICAg4oCiIGtpdHR5XG5cbiAgICAgICDigKIgaVRlcm0yXG5cbiAgICAgICDigKIgV2V6VGVybVxuXG4gICAgICAgSW4gdGhlc2UgdGVybWluYWxzLCB5b3UgY2FuIGNsaWNrIG9uIGZpbGVuYW1lcyB0byBvcGVuIHRoZW0gaW4geW91clxuICAgICAgIHByZWZlcnJlZCBlZGl0b3IsIG9yIGNsaWNrIG9uIGEgUFIgbnVtYmVyIGluIGEgY29tbWl0IHN0YXR1cyB0byBnb1xuICAgICAgIHN0cmFpZ2h0IHRvIHRoYXQgUFIgaW4geW91ciBicm93c2VyLlxuXG5BVVRIT1JcbiAgICAgICBXcml0dGVuIGJ5IEJpbGwgTWlsbC5cblxuQlVHU1xuICAgICAgIFJlcG9ydCBidWdzIGF0OiBodHRwczovL2dpdGh1Yi5jb20vbGxpbWxsaWIvZ2l0LWxzL2lzc3Vlc1xuXG5TRUUgQUxTT1xuICAgICAgIGdpdCgxKSwgZ2l0LXN0YXR1cygxKSwgZ2l0LWxvZygxKVxuXG4gICAgICAgRnVsbCBkb2N1bWVudGF0aW9uIGF0OiBodHRwczovL2dpdGh1Yi5jb20vbGxpbWxsaWIvZ2l0LWxzXG5cbmdpdC1scyAgICAgICAgICAgICAgICAgICAgICAgICAgICAyMDI2LTA0LTA4ICAgICAgICAgICAgICAgICAgICAgICAgIEdJVC1MUygxKVxuIn1dLCJpc0Vycm9yIjpmYWxzZSwidGltZXN0YW1wIjoxNzc1NjEwNDQyMzgyfX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiZDE2NzlmMTQiLCJwYXJlbnRJZCI6IjczMjQ0M2M3IiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowNzoyOS44NzBaIiwibWVzc2FnZSI6eyJyb2xlIjoiYXNzaXN0YW50IiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoiUGVyZmVjdCEgTm93IGxldCdzIHVwZGF0ZSB0aGUgTWFrZWZpbGUgYW5kIC5nb3JlbGVhc2VyLnlhbWwgdG8gYnVpbGQgYW5kIGluc3RhbGwgaXQ6In0seyJ0eXBlIjoidG9vbENhbGwiLCJpZCI6InRvb2x1c2VfVFMxeU1MTEt1SjcxOEpTOTA3UHRWUSIsIm5hbWUiOiJlZGl0IiwiYXJndW1lbnRzIjp7InBhdGgiOiJNYWtlZmlsZSIsImVkaXRzIjpbeyJvbGRUZXh0IjoiLlBIT05ZOiBhbGxcbmFsbDogZ2l0LWxzIiwibmV3VGV4dCI6Ii5QSE9OWTogYWxsXG5hbGw6IGdpdC1scyBnaXQtbHMuMSJ9LHsib2xkVGV4dCI6ImdpdC1sczogJChTUkMpXG5cdGdvIGJ1aWxkIiwibmV3VGV4dCI6ImdpdC1sczogJChTUkMpXG5cdGdvIGJ1aWxkXG5cbi5QSE9OWTogZ2l0LWxzLjFcbmdpdC1scy4xOlxuXHRAIyBNYW4gcGFnZSBpcyBhbHJlYWR5IGdlbmVyYXRlZCwganVzdCB2ZXJpZnkgaXQgZXhpc3RzXG5cdEB0ZXN0IC1mIGdpdC1scy4xIHx8IChlY2hvIFwiRXJyb3I6IGdpdC1scy4xIG5vdCBmb3VuZFwiICYmIGV4aXQgMSkifV19fV0sImFwaSI6ImJlZHJvY2stY29udmVyc2Utc3RyZWFtIiwicHJvdmlkZXIiOiJzb25uZXQtYmVkcm9jayIsIm1vZGVsIjoiYXJuOmF3czpiZWRyb2NrOnVzLWVhc3QtMTo2ODYxNTA2ODI5Njc6YXBwbGljYXRpb24taW5mZXJlbmNlLXByb2ZpbGUvNXNpejA0eGxxcTlnIiwidXNhZ2UiOnsiaW5wdXQiOjk0NzcsIm91dHB1dCI6MjY2LCJjYWNoZVJlYWQiOjAsImNhY2hlV3JpdGUiOjAsInRvdGFsVG9rZW5zIjo5NzQzLCJjb3N0Ijp7ImlucHV0IjowLCJvdXRwdXQiOjAsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWwiOjB9fSwic3RvcFJlYXNvbiI6InRvb2xVc2UiLCJ0aW1lc3RhbXAiOjE3NzU2MTA0NDIzODJ9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiI5M2VkYmIwNyIsInBhcmVudElkIjoiZDE2NzlmMTQiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjA3OjI5Ljg4MFoiLCJtZXNzYWdlIjp7InJvbGUiOiJ0b29sUmVzdWx0IiwidG9vbENhbGxJZCI6InRvb2x1c2VfVFMxeU1MTEt1SjcxOEpTOTA3UHRWUSIsInRvb2xOYW1lIjoiZWRpdCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6IlN1Y2Nlc3NmdWxseSByZXBsYWNlZCAyIGJsb2NrKHMpIGluIE1ha2VmaWxlLiJ9XSwiZGV0YWlscyI6eyJkaWZmIjoiICAgIC4uLlxuICAyIFRSQU5TQ1JJUFRTIDo9ICQod2lsZGNhcmQgdHJhbnNjcmlwdHMvKilcbiAgMyBTVEFUSUMgOj0gJCh3aWxkY2FyZCBzdGF0aWMvKilcbiAgNCBcbiAgNSAuUEhPTlk6IGFsbFxuLSA2IGFsbDogZ2l0LWxzXG4rIDYgYWxsOiBnaXQtbHMgZ2l0LWxzLjFcbiAgNyBcbiAgOCBnaXQtbHM6ICQoU1JDKVxuICA5IFx0Z28gYnVpbGRcbiAxMCBcbisxMSAuUEhPTlk6IGdpdC1scy4xXG4rMTIgZ2l0LWxzLjE6XG4rMTMgXHRAIyBNYW4gcGFnZSBpcyBhbHJlYWR5IGdlbmVyYXRlZCwganVzdCB2ZXJpZnkgaXQgZXhpc3RzXG4rMTQgXHRAdGVzdCAtZiBnaXQtbHMuMSB8fCAoZWNobyBcIkVycm9yOiBnaXQtbHMuMSBub3QgZm91bmRcIiAmJiBleGl0IDEpXG4rMTUgXG4gMTEgIyBkZXBlbmRzIG9uIGdvbGFuZ2NpLWxpbnQ6XG4gMTIgIyBodHRwczovL2dvbGFuZ2NpLWxpbnQucnVuL3dlbGNvbWUvaW5zdGFsbC8jbG9jYWwtaW5zdGFsbGF0aW9uXG4gMTMgLlBIT05ZOiBsaW50XG4gMTQgbGludDpcbiAgICAuLi4iLCJmaXJzdENoYW5nZWRMaW5lIjo2fSwiaXNFcnJvciI6ZmFsc2UsInRpbWVzdGFtcCI6MTc3NTYxMDQ0OTg3OX19LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6ImRlYmNhMDkyIiwicGFyZW50SWQiOiI5M2VkYmIwNyIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDc6MzYuMTk4WiIsIm1lc3NhZ2UiOnsicm9sZSI6ImFzc2lzdGFudCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0b29sQ2FsbCIsImlkIjoidG9vbHVzZV9ZemVSTXlVTUlab1B5TjVjMXhqaklTIiwibmFtZSI6ImVkaXQiLCJhcmd1bWVudHMiOnsicGF0aCI6Ii5nb3JlbGVhc2VyLnlhbWwiLCJlZGl0cyI6W3sib2xkVGV4dCI6ImJyZXdzOlxuICAtIG5hbWU6IGdpdC1sc1xuICAgIGhvbWVwYWdlOiBcImh0dHBzOi8vZ2l0aHViLmNvbS9sbGltbGxpYi9naXQtbHNcIlxuICAgIGRlc2NyaXB0aW9uOiBcImxpc3QgdGhlIGZpbGVzIGluIHRoZSBjdXJyZW50IGRpcmVjdG9yeSBhbG9uZyB3aXRoIGEgdXNlZnVsIHN1bW1hcnkgYW5kIGhlbHBmdWwgaHlwZXJsaW5rcy5cIlxuICAgIGxpY2Vuc2U6IFwiVW5saWNlbnNlXCJcbiAgICByZXBvc2l0b3J5OlxuICAgICAgb3duZXI6IGxsaW1sbGliXG4gICAgICBuYW1lOiBob21lYnJldy1naXQtbHNcbiAgICAgIGJyYW5jaDogbWFpbiIsIm5ld1RleHQiOiJicmV3czpcbiAgLSBuYW1lOiBnaXQtbHNcbiAgICBob21lcGFnZTogXCJodHRwczovL2dpdGh1Yi5jb20vbGxpbWxsaWIvZ2l0LWxzXCJcbiAgICBkZXNjcmlwdGlvbjogXCJsaXN0IHRoZSBmaWxlcyBpbiB0aGUgY3VycmVudCBkaXJlY3RvcnkgYWxvbmcgd2l0aCBhIHVzZWZ1bCBzdW1tYXJ5IGFuZCBoZWxwZnVsIGh5cGVybGlua3MuXCJcbiAgICBsaWNlbnNlOiBcIlVubGljZW5zZVwiXG4gICAgcmVwb3NpdG9yeTpcbiAgICAgIG93bmVyOiBsbGltbGxpYlxuICAgICAgbmFtZTogaG9tZWJyZXctZ2l0LWxzXG4gICAgICBicmFuY2g6IG1haW5cbiAgICBpbnN0YWxsOiB8XG4gICAgICBiaW4uaW5zdGFsbCBcImdpdC1sc1wiXG4gICAgICBtYW4xLmluc3RhbGwgXCJnaXQtbHMuMVwiIn1dfX1dLCJhcGkiOiJiZWRyb2NrLWNvbnZlcnNlLXN0cmVhbSIsInByb3ZpZGVyIjoic29ubmV0LWJlZHJvY2siLCJtb2RlbCI6ImFybjphd3M6YmVkcm9jazp1cy1lYXN0LTE6Njg2MTUwNjgyOTY3OmFwcGxpY2F0aW9uLWluZmVyZW5jZS1wcm9maWxlLzVzaXowNHhscXE5ZyIsInVzYWdlIjp7ImlucHV0Ijo5NzQ4LCJvdXRwdXQiOjMxNSwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbFRva2VucyI6MTAwNjMsImNvc3QiOnsiaW5wdXQiOjAsIm91dHB1dCI6MCwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbCI6MH19LCJzdG9wUmVhc29uIjoidG9vbFVzZSIsInRpbWVzdGFtcCI6MTc3NTYxMDQ0OTg4MX19LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6IjY3OGM2ZWY2IiwicGFyZW50SWQiOiJkZWJjYTA5MiIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDc6MzYuMjAxWiIsIm1lc3NhZ2UiOnsicm9sZSI6InRvb2xSZXN1bHQiLCJ0b29sQ2FsbElkIjoidG9vbHVzZV9ZemVSTXlVTUlab1B5TjVjMXhqaklTIiwidG9vbE5hbWUiOiJlZGl0IiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoiU3VjY2Vzc2Z1bGx5IHJlcGxhY2VkIDEgYmxvY2socykgaW4gLmdvcmVsZWFzZXIueWFtbC4ifV0sImRldGFpbHMiOnsiZGlmZiI6IiAgICAuLi5cbiA1MiAgICAgcmVwb3NpdG9yeTpcbiA1MyAgICAgICBvd25lcjogbGxpbWxsaWJcbiA1NCAgICAgICBuYW1lOiBob21lYnJldy1naXQtbHNcbiA1NSAgICAgICBicmFuY2g6IG1haW5cbis1NiAgICAgaW5zdGFsbDogfFxuKzU3ICAgICAgIGJpbi5pbnN0YWxsIFwiZ2l0LWxzXCJcbis1OCAgICAgICBtYW4xLmluc3RhbGwgXCJnaXQtbHMuMVwiIiwiZmlyc3RDaGFuZ2VkTGluZSI6NTZ9LCJpc0Vycm9yIjpmYWxzZSwidGltZXN0YW1wIjoxNzc1NjEwNDU2MjAxfX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiMjU1NmJmNjMiLCJwYXJlbnRJZCI6IjY3OGM2ZWY2IiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowNzo0NC4wMDBaIiwibWVzc2FnZSI6eyJyb2xlIjoiYXNzaXN0YW50IiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoiTm93IHdlIG5lZWQgdG8gdGVsbCBnb3JlbGVhc2VyIHRvIGluY2x1ZGUgdGhlIG1hbiBwYWdlIGluIHRoZSByZWxlYXNlIGFyY2hpdmVzOiJ9LHsidHlwZSI6InRvb2xDYWxsIiwiaWQiOiJ0b29sdXNlX1k5RmhXTVAyQ2hhaVFwOW9NQjVmbm4iLCJuYW1lIjoiZWRpdCIsImFyZ3VtZW50cyI6eyJlZGl0cyI6W3sibmV3VGV4dCI6ImFyY2hpdmVzOlxuICAtIGZvcm1hdHM6IFtcInRhci5nelwiXVxuICAgICMgdGhpcyBuYW1lIHRlbXBsYXRlIG1ha2VzIHRoZSBPUyBhbmQgQXJjaCBjb21wYXRpYmxlIHdpdGggdGhlIHJlc3VsdHMgb2YgYHVuYW1lYC5cbiAgICBuYW1lX3RlbXBsYXRlOiA+LVxuICAgICAge3sgLlByb2plY3ROYW1lIH19X1xuICAgICAge3stIHRpdGxlIC5PcyB9fV9cbiAgICAgIHt7LSBpZiBlcSAuQXJjaCBcImFtZDY0XCIgfX14ODZfNjRcbiAgICAgIHt7LSBlbHNlIGlmIGVxIC5BcmNoIFwiMzg2XCIgfX1pMzg2XG4gICAgICB7ey0gZWxzZSB9fXt7IC5BcmNoIH19e3sgZW5kIH19XG4gICAgICB7ey0gaWYgLkFybSB9fXZ7eyAuQXJtIH19e3sgZW5kIH19XG4gICAgIyB1c2UgemlwIGZvciB3aW5kb3dzIGFyY2hpdmVzXG4gICAgZm9ybWF0X292ZXJyaWRlczpcbiAgICAgIC0gZ29vczogd2luZG93c1xuICAgICAgICBmb3JtYXRzOiBbXCJ6aXBcIl1cbiAgICBmaWxlczpcbiAgICAgIC0gZ2l0LWxzLjEiLCJvbGRUZXh0IjoiYXJjaGl2ZXM6XG4gIC0gZm9ybWF0czogW1widGFyLmd6XCJdXG4gICAgIyB0aGlzIG5hbWUgdGVtcGxhdGUgbWFrZXMgdGhlIE9TIGFuZCBBcmNoIGNvbXBhdGlibGUgd2l0aCB0aGUgcmVzdWx0cyBvZiBgdW5hbWVgLlxuICAgIG5hbWVfdGVtcGxhdGU6ID4tXG4gICAgICB7eyAuUHJvamVjdE5hbWUgfX1fXG4gICAgICB7ey0gdGl0bGUgLk9zIH19X1xuICAgICAge3stIGlmIGVxIC5BcmNoIFwiYW1kNjRcIiB9fXg4Nl82NFxuICAgICAge3stIGVsc2UgaWYgZXEgLkFyY2ggXCIzODZcIiB9fWkzODZcbiAgICAgIHt7LSBlbHNlIH19e3sgLkFyY2ggfX17eyBlbmQgfX1cbiAgICAgIHt7LSBpZiAuQXJtIH19dnt7IC5Bcm0gfX17eyBlbmQgfX1cbiAgICAjIHVzZSB6aXAgZm9yIHdpbmRvd3MgYXJjaGl2ZXNcbiAgICBmb3JtYXRfb3ZlcnJpZGVzOlxuICAgICAgLSBnb29zOiB3aW5kb3dzXG4gICAgICAgIGZvcm1hdHM6IFtcInppcFwiXSJ9XSwicGF0aCI6Ii5nb3JlbGVhc2VyLnlhbWwifX1dLCJhcGkiOiJiZWRyb2NrLWNvbnZlcnNlLXN0cmVhbSIsInByb3ZpZGVyIjoic29ubmV0LWJlZHJvY2siLCJtb2RlbCI6ImFybjphd3M6YmVkcm9jazp1cy1lYXN0LTE6Njg2MTUwNjgyOTY3OmFwcGxpY2F0aW9uLWluZmVyZW5jZS1wcm9maWxlLzVzaXowNHhscXE5ZyIsInVzYWdlIjp7ImlucHV0IjoxMDA4MCwib3V0cHV0Ijo0NTQsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWxUb2tlbnMiOjEwNTM0LCJjb3N0Ijp7ImlucHV0IjowLCJvdXRwdXQiOjAsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWwiOjB9fSwic3RvcFJlYXNvbiI6InRvb2xVc2UiLCJ0aW1lc3RhbXAiOjE3NzU2MTA0NTYyMDF9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiJlNDQyZWZjYiIsInBhcmVudElkIjoiMjU1NmJmNjMiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjA3OjQ0LjAwMloiLCJtZXNzYWdlIjp7InJvbGUiOiJ0b29sUmVzdWx0IiwidG9vbENhbGxJZCI6InRvb2x1c2VfWTlGaFdNUDJDaGFpUXA5b01CNWZubiIsInRvb2xOYW1lIjoiZWRpdCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6IlN1Y2Nlc3NmdWxseSByZXBsYWNlZCAxIGJsb2NrKHMpIGluIC5nb3JlbGVhc2VyLnlhbWwuIn1dLCJkZXRhaWxzIjp7ImRpZmYiOiIgICAgLi4uXG4gMzUgICAgICMgdXNlIHppcCBmb3Igd2luZG93cyBhcmNoaXZlc1xuIDM2ICAgICBmb3JtYXRfb3ZlcnJpZGVzOlxuIDM3ICAgICAgIC0gZ29vczogd2luZG93c1xuIDM4ICAgICAgICAgZm9ybWF0czogW1wiemlwXCJdXG4rMzkgICAgIGZpbGVzOlxuKzQwICAgICAgIC0gZ2l0LWxzLjFcbiAzOSBcbiA0MCBjaGFuZ2Vsb2c6XG4gNDEgICBzb3J0OiBhc2NcbiA0MiAgIGZpbHRlcnM6XG4gICAgLi4uIiwiZmlyc3RDaGFuZ2VkTGluZSI6Mzl9LCJpc0Vycm9yIjpmYWxzZSwidGltZXN0YW1wIjoxNzc1NjEwNDY0MDAyfX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiNTZlMmRhZGQiLCJwYXJlbnRJZCI6ImU0NDJlZmNiIiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowNzo0Ny4yMTNaIiwibWVzc2FnZSI6eyJyb2xlIjoiYXNzaXN0YW50IiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoiTGV0J3MgdGVzdCB0aGUgYnVpbGQ6In0seyJ0eXBlIjoidG9vbENhbGwiLCJpZCI6InRvb2x1c2VfWU82aFpFajM2QkEweHpyc2Q3MXZYWCIsIm5hbWUiOiJiYXNoIiwiYXJndW1lbnRzIjp7ImNvbW1hbmQiOiJtYWtlIGNsZWFuIDI+L2Rldi9udWxsIHx8IHRydWU7IG1ha2UifX1dLCJhcGkiOiJiZWRyb2NrLWNvbnZlcnNlLXN0cmVhbSIsInByb3ZpZGVyIjoic29ubmV0LWJlZHJvY2siLCJtb2RlbCI6ImFybjphd3M6YmVkcm9jazp1cy1lYXN0LTE6Njg2MTUwNjgyOTY3OmFwcGxpY2F0aW9uLWluZmVyZW5jZS1wcm9maWxlLzVzaXowNHhscXE5ZyIsInVzYWdlIjp7ImlucHV0IjoxMDU2Miwib3V0cHV0Ijo2OSwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbFRva2VucyI6MTA2MzEsImNvc3QiOnsiaW5wdXQiOjAsIm91dHB1dCI6MCwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbCI6MH19LCJzdG9wUmVhc29uIjoidG9vbFVzZSIsInRpbWVzdGFtcCI6MTc3NTYxMDQ2NDAwMn19LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6IjI5NjhjYjc4IiwicGFyZW50SWQiOiI1NmUyZGFkZCIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDc6NDcuMjkwWiIsIm1lc3NhZ2UiOnsicm9sZSI6InRvb2xSZXN1bHQiLCJ0b29sQ2FsbElkIjoidG9vbHVzZV9ZTzZoWkVqMzZCQTB4enJzZDcxdlhYIiwidG9vbE5hbWUiOiJiYXNoIiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoiKG5vIG91dHB1dCkifV0sImlzRXJyb3IiOmZhbHNlLCJ0aW1lc3RhbXAiOjE3NzU2MTA0NjcyOTB9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiI1NzZlZTUxNiIsInBhcmVudElkIjoiMjk2OGNiNzgiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjA3OjUwLjQ1MFoiLCJtZXNzYWdlIjp7InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbeyJ0eXBlIjoidG9vbENhbGwiLCJpZCI6InRvb2x1c2VfVjlmdmMwM0ZGa3VqRFQ3bzRkV0IyRiIsIm5hbWUiOiJiYXNoIiwiYXJndW1lbnRzIjp7ImNvbW1hbmQiOiJscyAtbGggZ2l0LWxzIGdpdC1scy4xIn19XSwiYXBpIjoiYmVkcm9jay1jb252ZXJzZS1zdHJlYW0iLCJwcm92aWRlciI6InNvbm5ldC1iZWRyb2NrIiwibW9kZWwiOiJhcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY4NjE1MDY4Mjk2NzphcHBsaWNhdGlvbi1pbmZlcmVuY2UtcHJvZmlsZS81c2l6MDR4bHFxOWciLCJ1c2FnZSI6eyJpbnB1dCI6MTA2NDUsIm91dHB1dCI6NjIsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWxUb2tlbnMiOjEwNzA3LCJjb3N0Ijp7ImlucHV0IjowLCJvdXRwdXQiOjAsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWwiOjB9fSwic3RvcFJlYXNvbiI6InRvb2xVc2UiLCJ0aW1lc3RhbXAiOjE3NzU2MTA0NjcyOTF9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiIxMTVhYWIyOCIsInBhcmVudElkIjoiNTc2ZWU1MTYiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjA3OjUwLjQ4OVoiLCJtZXNzYWdlIjp7InJvbGUiOiJ0b29sUmVzdWx0IiwidG9vbENhbGxJZCI6InRvb2x1c2VfVjlmdmMwM0ZGa3VqRFQ3bzRkV0IyRiIsInRvb2xOYW1lIjoiYmFzaCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6Ii1yd3hyLXhyLXhAIDEgbGxpbWxsaWIgIHN0YWZmICAgMy4yTSBBcHIgIDcgMjE6MDcgZ2l0LWxzXG4tcnctci0tci0tQCAxIGxsaW1sbGliICBzdGFmZiAgIDIuNUsgQXByICA3IDIxOjA3IGdpdC1scy4xXG4ifV0sImlzRXJyb3IiOmZhbHNlLCJ0aW1lc3RhbXAiOjE3NzU2MTA0NzA0ODh9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiI2ZmVhMjUzZSIsInBhcmVudElkIjoiMTE1YWFiMjgiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjA3OjU0Ljc0NloiLCJtZXNzYWdlIjp7InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiJHcmVhdCEgTm93IGxldCdzIHRlc3QgdGhhdCB0aGUgbWFuIHBhZ2UgY2FuIGJlIGluc3RhbGxlZCBsb2NhbGx5IGFuZCBhY2Nlc3NlZCB2aWEgYGdpdCBscyAtLWhlbHBgOiJ9LHsidHlwZSI6InRvb2xDYWxsIiwiaWQiOiJ0b29sdXNlX0NJU2lWckZKalhxbkt2UkhWR2JyQzIiLCJuYW1lIjoiYmFzaCIsImFyZ3VtZW50cyI6eyJjb21tYW5kIjoibWtkaXIgLXAgfi8ubG9jYWwvc2hhcmUvbWFuL21hbjEgJiYgY3AgZ2l0LWxzLjEgfi8ubG9jYWwvc2hhcmUvbWFuL21hbjEvICYmIG1hbmRiIH4vLmxvY2FsL3NoYXJlL21hbiAyPiYxIHwgdGFpbCAtNSJ9fV0sImFwaSI6ImJlZHJvY2stY29udmVyc2Utc3RyZWFtIiwicHJvdmlkZXIiOiJzb25uZXQtYmVkcm9jayIsIm1vZGVsIjoiYXJuOmF3czpiZWRyb2NrOnVzLWVhc3QtMTo2ODYxNTA2ODI5Njc6YXBwbGljYXRpb24taW5mZXJlbmNlLXByb2ZpbGUvNXNpejA0eGxxcTlnIiwidXNhZ2UiOnsiaW5wdXQiOjEwNzkwLCJvdXRwdXQiOjEyMywiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbFRva2VucyI6MTA5MTMsImNvc3QiOnsiaW5wdXQiOjAsIm91dHB1dCI6MCwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbCI6MH19LCJzdG9wUmVhc29uIjoidG9vbFVzZSIsInRpbWVzdGFtcCI6MTc3NTYxMDQ3MDQ4OX19LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6ImFmYjA4M2Q5IiwicGFyZW50SWQiOiI2ZmVhMjUzZSIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDc6NTQuNzc1WiIsIm1lc3NhZ2UiOnsicm9sZSI6InRvb2xSZXN1bHQiLCJ0b29sQ2FsbElkIjoidG9vbHVzZV9DSVNpVnJGSmpYcW5LdlJIVkdickMyIiwidG9vbE5hbWUiOiJiYXNoIiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoiL2Jpbi9iYXNoOiBtYW5kYjogY29tbWFuZCBub3QgZm91bmRcbiJ9XSwiaXNFcnJvciI6ZmFsc2UsInRpbWVzdGFtcCI6MTc3NTYxMDQ3NDc3NH19LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6ImZlZTU5MmI0IiwicGFyZW50SWQiOiJhZmIwODNkOSIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDc6NTguNTI4WiIsIm1lc3NhZ2UiOnsicm9sZSI6ImFzc2lzdGFudCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0b29sQ2FsbCIsImlkIjoidG9vbHVzZV9RRFJVdlJha2dKM0s1aTdSU3Y4bFBjIiwibmFtZSI6ImJhc2giLCJhcmd1bWVudHMiOnsiY29tbWFuZCI6Im1hbiBnaXQtbHMgfCBoZWFkIC0yMCJ9fV0sImFwaSI6ImJlZHJvY2stY29udmVyc2Utc3RyZWFtIiwicHJvdmlkZXIiOiJzb25uZXQtYmVkcm9jayIsIm1vZGVsIjoiYXJuOmF3czpiZWRyb2NrOnVzLWVhc3QtMTo2ODYxNTA2ODI5Njc6YXBwbGljYXRpb24taW5mZXJlbmNlLXByb2ZpbGUvNXNpejA0eGxxcTlnIiwidXNhZ2UiOnsiaW5wdXQiOjEwOTM2LCJvdXRwdXQiOjU4LCJjYWNoZVJlYWQiOjAsImNhY2hlV3JpdGUiOjAsInRvdGFsVG9rZW5zIjoxMDk5NCwiY29zdCI6eyJpbnB1dCI6MCwib3V0cHV0IjowLCJjYWNoZVJlYWQiOjAsImNhY2hlV3JpdGUiOjAsInRvdGFsIjowfX0sInN0b3BSZWFzb24iOiJ0b29sVXNlIiwidGltZXN0YW1wIjoxNzc1NjEwNDc0Nzc1fX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiMTNhZTQ0YWIiLCJwYXJlbnRJZCI6ImZlZTU5MmI0IiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowNzo1OC43OTNaIiwibWVzc2FnZSI6eyJyb2xlIjoidG9vbFJlc3VsdCIsInRvb2xDYWxsSWQiOiJ0b29sdXNlX1FEUlV2UmFrZ0ozSzVpN1JTdjhsUGMiLCJ0b29sTmFtZSI6ImJhc2giLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiJHSVQtTFMoMSkgICAgICAgICAgICAgICAgICAgICAgICBVc2VyIENvbW1hbmRzICAgICAgICAgICAgICAgICAgICAgICBHSVQtTFMoMSlcblxuTkFNRVxuICAgICAgIGdpdC1scyAtIHNob3cgdGhlIGN1cnJlbnQgZGlyZWN0b3J5IGFubm90YXRlZCB3aXRoIGxpbmtzIGFuZCBnaXQgaW5mb1xuXG5TWU5PUFNJU1xuICAgICAgIGdpdCBscyBbPGRpcj5dXG5cbkRFU0NSSVBUSU9OXG4gICAgICAgZ2l0LWxzIGRpc3BsYXlzIHRoZSBmaWxlcyBpbiB0aGUgY3VycmVudCBkaXJlY3RvcnksIHRoZWlyIGN1cnJlbnQgZ2l0XG4gICAgICAgc3RhdHVzLCBhIHNob3J0IGRpZmZzdGF0LCB0aGVpciBsYXN0IG1vZGlmaWVkIGRhdGUsIHRoZSBhdXRob3IgYW5kIGFcbiAgICAgICBwb3J0aW9uIG9mIHRoZSBsYXN0IGNvbW1pdCBtZXNzYWdlIGZvciB0aGF0IGZpbGUuXG5cbiAgICAgICBBbGwgZmlsZXMgYXJlIGh5cGVybGlua2VkIHdpdGggT1NDOCBoeXBlcmxpbmtzLCBzbyB5b3Ugc2hvdWxkIGJlIGFibGVcbiAgICAgICB0byBvcGVuIHRoZW0gYnkgY2xpY2tpbmcgb24gdGhlbSBpbiBhIHByb3Blcmx5LWNvbmZpZ3VyZWQgdGVybWluYWwuIFRoZVxuICAgICAgIGF1dGhvciBuYW1lcyBhcmUgaHlwZXJsaW5rZWQgdG8gR2l0SHViIGlmIHRoZSByZXBvc2l0b3J5IGhhcyBhIEdpdEh1YlxuICAgICAgIHJlbW90ZSwgYXMgYXJlIGNvbW1pdCBtZXNzYWdlcy5cblxuT1BUSU9OU1xuICAgICAgIC0tdmVyc2lvblxuIn1dLCJpc0Vycm9yIjpmYWxzZSwidGltZXN0YW1wIjoxNzc1NjEwNDc4NzkzfX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiY2Y3ZTIwNmQiLCJwYXJlbnRJZCI6IjEzYWU0NGFiIiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowODowMi4zMDJaIiwibWVzc2FnZSI6eyJyb2xlIjoiYXNzaXN0YW50IiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoiRXhjZWxsZW50ISBOb3cgbGV0J3MgdmVyaWZ5IHRoYXQgYGdpdCBscyAtLWhlbHBgIHdpbGwgdXNlIHRoZSBtYW4gcGFnZToifSx7InR5cGUiOiJ0b29sQ2FsbCIsImlkIjoidG9vbHVzZV81NWlMa3VWMWxWN1ByT1ZaODJKOVJEIiwibmFtZSI6ImJhc2giLCJhcmd1bWVudHMiOnsiY29tbWFuZCI6ImdpdCBscyAtLWhlbHAgMj4mMSB8IGhlYWQgLTIwIn19XSwiYXBpIjoiYmVkcm9jay1jb252ZXJzZS1zdHJlYW0iLCJwcm92aWRlciI6InNvbm5ldC1iZWRyb2NrIiwibW9kZWwiOiJhcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY4NjE1MDY4Mjk2NzphcHBsaWNhdGlvbi1pbmZlcmVuY2UtcHJvZmlsZS81c2l6MDR4bHFxOWciLCJ1c2FnZSI6eyJpbnB1dCI6MTExNzgsIm91dHB1dCI6ODQsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWxUb2tlbnMiOjExMjYyLCJjb3N0Ijp7ImlucHV0IjowLCJvdXRwdXQiOjAsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWwiOjB9fSwic3RvcFJlYXNvbiI6InRvb2xVc2UiLCJ0aW1lc3RhbXAiOjE3NzU2MTA0Nzg3OTR9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiJjZmM1ZjUyOCIsInBhcmVudElkIjoiY2Y3ZTIwNmQiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjA4OjAyLjY0MVoiLCJtZXNzYWdlIjp7InJvbGUiOiJ0b29sUmVzdWx0IiwidG9vbENhbGxJZCI6InRvb2x1c2VfNTVpTGt1VjFsVjdQck9WWjgySjlSRCIsInRvb2xOYW1lIjoiYmFzaCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6IkdJVC1MUygxKSAgICAgICAgICAgICAgICAgICAgICAgIFVzZXIgQ29tbWFuZHMgICAgICAgICAgICAgICAgICAgICAgIEdJVC1MUygxKVxuXG5OQU1FXG4gICAgICAgZ2l0LWxzIC0gc2hvdyB0aGUgY3VycmVudCBkaXJlY3RvcnkgYW5ub3RhdGVkIHdpdGggbGlua3MgYW5kIGdpdCBpbmZvXG5cblNZTk9QU0lTXG4gICAgICAgZ2l0IGxzIFs8ZGlyPl1cblxuREVTQ1JJUFRJT05cbiAgICAgICBnaXQtbHMgZGlzcGxheXMgdGhlIGZpbGVzIGluIHRoZSBjdXJyZW50IGRpcmVjdG9yeSwgdGhlaXIgY3VycmVudCBnaXRcbiAgICAgICBzdGF0dXMsIGEgc2hvcnQgZGlmZnN0YXQsIHRoZWlyIGxhc3QgbW9kaWZpZWQgZGF0ZSwgdGhlIGF1dGhvciBhbmQgYVxuICAgICAgIHBvcnRpb24gb2YgdGhlIGxhc3QgY29tbWl0IG1lc3NhZ2UgZm9yIHRoYXQgZmlsZS5cblxuICAgICAgIEFsbCBmaWxlcyBhcmUgaHlwZXJsaW5rZWQgd2l0aCBPU0M4IGh5cGVybGlua3MsIHNvIHlvdSBzaG91bGQgYmUgYWJsZVxuICAgICAgIHRvIG9wZW4gdGhlbSBieSBjbGlja2luZyBvbiB0aGVtIGluIGEgcHJvcGVybHktY29uZmlndXJlZCB0ZXJtaW5hbC4gVGhlXG4gICAgICAgYXV0aG9yIG5hbWVzIGFyZSBoeXBlcmxpbmtlZCB0byBHaXRIdWIgaWYgdGhlIHJlcG9zaXRvcnkgaGFzIGEgR2l0SHViXG4gICAgICAgcmVtb3RlLCBhcyBhcmUgY29tbWl0IG1lc3NhZ2VzLlxuXG5PUFRJT05TXG4gICAgICAgLS12ZXJzaW9uXG4ifV0sImlzRXJyb3IiOmZhbHNlLCJ0aW1lc3RhbXAiOjE3NzU2MTA0ODI2NDF9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiI1ZTJkNzU0YyIsInBhcmVudElkIjoiY2ZjNWY1MjgiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjA4OjA2LjY5NFoiLCJtZXNzYWdlIjp7InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiJQZXJmZWN0ISDwn46JIExldCBtZSBhbHNvIGFkZCB0aGUgbWFuIHBhZ2UgdG8gLmdpdGlnbm9yZSBzaW5jZSBpdCdzIGEgZ2VuZXJhdGVkIGZpbGUuLi4gd2FpdCwgYWN0dWFsbHkgaXQncyBOT1QgZ2VuZXJhdGVkLCBpdCdzIGhhbmQtd3JpdHRlbiwgc28gd2Ugc2hvdWxkIGNvbW1pdCBpdC4gTGV0IG1lIHZlcmlmeSB0aGUgLmdvcmVsZWFzZXIgY29uZmlnIGlzIGNvcnJlY3Q6In0seyJ0eXBlIjoidG9vbENhbGwiLCJpZCI6InRvb2x1c2VfM2FGSDh2UUJzcmxFVFNucmJveHRNRCIsIm5hbWUiOiJyZWFkIiwiYXJndW1lbnRzIjp7InBhdGgiOiIuZ29yZWxlYXNlci55YW1sIn19XSwiYXBpIjoiYmVkcm9jay1jb252ZXJzZS1zdHJlYW0iLCJwcm92aWRlciI6InNvbm5ldC1iZWRyb2NrIiwibW9kZWwiOiJhcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY4NjE1MDY4Mjk2NzphcHBsaWNhdGlvbi1pbmZlcmVuY2UtcHJvZmlsZS81c2l6MDR4bHFxOWciLCJ1c2FnZSI6eyJpbnB1dCI6MTE0NDYsIm91dHB1dCI6MTE1LCJjYWNoZVJlYWQiOjAsImNhY2hlV3JpdGUiOjAsInRvdGFsVG9rZW5zIjoxMTU2MSwiY29zdCI6eyJpbnB1dCI6MCwib3V0cHV0IjowLCJjYWNoZVJlYWQiOjAsImNhY2hlV3JpdGUiOjAsInRvdGFsIjowfX0sInN0b3BSZWFzb24iOiJ0b29sVXNlIiwidGltZXN0YW1wIjoxNzc1NjEwNDgyNjQxfX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiZDlhNWFkMWUiLCJwYXJlbnRJZCI6IjVlMmQ3NTRjIiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowODowNi43MDNaIiwibWVzc2FnZSI6eyJyb2xlIjoidG9vbFJlc3VsdCIsInRvb2xDYWxsSWQiOiJ0b29sdXNlXzNhRkg4dlFCc3JsRVRTbnJib3h0TUQiLCJ0b29sTmFtZSI6InJlYWQiLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiIjIFRoaXMgaXMgYW4gZXhhbXBsZSAuZ29yZWxlYXNlci55bWwgZmlsZSB3aXRoIHNvbWUgc2Vuc2libGUgZGVmYXVsdHMuXG4jIE1ha2Ugc3VyZSB0byBjaGVjayB0aGUgZG9jdW1lbnRhdGlvbiBhdCBodHRwczovL2dvcmVsZWFzZXIuY29tXG5cbiMgVGhlIGxpbmVzIGJlbG93IGFyZSBjYWxsZWQgYG1vZGVsaW5lc2AuIFNlZSBgOmhlbHAgbW9kZWxpbmVgXG4jIEZlZWwgZnJlZSB0byByZW1vdmUgdGhvc2UgaWYgeW91IGRvbid0IHdhbnQvbmVlZCB0byB1c2UgdGhlbS5cbiMgeWFtbC1sYW5ndWFnZS1zZXJ2ZXI6ICRzY2hlbWE9aHR0cHM6Ly9nb3JlbGVhc2VyLmNvbS9zdGF0aWMvc2NoZW1hLmpzb25cbiMgdmltOiBzZXQgdHM9MiBzdz0yIHR3PTAgZm89Y25xb2pcblxudmVyc2lvbjogMlxuXG5iZWZvcmU6XG4gIGhvb2tzOlxuICAgICMgWW91IG1heSByZW1vdmUgdGhpcyBpZiB5b3UgZG9uJ3QgdXNlIGdvIG1vZHVsZXMuXG4gICAgLSBnbyBtb2QgdGlkeVxuXG5idWlsZHM6XG4gIC0gZW52OlxuICAgICAgLSBDR09fRU5BQkxFRD0wXG4gICAgZ29vczpcbiAgICAgIC0gbGludXhcbiAgICAgIC0gZGFyd2luXG4gICAgICAjIHdpbmRvd3Mgc3VwcG9ydCB0aWNrZXQ6IGh0dHBzOi8vZ2l0aHViLmNvbS9sbGltbGxpYi9naXQtbHMvaXNzdWVzLzE0XG4gICAgICAjIC0gd2luZG93c1xuXG5hcmNoaXZlczpcbiAgLSBmb3JtYXRzOiBbXCJ0YXIuZ3pcIl1cbiAgICAjIHRoaXMgbmFtZSB0ZW1wbGF0ZSBtYWtlcyB0aGUgT1MgYW5kIEFyY2ggY29tcGF0aWJsZSB3aXRoIHRoZSByZXN1bHRzIG9mIGB1bmFtZWAuXG4gICAgbmFtZV90ZW1wbGF0ZTogPi1cbiAgICAgIHt7IC5Qcm9qZWN0TmFtZSB9fV9cbiAgICAgIHt7LSB0aXRsZSAuT3MgfX1fXG4gICAgICB7ey0gaWYgZXEgLkFyY2ggXCJhbWQ2NFwiIH19eDg2XzY0XG4gICAgICB7ey0gZWxzZSBpZiBlcSAuQXJjaCBcIjM4NlwiIH19aTM4NlxuICAgICAge3stIGVsc2UgfX17eyAuQXJjaCB9fXt7IGVuZCB9fVxuICAgICAge3stIGlmIC5Bcm0gfX12e3sgLkFybSB9fXt7IGVuZCB9fVxuICAgICMgdXNlIHppcCBmb3Igd2luZG93cyBhcmNoaXZlc1xuICAgIGZvcm1hdF9vdmVycmlkZXM6XG4gICAgICAtIGdvb3M6IHdpbmRvd3NcbiAgICAgICAgZm9ybWF0czogW1wiemlwXCJdXG4gICAgZmlsZXM6XG4gICAgICAtIGdpdC1scy4xXG5cbmNoYW5nZWxvZzpcbiAgc29ydDogYXNjXG4gIGZpbHRlcnM6XG4gICAgZXhjbHVkZTpcbiAgICAgIC0gXCJeZG9jczpcIlxuICAgICAgLSBcIl50ZXN0OlwiXG5cbmJyZXdzOlxuICAtIG5hbWU6IGdpdC1sc1xuICAgIGhvbWVwYWdlOiBcImh0dHBzOi8vZ2l0aHViLmNvbS9sbGltbGxpYi9naXQtbHNcIlxuICAgIGRlc2NyaXB0aW9uOiBcImxpc3QgdGhlIGZpbGVzIGluIHRoZSBjdXJyZW50IGRpcmVjdG9yeSBhbG9uZyB3aXRoIGEgdXNlZnVsIHN1bW1hcnkgYW5kIGhlbHBmdWwgaHlwZXJsaW5rcy5cIlxuICAgIGxpY2Vuc2U6IFwiVW5saWNlbnNlXCJcbiAgICByZXBvc2l0b3J5OlxuICAgICAgb3duZXI6IGxsaW1sbGliXG4gICAgICBuYW1lOiBob21lYnJldy1naXQtbHNcbiAgICAgIGJyYW5jaDogbWFpblxuICAgIGluc3RhbGw6IHxcbiAgICAgIGJpbi5pbnN0YWxsIFwiZ2l0LWxzXCJcbiAgICAgIG1hbjEuaW5zdGFsbCBcImdpdC1scy4xXCJcbiJ9XSwiaXNFcnJvciI6ZmFsc2UsInRpbWVzdGFtcCI6MTc3NTYxMDQ4NjcwMn19LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6ImJlN2RjODQ1IiwicGFyZW50SWQiOiJkOWE1YWQxZSIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDg6MTAuMjA2WiIsIm1lc3NhZ2UiOnsicm9sZSI6ImFzc2lzdGFudCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6IlBlcmZlY3QhIExldCdzIHJ1biB0aGUgbGludGVyIHRvIG1ha2Ugc3VyZSBldmVyeXRoaW5nIGlzIGdvb2Q6In0seyJ0eXBlIjoidG9vbENhbGwiLCJpZCI6InRvb2x1c2VfeHJYb2FETnVpQmM1ekJNekVzSXVXOSIsIm5hbWUiOiJiYXNoIiwiYXJndW1lbnRzIjp7ImNvbW1hbmQiOiJtYWtlIGxpbnQifX1dLCJhcGkiOiJiZWRyb2NrLWNvbnZlcnNlLXN0cmVhbSIsInByb3ZpZGVyIjoic29ubmV0LWJlZHJvY2siLCJtb2RlbCI6ImFybjphd3M6YmVkcm9jazp1cy1lYXN0LTE6Njg2MTUwNjgyOTY3OmFwcGxpY2F0aW9uLWluZmVyZW5jZS1wcm9maWxlLzVzaXowNHhscXE5ZyIsInVzYWdlIjp7ImlucHV0IjoxMjA5Nywib3V0cHV0Ijo2OCwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbFRva2VucyI6MTIxNjUsImNvc3QiOnsiaW5wdXQiOjAsIm91dHB1dCI6MCwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbCI6MH19LCJzdG9wUmVhc29uIjoidG9vbFVzZSIsInRpbWVzdGFtcCI6MTc3NTYxMDQ4NjcwNH19LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6ImY1YmZjYjYyIiwicGFyZW50SWQiOiJiZTdkYzg0NSIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDg6MTIuMzYzWiIsIm1lc3NhZ2UiOnsicm9sZSI6InRvb2xSZXN1bHQiLCJ0b29sQ2FsbElkIjoidG9vbHVzZV94clhvYUROdWlCYzV6Qk16RXNJdVc5IiwidG9vbE5hbWUiOiJiYXNoIiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoiZ29sYW5nY2ktbGludCBydW5cbjAgaXNzdWVzLlxuIn1dLCJpc0Vycm9yIjpmYWxzZSwidGltZXN0YW1wIjoxNzc1NjEwNDkyMzYzfX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiY2JhMzgxNTgiLCJwYXJlbnRJZCI6ImY1YmZjYjYyIiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowODoyNS4zMzJaIiwibWVzc2FnZSI6eyJyb2xlIjoiYXNzaXN0YW50IiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoiRXhjZWxsZW50ISBMZXQncyBjcmVhdGUgYSBxdWljayBzdW1tYXJ5IGRvY3VtZW50OiJ9LHsidHlwZSI6InRvb2xDYWxsIiwiaWQiOiJ0b29sdXNlX3dvcVQ0ck9Cb09DVGZvZG9DcEdSMFIiLCJuYW1lIjoid3JpdGUiLCJhcmd1bWVudHMiOnsiY29udGVudCI6IiMgTWFuIFBhZ2UgU2V0dXBcblxuVGhpcyBkaXJlY3RvcnkgY29udGFpbnMgdGhlIG1hbiBwYWdlIGZvciBnaXQtbHMuXG5cbiMjIEZpbGVzXG5cbi0gYGdpdC1scy4xYCAtIFRoZSBtYW4gcGFnZSBpbiByb2ZmIGZvcm1hdFxuXG4jIyBUZXN0aW5nIExvY2FsbHlcblxuVG8gdGVzdCB0aGUgbWFuIHBhZ2U6XG5cbmBgYGJhc2hcbm1hbiAuL2dpdC1scy4xXG5gYGBcblxuVG8gaW5zdGFsbCBpdCBsb2NhbGx5IChzbyBgZ2l0IGxzIC0taGVscGAgd29ya3MpOlxuXG5gYGBiYXNoXG5ta2RpciAtcCB+Ly5sb2NhbC9zaGFyZS9tYW4vbWFuMVxuY3AgZ2l0LWxzLjEgfi8ubG9jYWwvc2hhcmUvbWFuL21hbjEvXG5gYGBcblxuVGhlbiBgZ2l0IGxzIC0taGVscGAgc2hvdWxkIGRpc3BsYXkgdGhlIG1hbiBwYWdlLlxuXG4jIyBIb21lYnJldyBJbnN0YWxsYXRpb25cblxuV2hlbiB5b3UgcmVsZWFzZSB2aWEgZ29yZWxlYXNlciwgdGhlIG1hbiBwYWdlIHdpbGwgYXV0b21hdGljYWxseSBiZTpcbjEuIEluY2x1ZGVkIGluIHJlbGVhc2UgdGFyYmFsbHMgKHNlZSBgLmdvcmVsZWFzZXIueWFtbGApXG4yLiBJbnN0YWxsZWQgdG8gYC9vcHQvaG9tZWJyZXcvc2hhcmUvbWFuL21hbjEvYCB2aWEgdGhlIEhvbWVicmV3IGZvcm11bGFcblxuVXNlcnMgd2hvIGluc3RhbGwgdmlhIGBicmV3IGluc3RhbGwgbGxpbWxsaWIvZ2l0LWxzL2dpdC1sc2Agd2lsbCBhdXRvbWF0aWNhbGx5IGdldCB0aGUgbWFuIHBhZ2UsIGFuZCBgZ2l0IGxzIC0taGVscGAgd2lsbCB3b3JrIGNvcnJlY3RseS5cblxuIyMgVXBkYXRpbmcgdGhlIE1hbiBQYWdlXG5cblRoZSBtYW4gcGFnZSBpcyB3cml0dGVuIGluIHJvZmYgZm9ybWF0LiBLZXkgbWFjcm9zOlxuXG4tIGAuVEhgIC0gVGl0bGUgaGVhZGVyIChwYWdlIHRpdGxlLCBzZWN0aW9uLCBkYXRlLCBldGMuKVxuLSBgLlNIYCAtIFNlY3Rpb24gaGVhZGVyXG4tIGAuVFBgIC0gVGFnZ2VkIHBhcmFncmFwaCAoZm9yIG9wdGlvbnMpXG4tIGAuQmAgLSBCb2xkIHRleHRcbi0gYC5JYCAtIEl0YWxpYyB0ZXh0XG4tIGAuQklgIC0gQm9sZC1pdGFsaWMgKG1peGVkKVxuLSBgLkJSYCAtIEJvbGQtcm9tYW4gKG1peGVkKVxuLSBgLlBQYCAtIFBhcmFncmFwaCBicmVha1xuXG5UZXN0IHlvdXIgY2hhbmdlcyB3aXRoIGBtYW4gLi9naXQtbHMuMWAgYmVmb3JlIGNvbW1pdHRpbmcuXG4iLCJwYXRoIjoibWFucGFnZS9SRUFETUUubWQifX1dLCJhcGkiOiJiZWRyb2NrLWNvbnZlcnNlLXN0cmVhbSIsInByb3ZpZGVyIjoic29ubmV0LWJlZHJvY2siLCJtb2RlbCI6ImFybjphd3M6YmVkcm9jazp1cy1lYXN0LTE6Njg2MTUwNjgyOTY3OmFwcGxpY2F0aW9uLWluZmVyZW5jZS1wcm9maWxlLzVzaXowNHhscXE5ZyIsInVzYWdlIjp7ImlucHV0IjoxMjE4OSwib3V0cHV0Ijo0NDgsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWxUb2tlbnMiOjEyNjM3LCJjb3N0Ijp7ImlucHV0IjowLCJvdXRwdXQiOjAsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWwiOjB9fSwic3RvcFJlYXNvbiI6InRvb2xVc2UiLCJ0aW1lc3RhbXAiOjE3NzU2MTA0OTIzNjN9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiI2NjhkY2UyNyIsInBhcmVudElkIjoiY2JhMzgxNTgiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjA4OjI1LjMzOFoiLCJtZXNzYWdlIjp7InJvbGUiOiJ0b29sUmVzdWx0IiwidG9vbENhbGxJZCI6InRvb2x1c2Vfd29xVDRyT0JvT0NUZm9kb0NwR1IwUiIsInRvb2xOYW1lIjoid3JpdGUiLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiJTdWNjZXNzZnVsbHkgd3JvdGUgMTEzMCBieXRlcyB0byBtYW5wYWdlL1JFQURNRS5tZCJ9XSwiaXNFcnJvciI6ZmFsc2UsInRpbWVzdGFtcCI6MTc3NTYxMDUwNTMzNn19LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6IjAxMzNjMTdjIiwicGFyZW50SWQiOiI2NjhkY2UyNyIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDg6MjkuMTI0WiIsIm1lc3NhZ2UiOnsicm9sZSI6ImFzc2lzdGFudCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0b29sQ2FsbCIsImlkIjoidG9vbHVzZV96bGZER3A2RnpYcllSaUEzTDE0RTZRIiwibmFtZSI6ImJhc2giLCJhcmd1bWVudHMiOnsiY29tbWFuZCI6Im12IGdpdC1scy4xIG1hbnBhZ2UvIn19XSwiYXBpIjoiYmVkcm9jay1jb252ZXJzZS1zdHJlYW0iLCJwcm92aWRlciI6InNvbm5ldC1iZWRyb2NrIiwibW9kZWwiOiJhcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY4NjE1MDY4Mjk2NzphcHBsaWNhdGlvbi1pbmZlcmVuY2UtcHJvZmlsZS81c2l6MDR4bHFxOWciLCJ1c2FnZSI6eyJpbnB1dCI6MTI2NjMsIm91dHB1dCI6NjAsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWxUb2tlbnMiOjEyNzIzLCJjb3N0Ijp7ImlucHV0IjowLCJvdXRwdXQiOjAsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWwiOjB9fSwic3RvcFJlYXNvbiI6InRvb2xVc2UiLCJ0aW1lc3RhbXAiOjE3NzU2MTA1MDUzMzl9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiI5MzA5ZGE2MyIsInBhcmVudElkIjoiMDEzM2MxN2MiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjA4OjI5LjE1N1oiLCJtZXNzYWdlIjp7InJvbGUiOiJ0b29sUmVzdWx0IiwidG9vbENhbGxJZCI6InRvb2x1c2VfemxmREdwNkZ6WHJZUmlBM0wxNEU2USIsInRvb2xOYW1lIjoiYmFzaCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6IihubyBvdXRwdXQpIn1dLCJpc0Vycm9yIjpmYWxzZSwidGltZXN0YW1wIjoxNzc1NjEwNTA5MTU3fX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiODcxZWIzODUiLCJwYXJlbnRJZCI6IjkzMDlkYTYzIiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowODozMy45NTdaIiwibWVzc2FnZSI6eyJyb2xlIjoiYXNzaXN0YW50IiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoiTm93IHVwZGF0ZSB0aGUgcGF0aHMgaW4gdGhlIGNvbmZpZyBmaWxlczoifSx7InR5cGUiOiJ0b29sQ2FsbCIsImlkIjoidG9vbHVzZV9iUk1NTTk3UWUzZGNBaE9QaDR2UDduIiwibmFtZSI6ImVkaXQiLCJhcmd1bWVudHMiOnsiZWRpdHMiOlt7Im5ld1RleHQiOiIgICAgZmlsZXM6XG4gICAgICAtIG1hbnBhZ2UvZ2l0LWxzLjEiLCJvbGRUZXh0IjoiICAgIGZpbGVzOlxuICAgICAgLSBnaXQtbHMuMSJ9LHsibmV3VGV4dCI6IiAgICBpbnN0YWxsOiB8XG4gICAgICBiaW4uaW5zdGFsbCBcImdpdC1sc1wiXG4gICAgICBtYW4xLmluc3RhbGwgXCJtYW5wYWdlL2dpdC1scy4xXCIiLCJvbGRUZXh0IjoiICAgIGluc3RhbGw6IHxcbiAgICAgIGJpbi5pbnN0YWxsIFwiZ2l0LWxzXCJcbiAgICAgIG1hbjEuaW5zdGFsbCBcImdpdC1scy4xXCIifV0sInBhdGgiOiIuZ29yZWxlYXNlci55YW1sIn19XSwiYXBpIjoiYmVkcm9jay1jb252ZXJzZS1zdHJlYW0iLCJwcm92aWRlciI6InNvbm5ldC1iZWRyb2NrIiwibW9kZWwiOiJhcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY4NjE1MDY4Mjk2NzphcHBsaWNhdGlvbi1pbmZlcmVuY2UtcHJvZmlsZS81c2l6MDR4bHFxOWciLCJ1c2FnZSI6eyJpbnB1dCI6MTI3MzcsIm91dHB1dCI6MTk2LCJjYWNoZVJlYWQiOjAsImNhY2hlV3JpdGUiOjAsInRvdGFsVG9rZW5zIjoxMjkzMywiY29zdCI6eyJpbnB1dCI6MCwib3V0cHV0IjowLCJjYWNoZVJlYWQiOjAsImNhY2hlV3JpdGUiOjAsInRvdGFsIjowfX0sInN0b3BSZWFzb24iOiJ0b29sVXNlIiwidGltZXN0YW1wIjoxNzc1NjEwNTA5MTU4fX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiOTc1ZjVlNjQiLCJwYXJlbnRJZCI6Ijg3MWViMzg1IiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowODozMy45NjNaIiwibWVzc2FnZSI6eyJyb2xlIjoidG9vbFJlc3VsdCIsInRvb2xDYWxsSWQiOiJ0b29sdXNlX2JSTU1NOTdRZTNkY0FoT1BoNHZQN24iLCJ0b29sTmFtZSI6ImVkaXQiLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiJTdWNjZXNzZnVsbHkgcmVwbGFjZWQgMiBibG9jayhzKSBpbiAuZ29yZWxlYXNlci55YW1sLiJ9XSwiZGV0YWlscyI6eyJkaWZmIjoiICAgIC4uLlxuIDM2ICAgICBmb3JtYXRfb3ZlcnJpZGVzOlxuIDM3ICAgICAgIC0gZ29vczogd2luZG93c1xuIDM4ICAgICAgICAgZm9ybWF0czogW1wiemlwXCJdXG4gMzkgICAgIGZpbGVzOlxuLTQwICAgICAgIC0gZ2l0LWxzLjFcbis0MCAgICAgICAtIG1hbnBhZ2UvZ2l0LWxzLjFcbiA0MSBcbiA0MiBjaGFuZ2Vsb2c6XG4gNDMgICBzb3J0OiBhc2NcbiA0NCAgIGZpbHRlcnM6XG4gICAgLi4uXG4gNTYgICAgICAgbmFtZTogaG9tZWJyZXctZ2l0LWxzXG4gNTcgICAgICAgYnJhbmNoOiBtYWluXG4gNTggICAgIGluc3RhbGw6IHxcbiA1OSAgICAgICBiaW4uaW5zdGFsbCBcImdpdC1sc1wiXG4tNjAgICAgICAgbWFuMS5pbnN0YWxsIFwiZ2l0LWxzLjFcIlxuKzYwICAgICAgIG1hbjEuaW5zdGFsbCBcIm1hbnBhZ2UvZ2l0LWxzLjFcIiIsImZpcnN0Q2hhbmdlZExpbmUiOjQwfSwiaXNFcnJvciI6ZmFsc2UsInRpbWVzdGFtcCI6MTc3NTYxMDUxMzk2Mn19LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6IjcyYjA0YTFjIiwicGFyZW50SWQiOiI5NzVmNWU2NCIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDg6MzguNjQyWiIsIm1lc3NhZ2UiOnsicm9sZSI6ImFzc2lzdGFudCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0b29sQ2FsbCIsImlkIjoidG9vbHVzZV9mVE90YllYYU5RYW9BQURjVThJS2VFIiwibmFtZSI6ImVkaXQiLCJhcmd1bWVudHMiOnsiZWRpdHMiOlt7Im5ld1RleHQiOiIuUEhPTlk6IGFsbFxuYWxsOiBnaXQtbHMgbWFucGFnZS9naXQtbHMuMSIsIm9sZFRleHQiOiIuUEhPTlk6IGFsbFxuYWxsOiBnaXQtbHMgZ2l0LWxzLjEifSx7Im5ld1RleHQiOiJnaXQtbHM6ICQoU1JDKVxuXHRnbyBidWlsZFxuXG4uUEhPTlk6IG1hbnBhZ2UvZ2l0LWxzLjFcbm1hbnBhZ2UvZ2l0LWxzLjE6XG5cdEAjIE1hbiBwYWdlIGlzIGFscmVhZHkgZ2VuZXJhdGVkLCBqdXN0IHZlcmlmeSBpdCBleGlzdHNcblx0QHRlc3QgLWYgbWFucGFnZS9naXQtbHMuMSB8fCAoZWNobyBcIkVycm9yOiBtYW5wYWdlL2dpdC1scy4xIG5vdCBmb3VuZFwiICYmIGV4aXQgMSkiLCJvbGRUZXh0IjoiZ2l0LWxzOiAkKFNSQylcblx0Z28gYnVpbGRcblxuLlBIT05ZOiBnaXQtbHMuMVxuZ2l0LWxzLjE6XG5cdEAjIE1hbiBwYWdlIGlzIGFscmVhZHkgZ2VuZXJhdGVkLCBqdXN0IHZlcmlmeSBpdCBleGlzdHNcblx0QHRlc3QgLWYgZ2l0LWxzLjEgfHwgKGVjaG8gXCJFcnJvcjogZ2l0LWxzLjEgbm90IGZvdW5kXCIgJiYgZXhpdCAxKSJ9XSwicGF0aCI6Ik1ha2VmaWxlIn19XSwiYXBpIjoiYmVkcm9jay1jb252ZXJzZS1zdHJlYW0iLCJwcm92aWRlciI6InNvbm5ldC1iZWRyb2NrIiwibW9kZWwiOiJhcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY4NjE1MDY4Mjk2NzphcHBsaWNhdGlvbi1pbmZlcmVuY2UtcHJvZmlsZS81c2l6MDR4bHFxOWciLCJ1c2FnZSI6eyJpbnB1dCI6MTI5NjEsIm91dHB1dCI6MzEzLCJjYWNoZVJlYWQiOjAsImNhY2hlV3JpdGUiOjAsInRvdGFsVG9rZW5zIjoxMzI3NCwiY29zdCI6eyJpbnB1dCI6MCwib3V0cHV0IjowLCJjYWNoZVJlYWQiOjAsImNhY2hlV3JpdGUiOjAsInRvdGFsIjowfX0sInN0b3BSZWFzb24iOiJ0b29sVXNlIiwidGltZXN0YW1wIjoxNzc1NjEwNTEzOTYzfX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiZjQxODkwZDUiLCJwYXJlbnRJZCI6IjcyYjA0YTFjIiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowODozOC42NTBaIiwibWVzc2FnZSI6eyJyb2xlIjoidG9vbFJlc3VsdCIsInRvb2xDYWxsSWQiOiJ0b29sdXNlX2ZUT3RiWVhhTlFhb0FBRGNVOElLZUUiLCJ0b29sTmFtZSI6ImVkaXQiLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiJTdWNjZXNzZnVsbHkgcmVwbGFjZWQgMiBibG9jayhzKSBpbiBNYWtlZmlsZS4ifV0sImRldGFpbHMiOnsiZGlmZiI6IiAgICAuLi5cbiAgMiBUUkFOU0NSSVBUUyA6PSAkKHdpbGRjYXJkIHRyYW5zY3JpcHRzLyopXG4gIDMgU1RBVElDIDo9ICQod2lsZGNhcmQgc3RhdGljLyopXG4gIDQgXG4gIDUgLlBIT05ZOiBhbGxcbi0gNiBhbGw6IGdpdC1scyBnaXQtbHMuMVxuKyA2IGFsbDogZ2l0LWxzIG1hbnBhZ2UvZ2l0LWxzLjFcbiAgNyBcbiAgOCBnaXQtbHM6ICQoU1JDKVxuICA5IFx0Z28gYnVpbGRcbiAxMCBcbi0xMSAuUEhPTlk6IGdpdC1scy4xXG4tMTIgZ2l0LWxzLjE6XG4rMTEgLlBIT05ZOiBtYW5wYWdlL2dpdC1scy4xXG4rMTIgbWFucGFnZS9naXQtbHMuMTpcbiAxMyBcdEAjIE1hbiBwYWdlIGlzIGFscmVhZHkgZ2VuZXJhdGVkLCBqdXN0IHZlcmlmeSBpdCBleGlzdHNcbi0xNCBcdEB0ZXN0IC1mIGdpdC1scy4xIHx8IChlY2hvIFwiRXJyb3I6IGdpdC1scy4xIG5vdCBmb3VuZFwiICYmIGV4aXQgMSlcbisxNCBcdEB0ZXN0IC1mIG1hbnBhZ2UvZ2l0LWxzLjEgfHwgKGVjaG8gXCJFcnJvcjogbWFucGFnZS9naXQtbHMuMSBub3QgZm91bmRcIiAmJiBleGl0IDEpXG4gMTUgXG4gMTYgIyBkZXBlbmRzIG9uIGdvbGFuZ2NpLWxpbnQ6XG4gMTcgIyBodHRwczovL2dvbGFuZ2NpLWxpbnQucnVuL3dlbGNvbWUvaW5zdGFsbC8jbG9jYWwtaW5zdGFsbGF0aW9uXG4gMTggLlBIT05ZOiBsaW50XG4gICAgLi4uIiwiZmlyc3RDaGFuZ2VkTGluZSI6Nn0sImlzRXJyb3IiOmZhbHNlLCJ0aW1lc3RhbXAiOjE3NzU2MTA1MTg2NTB9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiJiYWY0MjI1NiIsInBhcmVudElkIjoiZjQxODkwZDUiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjA4OjQyLjczN1oiLCJtZXNzYWdlIjp7InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiJUZXN0IHRoYXQgZXZlcnl0aGluZyBzdGlsbCB3b3JrczoifSx7InR5cGUiOiJ0b29sQ2FsbCIsImlkIjoidG9vbHVzZV80MXVLOXk2NkNhcVNHWDd5dWRLQUU5IiwibmFtZSI6ImJhc2giLCJhcmd1bWVudHMiOnsiY29tbWFuZCI6Im1ha2UifX0seyJ0eXBlIjoidG9vbENhbGwiLCJpZCI6InRvb2x1c2VfUFIyNDVNZGM2ZFl0ZFZTSEZiRGYybCIsIm5hbWUiOiJiYXNoIiwiYXJndW1lbnRzIjp7ImNvbW1hbmQiOiJtYW4gLi9tYW5wYWdlL2dpdC1scy4xIHwgaGVhZCAtMjAifX1dLCJhcGkiOiJiZWRyb2NrLWNvbnZlcnNlLXN0cmVhbSIsInByb3ZpZGVyIjoic29ubmV0LWJlZHJvY2siLCJtb2RlbCI6ImFybjphd3M6YmVkcm9jazp1cy1lYXN0LTE6Njg2MTUwNjgyOTY3OmFwcGxpY2F0aW9uLWluZmVyZW5jZS1wcm9maWxlLzVzaXowNHhscXE5ZyIsInVzYWdlIjp7ImlucHV0IjoxMzI5OSwib3V0cHV0IjoxMDYsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWxUb2tlbnMiOjEzNDA1LCJjb3N0Ijp7ImlucHV0IjowLCJvdXRwdXQiOjAsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWwiOjB9fSwic3RvcFJlYXNvbiI6InRvb2xVc2UiLCJ0aW1lc3RhbXAiOjE3NzU2MTA1MTg2NTF9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiI5MDc3YzdjNiIsInBhcmVudElkIjoiYmFmNDIyNTYiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjA4OjQyLjgwM1oiLCJtZXNzYWdlIjp7InJvbGUiOiJ0b29sUmVzdWx0IiwidG9vbENhbGxJZCI6InRvb2x1c2VfNDF1Szl5NjZDYXFTR1g3eXVkS0FFOSIsInRvb2xOYW1lIjoiYmFzaCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6IihubyBvdXRwdXQpIn1dLCJpc0Vycm9yIjpmYWxzZSwidGltZXN0YW1wIjoxNzc1NjEwNTIyODAzfX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiM2I1YmZjN2YiLCJwYXJlbnRJZCI6IjkwNzdjN2M2IiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowODo0Mi45ODdaIiwibWVzc2FnZSI6eyJyb2xlIjoidG9vbFJlc3VsdCIsInRvb2xDYWxsSWQiOiJ0b29sdXNlX1BSMjQ1TWRjNmRZdGRWU0hGYkRmMmwiLCJ0b29sTmFtZSI6ImJhc2giLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiJHSVQtTFMoMSkgICAgICAgICAgICAgICAgICAgICAgICBVc2VyIENvbW1hbmRzICAgICAgICAgICAgICAgICAgICAgICBHSVQtTFMoMSlcblxuTkFNRVxuICAgICAgIGdpdC1scyAtIHNob3cgdGhlIGN1cnJlbnQgZGlyZWN0b3J5IGFubm90YXRlZCB3aXRoIGxpbmtzIGFuZCBnaXQgaW5mb1xuXG5TWU5PUFNJU1xuICAgICAgIGdpdCBscyBbPGRpcj5dXG5cbkRFU0NSSVBUSU9OXG4gICAgICAgZ2l0LWxzIGRpc3BsYXlzIHRoZSBmaWxlcyBpbiB0aGUgY3VycmVudCBkaXJlY3RvcnksIHRoZWlyIGN1cnJlbnQgZ2l0XG4gICAgICAgc3RhdHVzLCBhIHNob3J0IGRpZmZzdGF0LCB0aGVpciBsYXN0IG1vZGlmaWVkIGRhdGUsIHRoZSBhdXRob3IgYW5kIGFcbiAgICAgICBwb3J0aW9uIG9mIHRoZSBsYXN0IGNvbW1pdCBtZXNzYWdlIGZvciB0aGF0IGZpbGUuXG5cbiAgICAgICBBbGwgZmlsZXMgYXJlIGh5cGVybGlua2VkIHdpdGggT1NDOCBoeXBlcmxpbmtzLCBzbyB5b3Ugc2hvdWxkIGJlIGFibGVcbiAgICAgICB0byBvcGVuIHRoZW0gYnkgY2xpY2tpbmcgb24gdGhlbSBpbiBhIHByb3Blcmx5LWNvbmZpZ3VyZWQgdGVybWluYWwuIFRoZVxuICAgICAgIGF1dGhvciBuYW1lcyBhcmUgaHlwZXJsaW5rZWQgdG8gR2l0SHViIGlmIHRoZSByZXBvc2l0b3J5IGhhcyBhIEdpdEh1YlxuICAgICAgIHJlbW90ZSwgYXMgYXJlIGNvbW1pdCBtZXNzYWdlcy5cblxuT1BUSU9OU1xuICAgICAgIC0tdmVyc2lvblxuIn1dLCJpc0Vycm9yIjpmYWxzZSwidGltZXN0YW1wIjoxNzc1NjEwNTIyOTg3fX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiYjMwNjM0YzQiLCJwYXJlbnRJZCI6IjNiNWJmYzdmIiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTowODo0Ni43NjZaIiwibWVzc2FnZSI6eyJyb2xlIjoiYXNzaXN0YW50IiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoiUGVyZmVjdCEgTGV0J3MgdXBkYXRlIHRoZSBsb2NhbCBtYW4gcGFnZSBpbnN0YWxsYXRpb24gYW5kIHZlcmlmeSBgZ2l0IGxzIC0taGVscGAgc3RpbGwgd29ya3M6In0seyJ0eXBlIjoidG9vbENhbGwiLCJpZCI6InRvb2x1c2VfQlJxeDduSlNOcFY0cGtPVzNSbWdHbCIsIm5hbWUiOiJiYXNoIiwiYXJndW1lbnRzIjp7ImNvbW1hbmQiOiJjcCBtYW5wYWdlL2dpdC1scy4xIH4vLmxvY2FsL3NoYXJlL21hbi9tYW4xLyAmJiBnaXQgbHMgLS1oZWxwIDI+JjEgfCBoZWFkIC0yMCJ9fV0sImFwaSI6ImJlZHJvY2stY29udmVyc2Utc3RyZWFtIiwicHJvdmlkZXIiOiJzb25uZXQtYmVkcm9jayIsIm1vZGVsIjoiYXJuOmF3czpiZWRyb2NrOnVzLWVhc3QtMTo2ODYxNTA2ODI5Njc6YXBwbGljYXRpb24taW5mZXJlbmNlLXByb2ZpbGUvNXNpejA0eGxxcTlnIiwidXNhZ2UiOnsiaW5wdXQiOjEzNjM4LCJvdXRwdXQiOjEwNiwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbFRva2VucyI6MTM3NDQsImNvc3QiOnsiaW5wdXQiOjAsIm91dHB1dCI6MCwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbCI6MH19LCJzdG9wUmVhc29uIjoidG9vbFVzZSIsInRpbWVzdGFtcCI6MTc3NTYxMDUyMjk4OH19LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6ImU3MDAyODY4IiwicGFyZW50SWQiOiJiMzA2MzRjNCIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDg6NDYuOTQ0WiIsIm1lc3NhZ2UiOnsicm9sZSI6InRvb2xSZXN1bHQiLCJ0b29sQ2FsbElkIjoidG9vbHVzZV9CUnF4N25KU05wVjRwa09XM1JtZ0dsIiwidG9vbE5hbWUiOiJiYXNoIiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoiR0lULUxTKDEpICAgICAgICAgICAgICAgICAgICAgICAgVXNlciBDb21tYW5kcyAgICAgICAgICAgICAgICAgICAgICAgR0lULUxTKDEpXG5cbk5BTUVcbiAgICAgICBnaXQtbHMgLSBzaG93IHRoZSBjdXJyZW50IGRpcmVjdG9yeSBhbm5vdGF0ZWQgd2l0aCBsaW5rcyBhbmQgZ2l0IGluZm9cblxuU1lOT1BTSVNcbiAgICAgICBnaXQgbHMgWzxkaXI+XVxuXG5ERVNDUklQVElPTlxuICAgICAgIGdpdC1scyBkaXNwbGF5cyB0aGUgZmlsZXMgaW4gdGhlIGN1cnJlbnQgZGlyZWN0b3J5LCB0aGVpciBjdXJyZW50IGdpdFxuICAgICAgIHN0YXR1cywgYSBzaG9ydCBkaWZmc3RhdCwgdGhlaXIgbGFzdCBtb2RpZmllZCBkYXRlLCB0aGUgYXV0aG9yIGFuZCBhXG4gICAgICAgcG9ydGlvbiBvZiB0aGUgbGFzdCBjb21taXQgbWVzc2FnZSBmb3IgdGhhdCBmaWxlLlxuXG4gICAgICAgQWxsIGZpbGVzIGFyZSBoeXBlcmxpbmtlZCB3aXRoIE9TQzggaHlwZXJsaW5rcywgc28geW91IHNob3VsZCBiZSBhYmxlXG4gICAgICAgdG8gb3BlbiB0aGVtIGJ5IGNsaWNraW5nIG9uIHRoZW0gaW4gYSBwcm9wZXJseS1jb25maWd1cmVkIHRlcm1pbmFsLiBUaGVcbiAgICAgICBhdXRob3IgbmFtZXMgYXJlIGh5cGVybGlua2VkIHRvIEdpdEh1YiBpZiB0aGUgcmVwb3NpdG9yeSBoYXMgYSBHaXRIdWJcbiAgICAgICByZW1vdGUsIGFzIGFyZSBjb21taXQgbWVzc2FnZXMuXG5cbk9QVElPTlNcbiAgICAgICAtLXZlcnNpb25cbiJ9XSwiaXNFcnJvciI6ZmFsc2UsInRpbWVzdGFtcCI6MTc3NTYxMDUyNjk0NH19LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6IjAzOGNlZWJiIiwicGFyZW50SWQiOiJlNzAwMjg2OCIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDg6NDkuODg1WiIsIm1lc3NhZ2UiOnsicm9sZSI6ImFzc2lzdGFudCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6IkV4Y2VsbGVudCEgTGV0J3MgcnVuIGxpbnQgb25lIG1vcmUgdGltZSB0byBtYWtlIHN1cmUgZXZlcnl0aGluZyBpcyBnb29kOiJ9LHsidHlwZSI6InRvb2xDYWxsIiwiaWQiOiJ0b29sdXNlX2FiRXJHM25rWFVESkpnRVgwb2xSeU0iLCJuYW1lIjoiYmFzaCIsImFyZ3VtZW50cyI6eyJjb21tYW5kIjoibWFrZSBsaW50In19XSwiYXBpIjoiYmVkcm9jay1jb252ZXJzZS1zdHJlYW0iLCJwcm92aWRlciI6InNvbm5ldC1iZWRyb2NrIiwibW9kZWwiOiJhcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY4NjE1MDY4Mjk2NzphcHBsaWNhdGlvbi1pbmZlcmVuY2UtcHJvZmlsZS81c2l6MDR4bHFxOWciLCJ1c2FnZSI6eyJpbnB1dCI6MTM5MjgsIm91dHB1dCI6NzAsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWxUb2tlbnMiOjEzOTk4LCJjb3N0Ijp7ImlucHV0IjowLCJvdXRwdXQiOjAsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWwiOjB9fSwic3RvcFJlYXNvbiI6InRvb2xVc2UiLCJ0aW1lc3RhbXAiOjE3NzU2MTA1MjY5NDV9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiJkMGNjNTUyNyIsInBhcmVudElkIjoiMDM4Y2VlYmIiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjA4OjUxLjMxNVoiLCJtZXNzYWdlIjp7InJvbGUiOiJ0b29sUmVzdWx0IiwidG9vbENhbGxJZCI6InRvb2x1c2VfYWJFckczbmtYVURKSmdFWDBvbFJ5TSIsInRvb2xOYW1lIjoiYmFzaCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6ImdvbGFuZ2NpLWxpbnQgcnVuXG4wIGlzc3Vlcy5cbiJ9XSwiaXNFcnJvciI6ZmFsc2UsInRpbWVzdGFtcCI6MTc3NTYxMDUzMTMxNX19LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6ImVjMmJkMzY4IiwicGFyZW50SWQiOiJkMGNjNTUyNyIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6MDk6MDEuMDg3WiIsIm1lc3NhZ2UiOnsicm9sZSI6ImFzc2lzdGFudCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6IlBlcmZlY3QhIExldCBtZSBjcmVhdGUgYSBzdW1tYXJ5IG9mIHdoYXQgd2FzIGRvbmU6XG5cbiMjIFN1bW1hcnlcblxu4pyFICoqQ3JlYXRlZCBhIG1hbiBwYWdlIGZvciBnaXQtbHMhKipcblxuIyMjIFdoYXQgd2FzIGRvbmU6XG5cbjEuICoqQ3JlYXRlZCBgbWFucGFnZS9naXQtbHMuMWAqKiAtIEEgcHJvcGVyIHJvZmYgZm9ybWF0IG1hbiBwYWdlIHdpdGggYWxsIHRoZSBvcHRpb25zLCBleGFtcGxlcywgYW5kIGRvY3VtZW50YXRpb25cblxuMi4gKipVcGRhdGVkIGAuZ29yZWxlYXNlci55YW1sYCoqOlxuICAgLSBBZGRlZCB0aGUgbWFuIHBhZ2UgdG8gcmVsZWFzZSBhcmNoaXZlc1xuICAgLSBBZGRlZCBgbWFuMS5pbnN0YWxsIFwibWFucGFnZS9naXQtbHMuMVwiYCB0byB0aGUgSG9tZWJyZXcgZm9ybXVsYSBzbyBpdCBnZXRzIGluc3RhbGxlZCB0byBgL29wdC9ob21lYnJldy9zaGFyZS9tYW4vbWFuMS9gXG5cbjMuICoqVXBkYXRlZCBgTWFrZWZpbGVgKio6XG4gICAtIEFkZGVkIGBtYW5wYWdlL2dpdC1scy4xYCBhcyBhIGJ1aWxkIHRhcmdldCAoaXQganVzdCB2ZXJpZmllcyB0aGUgZmlsZSBleGlzdHMpXG5cbjQuICoqQ3JlYXRlZCBgbWFucGFnZS9SRUFETUUubWRgKiogLSBEb2N1bWVudGF0aW9uIG9uIGhvdyB0aGUgbWFuIHBhZ2Ugd29ya3MgYW5kIGhvdyB0byB1cGRhdGUgaXRcblxuIyMjIEhvdyBpdCB3b3JrczpcblxuLSAqKkxvY2FsbHkqKjogV2hlbiB1c2VycyBpbnN0YWxsIHZpYSBIb21lYnJldywgdGhlIG1hbiBwYWdlIGlzIGF1dG9tYXRpY2FsbHkgaW5zdGFsbGVkXG4tICoqYGdpdCBscyAtLWhlbHBgKio6IEdpdCBhdXRvbWF0aWNhbGx5IGxvb2tzIGZvciBhIG1hbiBwYWdlIG5hbWVkIGBnaXQtbHNgIGFuZCBkaXNwbGF5cyBpdFxuLSAqKk1hbnVhbCB0ZXN0aW5nKio6IFlvdSBjYW4gcnVuIGBtYW4gLi9tYW5wYWdlL2dpdC1scy4xYCB0byBwcmV2aWV3IGNoYW5nZXNcblxuIyMjIE5leHQgcmVsZWFzZTpcblxuV2hlbiB5b3UgcnVuIHlvdXIgbmV4dCBgbWFrZSBwdWJsaXNoYCAod2hpY2ggY2FsbHMgZ29yZWxlYXNlciksIHRoZSBtYW4gcGFnZSB3aWxsIGJlOlxuMS4gSW5jbHVkZWQgaW4gYWxsIHJlbGVhc2UgdGFyYmFsbHNcbjIuIEF1dG9tYXRpY2FsbHkgaW5zdGFsbGVkIGJ5IEhvbWVicmV3IHRvIHRoZSBwcm9wZXIgbG9jYXRpb25cbjMuIEFjY2Vzc2libGUgdmlhIGBnaXQgbHMgLS1oZWxwYCBvciBgbWFuIGdpdC1sc2BcblxuVGhlIHJvZmYgZm9ybWF0IGlzbid0IHJvY2tldCBzY2llbmNlIGFmdGVyIGFsbCAtIGp1c3QgYSBmZXcgbWFjcm9zIGxpa2UgYC5TSGAgZm9yIHNlY3Rpb25zLCBgLlRQYCBmb3Igb3B0aW9ucywgYW5kIGAuQmAvYC5JYCBmb3IgZm9ybWF0dGluZyEg8J+agCJ9XSwiYXBpIjoiYmVkcm9jay1jb252ZXJzZS1zdHJlYW0iLCJwcm92aWRlciI6InNvbm5ldC1iZWRyb2NrIiwibW9kZWwiOiJhcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY4NjE1MDY4Mjk2NzphcHBsaWNhdGlvbi1pbmZlcmVuY2UtcHJvZmlsZS81c2l6MDR4bHFxOWciLCJ1c2FnZSI6eyJpbnB1dCI6MTQwMjIsIm91dHB1dCI6NDAyLCJjYWNoZVJlYWQiOjAsImNhY2hlV3JpdGUiOjAsInRvdGFsVG9rZW5zIjoxNDQyNCwiY29zdCI6eyJpbnB1dCI6MCwib3V0cHV0IjowLCJjYWNoZVJlYWQiOjAsImNhY2hlV3JpdGUiOjAsInRvdGFsIjowfX0sInN0b3BSZWFzb24iOiJzdG9wIiwidGltZXN0YW1wIjoxNzc1NjEwNTMxMzE2fX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiNjQ0NWM3ZWIiLCJwYXJlbnRJZCI6ImVjMmJkMzY4IiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTo0NDo0NS45ODdaIiwibWVzc2FnZSI6eyJyb2xlIjoidXNlciIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6ImdyZWF0LiBmaWxlIGEgUFIgd2l0aCBhIHRyYW5zY3JpcHQgaW5jbHVkaW5nIHRoZSBwciBudW1iZXIifV0sInRpbWVzdGFtcCI6MTc3NTYxMjY4NTk4Nn19LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6ImIyZmZiNzM1IiwicGFyZW50SWQiOiI2NDQ1YzdlYiIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6NDQ6NTAuNTY4WiIsIm1lc3NhZ2UiOnsicm9sZSI6ImFzc2lzdGFudCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0b29sQ2FsbCIsImlkIjoidG9vbHVzZV83YTFQdW42bkxHc2tEaHg1ZlZaMGZtIiwibmFtZSI6ImJhc2giLCJhcmd1bWVudHMiOnsiY29tbWFuZCI6ImNkIC9Vc2Vycy9sbGltbGxpYi9jb2RlL2dpdC1scyAmJiBnaXQgc3RhdHVzIn19XSwiYXBpIjoiYmVkcm9jay1jb252ZXJzZS1zdHJlYW0iLCJwcm92aWRlciI6InNvbm5ldC1iZWRyb2NrIiwibW9kZWwiOiJhcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY4NjE1MDY4Mjk2NzphcHBsaWNhdGlvbi1pbmZlcmVuY2UtcHJvZmlsZS81c2l6MDR4bHFxOWciLCJ1c2FnZSI6eyJpbnB1dCI6MTQ0MzksIm91dHB1dCI6NjYsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWxUb2tlbnMiOjE0NTA1LCJjb3N0Ijp7ImlucHV0IjowLCJvdXRwdXQiOjAsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWwiOjB9fSwic3RvcFJlYXNvbiI6InRvb2xVc2UiLCJ0aW1lc3RhbXAiOjE3NzU2MTI2ODU5OTB9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiIxODg2N2I3YyIsInBhcmVudElkIjoiYjJmZmI3MzUiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjQ0OjUwLjU5MFoiLCJtZXNzYWdlIjp7InJvbGUiOiJ0b29sUmVzdWx0IiwidG9vbENhbGxJZCI6InRvb2x1c2VfN2ExUHVuNm5MR3NrRGh4NWZWWjBmbSIsInRvb2xOYW1lIjoiYmFzaCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6ImZhdGFsOiBub3QgYSBnaXQgcmVwb3NpdG9yeSAob3IgYW55IG9mIHRoZSBwYXJlbnQgZGlyZWN0b3JpZXMpOiAuZ2l0XG5cblxuQ29tbWFuZCBleGl0ZWQgd2l0aCBjb2RlIDEyOCJ9XSwiZGV0YWlscyI6e30sImlzRXJyb3IiOnRydWUsInRpbWVzdGFtcCI6MTc3NTYxMjY5MDU5MH19LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6IjE0ZmNmMDE4IiwicGFyZW50SWQiOiIxODg2N2I3YyIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6NDQ6NTQuNjM3WiIsIm1lc3NhZ2UiOnsicm9sZSI6ImFzc2lzdGFudCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0b29sQ2FsbCIsImlkIjoidG9vbHVzZV8yN3NqeUNJVElKbE9uMUwybHBQSnE2IiwibmFtZSI6ImJhc2giLCJhcmd1bWVudHMiOnsiY29tbWFuZCI6ImxzIC1sYSAuZ2l0In19XSwiYXBpIjoiYmVkcm9jay1jb252ZXJzZS1zdHJlYW0iLCJwcm92aWRlciI6InNvbm5ldC1iZWRyb2NrIiwibW9kZWwiOiJhcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY4NjE1MDY4Mjk2NzphcHBsaWNhdGlvbi1pbmZlcmVuY2UtcHJvZmlsZS81c2l6MDR4bHFxOWciLCJ1c2FnZSI6eyJpbnB1dCI6MTQ1NTAsIm91dHB1dCI6NTUsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWxUb2tlbnMiOjE0NjA1LCJjb3N0Ijp7ImlucHV0IjowLCJvdXRwdXQiOjAsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWwiOjB9fSwic3RvcFJlYXNvbiI6InRvb2xVc2UiLCJ0aW1lc3RhbXAiOjE3NzU2MTI2OTA1OTB9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiI2OTAyNWY3OCIsInBhcmVudElkIjoiMTRmY2YwMTgiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjQ0OjU0LjY3NFoiLCJtZXNzYWdlIjp7InJvbGUiOiJ0b29sUmVzdWx0IiwidG9vbENhbGxJZCI6InRvb2x1c2VfMjdzanlDSVRJSmxPbjFMMmxwUEpxNiIsInRvb2xOYW1lIjoiYmFzaCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6Ii1ydy1yLS1yLS1AIDEgbGxpbWxsaWIgIHN0YWZmICA2NCBBcHIgIDcgMjE6MDIgLmdpdFxuIn1dLCJpc0Vycm9yIjpmYWxzZSwidGltZXN0YW1wIjoxNzc1NjEyNjk0Njc0fX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiZmYyNjRlMDMiLCJwYXJlbnRJZCI6IjY5MDI1Zjc4IiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTo0NDo1OC42MzJaIiwibWVzc2FnZSI6eyJyb2xlIjoiYXNzaXN0YW50IiwiY29udGVudCI6W3sidHlwZSI6InRvb2xDYWxsIiwiaWQiOiJ0b29sdXNlX0dWQ2NnQ0tBeE5BZ3NkVkROTGg2cEkiLCJuYW1lIjoiYmFzaCIsImFyZ3VtZW50cyI6eyJjb21tYW5kIjoiY2F0IC5naXQifX1dLCJhcGkiOiJiZWRyb2NrLWNvbnZlcnNlLXN0cmVhbSIsInByb3ZpZGVyIjoic29ubmV0LWJlZHJvY2siLCJtb2RlbCI6ImFybjphd3M6YmVkcm9jazp1cy1lYXN0LTE6Njg2MTUwNjgyOTY3OmFwcGxpY2F0aW9uLWluZmVyZW5jZS1wcm9maWxlLzVzaXowNHhscXE5ZyIsInVzYWdlIjp7ImlucHV0IjoxNDY0OCwib3V0cHV0Ijo1MywiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbFRva2VucyI6MTQ3MDEsImNvc3QiOnsiaW5wdXQiOjAsIm91dHB1dCI6MCwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbCI6MH19LCJzdG9wUmVhc29uIjoidG9vbFVzZSIsInRpbWVzdGFtcCI6MTc3NTYxMjY5NDY3NX19LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6IjY1YzQ2NjM3IiwicGFyZW50SWQiOiJmZjI2NGUwMyIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6NDQ6NTguNjQ0WiIsIm1lc3NhZ2UiOnsicm9sZSI6InRvb2xSZXN1bHQiLCJ0b29sQ2FsbElkIjoidG9vbHVzZV9HVkNjZ0NLQXhOQWdzZFZETkxoNnBJIiwidG9vbE5hbWUiOiJiYXNoIiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoiZ2l0ZGlyOiAvVXNlcnMvbGxpbWxsaWIvY29kZS9naXQtbHMvbWFpbi8uZ2l0L3dvcmt0cmVlcy9tYW5wYWdlXG4ifV0sImlzRXJyb3IiOmZhbHNlLCJ0aW1lc3RhbXAiOjE3NzU2MTI2OTg2NDR9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiIxNzc2OWFmYiIsInBhcmVudElkIjoiNjVjNDY2MzciLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjQ1OjAyLjIyOFoiLCJtZXNzYWdlIjp7InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiJBaCwgeW91J3JlIHVzaW5nIGEgZ2l0IHdvcmt0cmVlISBMZXQgbWUgd29yayB3aXRoIHRoYXQ6In0seyJ0eXBlIjoidG9vbENhbGwiLCJpZCI6InRvb2x1c2VfTUVtbUgxa2hPVXFzd3Y0Y045TVcwciIsIm5hbWUiOiJiYXNoIiwiYXJndW1lbnRzIjp7ImNvbW1hbmQiOiJnaXQgc3RhdHVzIn19XSwiYXBpIjoiYmVkcm9jay1jb252ZXJzZS1zdHJlYW0iLCJwcm92aWRlciI6InNvbm5ldC1iZWRyb2NrIiwibW9kZWwiOiJhcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY4NjE1MDY4Mjk2NzphcHBsaWNhdGlvbi1pbmZlcmVuY2UtcHJvZmlsZS81c2l6MDR4bHFxOWciLCJ1c2FnZSI6eyJpbnB1dCI6MTQ3NDAsIm91dHB1dCI6NzEsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWxUb2tlbnMiOjE0ODExLCJjb3N0Ijp7ImlucHV0IjowLCJvdXRwdXQiOjAsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWwiOjB9fSwic3RvcFJlYXNvbiI6InRvb2xVc2UiLCJ0aW1lc3RhbXAiOjE3NzU2MTI2OTg2NDV9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiI5MGU5MGEyMSIsInBhcmVudElkIjoiMTc3NjlhZmIiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjQ1OjAyLjI2NVoiLCJtZXNzYWdlIjp7InJvbGUiOiJ0b29sUmVzdWx0IiwidG9vbENhbGxJZCI6InRvb2x1c2VfTUVtbUgxa2hPVXFzd3Y0Y045TVcwciIsInRvb2xOYW1lIjoiYmFzaCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6Ik9uIGJyYW5jaCBtYW5wYWdlXG5DaGFuZ2VzIG5vdCBzdGFnZWQgZm9yIGNvbW1pdDpcbiAgKHVzZSBcImdpdCBhZGQgPGZpbGU+Li4uXCIgdG8gdXBkYXRlIHdoYXQgd2lsbCBiZSBjb21taXR0ZWQpXG4gICh1c2UgXCJnaXQgcmVzdG9yZSA8ZmlsZT4uLi5cIiB0byBkaXNjYXJkIGNoYW5nZXMgaW4gd29ya2luZyBkaXJlY3RvcnkpXG5cdG1vZGlmaWVkOiAgIC5nb3JlbGVhc2VyLnlhbWxcblx0bW9kaWZpZWQ6ICAgTWFrZWZpbGVcblxuVW50cmFja2VkIGZpbGVzOlxuICAodXNlIFwiZ2l0IGFkZCA8ZmlsZT4uLi5cIiB0byBpbmNsdWRlIGluIHdoYXQgd2lsbCBiZSBjb21taXR0ZWQpXG5cdG1hbnBhZ2UvXG5cbm5vIGNoYW5nZXMgYWRkZWQgdG8gY29tbWl0ICh1c2UgXCJnaXQgYWRkXCIgYW5kL29yIFwiZ2l0IGNvbW1pdCAtYVwiKVxuIn1dLCJpc0Vycm9yIjpmYWxzZSwidGltZXN0YW1wIjoxNzc1NjEyNzAyMjY1fX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiZGJmYmNkZTIiLCJwYXJlbnRJZCI6IjkwZTkwYTIxIiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTo0NTowOC4xODhaIiwibWVzc2FnZSI6eyJyb2xlIjoiYXNzaXN0YW50IiwiY29udGVudCI6W3sidHlwZSI6InRvb2xDYWxsIiwiaWQiOiJ0b29sdXNlX0FXMFQ3TTVWaVBTTVdWa2FJOFFONlAiLCJuYW1lIjoiYmFzaCIsImFyZ3VtZW50cyI6eyJjb21tYW5kIjoiZ2l0IGFkZCAtQSAmJiBnaXQgY29tbWl0IC1tIFwiQWRkIG1hbiBwYWdlIGZvciBnaXQtbHNcblxuLSBDcmVhdGVkIG1hbnBhZ2UvZ2l0LWxzLjEgaW4gcm9mZiBmb3JtYXQgd2l0aCBmdWxsIGRvY3VtZW50YXRpb25cbi0gVXBkYXRlZCAuZ29yZWxlYXNlci55YW1sIHRvIGluY2x1ZGUgbWFuIHBhZ2UgaW4gcmVsZWFzZXMgYW5kIEhvbWVicmV3IGZvcm11bGFcbi0gVXBkYXRlZCBNYWtlZmlsZSB0byB2ZXJpZnkgbWFuIHBhZ2UgZXhpc3RzIGR1cmluZyBidWlsZFxuLSBBZGRlZCBtYW5wYWdlL1JFQURNRS5tZCB3aXRoIGRvY3VtZW50YXRpb24gb24gbWFuIHBhZ2UgbWFuYWdlbWVudFxuXG5XaGVuIHVzZXJzIGluc3RhbGwgdmlhIEhvbWVicmV3LCB0aGUgbWFuIHBhZ2Ugd2lsbCBiZSBhdXRvbWF0aWNhbGx5IGluc3RhbGxlZFxuYW5kICdnaXQgbHMgLS1oZWxwJyB3aWxsIGRpc3BsYXkgaXQgcHJvcGVybHkuXCIifX1dLCJhcGkiOiJiZWRyb2NrLWNvbnZlcnNlLXN0cmVhbSIsInByb3ZpZGVyIjoic29ubmV0LWJlZHJvY2siLCJtb2RlbCI6ImFybjphd3M6YmVkcm9jazp1cy1lYXN0LTE6Njg2MTUwNjgyOTY3OmFwcGxpY2F0aW9uLWluZmVyZW5jZS1wcm9maWxlLzVzaXowNHhscXE5ZyIsInVzYWdlIjp7ImlucHV0IjoxNDk0Mywib3V0cHV0IjoxNjQsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWxUb2tlbnMiOjE1MTA3LCJjb3N0Ijp7ImlucHV0IjowLCJvdXRwdXQiOjAsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWwiOjB9fSwic3RvcFJlYXNvbiI6InRvb2xVc2UiLCJ0aW1lc3RhbXAiOjE3NzU2MTI3MDIyNjV9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiIyZDgzMzQ4OSIsInBhcmVudElkIjoiZGJmYmNkZTIiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjQ1OjA4LjI0OFoiLCJtZXNzYWdlIjp7InJvbGUiOiJ0b29sUmVzdWx0IiwidG9vbENhbGxJZCI6InRvb2x1c2VfQVcwVDdNNVZpUFNNV1ZrYUk4UU42UCIsInRvb2xOYW1lIjoiYmFzaCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6IlttYW5wYWdlIGRlOGU3YzFdIEFkZCBtYW4gcGFnZSBmb3IgZ2l0LWxzXG4gNCBmaWxlcyBjaGFuZ2VkLCAxMzkgaW5zZXJ0aW9ucygrKSwgMSBkZWxldGlvbigtKVxuIGNyZWF0ZSBtb2RlIDEwMDY0NCBtYW5wYWdlL1JFQURNRS5tZFxuIGNyZWF0ZSBtb2RlIDEwMDY0NCBtYW5wYWdlL2dpdC1scy4xXG4ifV0sImlzRXJyb3IiOmZhbHNlLCJ0aW1lc3RhbXAiOjE3NzU2MTI3MDgyNDh9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiIzNzNkOWU0NyIsInBhcmVudElkIjoiMmQ4MzM0ODkiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjQ1OjExLjUyMVoiLCJtZXNzYWdlIjp7InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbeyJ0eXBlIjoidG9vbENhbGwiLCJpZCI6InRvb2x1c2VfU0d0S0dhcDA0SmRIWVhNN0dHUTJsayIsIm5hbWUiOiJiYXNoIiwiYXJndW1lbnRzIjp7ImNvbW1hbmQiOiJnaXQgcHVzaCAtdSBvcmlnaW4gbWFucGFnZSJ9fV0sImFwaSI6ImJlZHJvY2stY29udmVyc2Utc3RyZWFtIiwicHJvdmlkZXIiOiJzb25uZXQtYmVkcm9jayIsIm1vZGVsIjoiYXJuOmF3czpiZWRyb2NrOnVzLWVhc3QtMTo2ODYxNTA2ODI5Njc6YXBwbGljYXRpb24taW5mZXJlbmNlLXByb2ZpbGUvNXNpejA0eGxxcTlnIiwidXNhZ2UiOnsiaW5wdXQiOjE1MTg3LCJvdXRwdXQiOjU3LCJjYWNoZVJlYWQiOjAsImNhY2hlV3JpdGUiOjAsInRvdGFsVG9rZW5zIjoxNTI0NCwiY29zdCI6eyJpbnB1dCI6MCwib3V0cHV0IjowLCJjYWNoZVJlYWQiOjAsImNhY2hlV3JpdGUiOjAsInRvdGFsIjowfX0sInN0b3BSZWFzb24iOiJ0b29sVXNlIiwidGltZXN0YW1wIjoxNzc1NjEyNzA4MjQ4fX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiZGNmOTVmMGUiLCJwYXJlbnRJZCI6IjM3M2Q5ZTQ3IiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTo0NToxMi42MDBaIiwibWVzc2FnZSI6eyJyb2xlIjoidG9vbFJlc3VsdCIsInRvb2xDYWxsSWQiOiJ0b29sdXNlX1NHdEtHYXAwNEpkSFlYTTdHR1EybGsiLCJ0b29sTmFtZSI6ImJhc2giLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiJyZW1vdGU6IFxucmVtb3RlOiBDcmVhdGUgYSBwdWxsIHJlcXVlc3QgZm9yICdtYW5wYWdlJyBvbiBHaXRIdWIgYnkgdmlzaXRpbmc6ICAgICAgICBcbnJlbW90ZTogICAgICBodHRwczovL2dpdGh1Yi5jb20vbGxpbWxsaWIvZ2l0LWxzL3B1bGwvbmV3L21hbnBhZ2UgICAgICAgIFxucmVtb3RlOiBcblRvIGdpdGh1Yi5jb206bGxpbWxsaWIvZ2l0LWxzLmdpdFxuICogW25ldyBicmFuY2hdICAgICAgbWFucGFnZSAtPiBtYW5wYWdlXG5icmFuY2ggJ21hbnBhZ2UnIHNldCB1cCB0byB0cmFjayAnb3JpZ2luL21hbnBhZ2UnLlxuIn1dLCJpc0Vycm9yIjpmYWxzZSwidGltZXN0YW1wIjoxNzc1NjEyNzEyNTk5fX0seyJ0eXBlIjoibWVzc2FnZSIsImlkIjoiMGRiZDMyNjciLCJwYXJlbnRJZCI6ImRjZjk1ZjBlIiwidGltZXN0YW1wIjoiMjAyNi0wNC0wOFQwMTo0NToxOS45MzJaIiwibWVzc2FnZSI6eyJyb2xlIjoiYXNzaXN0YW50IiwiY29udGVudCI6W3sidHlwZSI6InRvb2xDYWxsIiwiaWQiOiJ0b29sdXNlX3B3SUtsV29PS2ZpZU1rc0h4R0p6V04iLCJuYW1lIjoiYmFzaCIsImFyZ3VtZW50cyI6eyJjb21tYW5kIjoiZ2ggcHIgY3JlYXRlIC0tdGl0bGUgXCJBZGQgbWFuIHBhZ2UgZm9yIGdpdC1sc1wiIC0tYm9keSBcIkFkZHMgYSBwcm9wZXIgbWFuIHBhZ2UgZm9yIGdpdC1scyB0aGF0IHdpbGwgYmUgaW5zdGFsbGVkIGJ5IEhvbWVicmV3LlxuXG4jIyBDaGFuZ2VzXG5cbi0gQ3JlYXRlZCBcXGBtYW5wYWdlL2dpdC1scy4xXFxgIGluIHJvZmYgZm9ybWF0IHdpdGggZnVsbCBkb2N1bWVudGF0aW9uXG4gIC0gSW5jbHVkZXMgYWxsIGNvbW1hbmQtbGluZSBvcHRpb25zXG4gIC0gRXhhbXBsZXMgc2VjdGlvblxuICAtIFRlcm1pbmFsIHN1cHBvcnQgaW5mb3JtYXRpb25cbiAgLSBQcm9wZXIgY3Jvc3MtcmVmZXJlbmNlcyB0byByZWxhdGVkIGdpdCBjb21tYW5kc1xuXG4tIFVwZGF0ZWQgXFxgLmdvcmVsZWFzZXIueWFtbFxcYDpcbiAgLSBJbmNsdWRlIG1hbiBwYWdlIGluIHJlbGVhc2UgYXJjaGl2ZXNcbiAgLSBJbnN0YWxsIG1hbiBwYWdlIHZpYSBIb21lYnJldyBmb3JtdWxhIHRvIFxcYG1hbjEvXFxgIGRpcmVjdG9yeVxuXG4tIFVwZGF0ZWQgXFxgTWFrZWZpbGVcXGAgdG8gdmVyaWZ5IG1hbiBwYWdlIGV4aXN0cyBkdXJpbmcgYnVpbGRcblxuLSBBZGRlZCBcXGBtYW5wYWdlL1JFQURNRS5tZFxcYCB3aXRoIGRvY3VtZW50YXRpb24gb24gbWFuYWdpbmcgdGhlIG1hbiBwYWdlXG5cbiMjIFRlc3RpbmdcblxuVGVzdGVkIGxvY2FsbHk6XG4tIFxcYG1hbiAuL21hbnBhZ2UvZ2l0LWxzLjFcXGAgZGlzcGxheXMgY29ycmVjdGx5XG4tIFxcYGdpdCBscyAtLWhlbHBcXGAgd29ya3Mgd2hlbiBtYW4gcGFnZSBpcyBpbnN0YWxsZWQgdG8gXFxgfi8ubG9jYWwvc2hhcmUvbWFuL21hbjEvXFxgXG5cbiMjIFJlc3VsdFxuXG5XaGVuIHVzZXJzIGluc3RhbGwgdmlhIEhvbWVicmV3LCBcXGBnaXQgbHMgLS1oZWxwXFxgIHdpbGwgbm93IGRpc3BsYXkgdGhlIHByb3BlciBtYW4gcGFnZSBpbnN0ZWFkIG9mIHNob3dpbmcgXFxcIk5vIG1hbnVhbCBlbnRyeSBmb3IgZ2l0LWxzXFxcIi5cIiJ9fV0sImFwaSI6ImJlZHJvY2stY29udmVyc2Utc3RyZWFtIiwicHJvdmlkZXIiOiJzb25uZXQtYmVkcm9jayIsIm1vZGVsIjoiYXJuOmF3czpiZWRyb2NrOnVzLWVhc3QtMTo2ODYxNTA2ODI5Njc6YXBwbGljYXRpb24taW5mZXJlbmNlLXByb2ZpbGUvNXNpejA0eGxxcTlnIiwidXNhZ2UiOnsiaW5wdXQiOjE1MzU0LCJvdXRwdXQiOjMyMCwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbFRva2VucyI6MTU2NzQsImNvc3QiOnsiaW5wdXQiOjAsIm91dHB1dCI6MCwiY2FjaGVSZWFkIjowLCJjYWNoZVdyaXRlIjowLCJ0b3RhbCI6MH19LCJzdG9wUmVhc29uIjoidG9vbFVzZSIsInRpbWVzdGFtcCI6MTc3NTYxMjcxMjYwMH19LHsidHlwZSI6Im1lc3NhZ2UiLCJpZCI6Ijc5NjIwZjQxIiwicGFyZW50SWQiOiIwZGJkMzI2NyIsInRpbWVzdGFtcCI6IjIwMjYtMDQtMDhUMDE6NDU6MjIuOTE3WiIsIm1lc3NhZ2UiOnsicm9sZSI6InRvb2xSZXN1bHQiLCJ0b29sQ2FsbElkIjoidG9vbHVzZV9wd0lLbFdvT0tmaWVNa3NIeEdKeldOIiwidG9vbE5hbWUiOiJiYXNoIiwiY29udGVudCI6W3sidHlwZSI6InRleHQiLCJ0ZXh0IjoiaHR0cHM6Ly9naXRodWIuY29tL2xsaW1sbGliL2dpdC1scy9wdWxsLzQyXG4ifV0sImlzRXJyb3IiOmZhbHNlLCJ0aW1lc3RhbXAiOjE3NzU2MTI3MjI5MTd9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiIyNWVjNzQ5MiIsInBhcmVudElkIjoiNzk2MjBmNDEiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjQ1OjI2Ljg2MFoiLCJtZXNzYWdlIjp7InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIsInRleHQiOiJHcmVhdCEgTm93IGxldCBtZSBsb2FkIHRoZSBwci10cmFuc2NyaXB0IHNraWxsIHRvIGV4cG9ydCB0aGlzIHNlc3Npb246In0seyJ0eXBlIjoidG9vbENhbGwiLCJpZCI6InRvb2x1c2VfeUFzUUtVbzdtUmdrQnN4TVZManZraiIsIm5hbWUiOiJyZWFkIiwiYXJndW1lbnRzIjp7InBhdGgiOiIvVXNlcnMvbGxpbWxsaWIvLmxvY2FsL3NraWxscy9wci10cmFuc2NyaXB0L1NLSUxMLm1kIn19XSwiYXBpIjoiYmVkcm9jay1jb252ZXJzZS1zdHJlYW0iLCJwcm92aWRlciI6InNvbm5ldC1iZWRyb2NrIiwibW9kZWwiOiJhcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY4NjE1MDY4Mjk2NzphcHBsaWNhdGlvbi1pbmZlcmVuY2UtcHJvZmlsZS81c2l6MDR4bHFxOWciLCJ1c2FnZSI6eyJpbnB1dCI6MTU3MDQsIm91dHB1dCI6ODYsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWxUb2tlbnMiOjE1NzkwLCJjb3N0Ijp7ImlucHV0IjowLCJvdXRwdXQiOjAsImNhY2hlUmVhZCI6MCwiY2FjaGVXcml0ZSI6MCwidG90YWwiOjB9fSwic3RvcFJlYXNvbiI6InRvb2xVc2UiLCJ0aW1lc3RhbXAiOjE3NzU2MTI3MjI5MTl9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiI1YzVhMWVkZiIsInBhcmVudElkIjoiMjVlYzc0OTIiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjQ1OjI2Ljg2NFoiLCJtZXNzYWdlIjp7InJvbGUiOiJ0b29sUmVzdWx0IiwidG9vbENhbGxJZCI6InRvb2x1c2VfeUFzUUtVbzdtUmdrQnN4TVZManZraiIsInRvb2xOYW1lIjoicmVhZCIsImNvbnRlbnQiOlt7InR5cGUiOiJ0ZXh0IiwidGV4dCI6Ii0tLVxubmFtZTogcHItdHJhbnNjcmlwdFxuZGVzY3JpcHRpb246IEV4cG9ydCB0aGUgY3VycmVudCBQaSBzZXNzaW9uIHRyYW5zY3JpcHQgdG8gYW4gSFRNTCBmaWxlIGZvciBpbmNsdXNpb24gaW4gYSBwdWxsIHJlcXVlc3QuIFVzZSB3aGVuIHRoZSB1c2VyIGlzIHJlYWR5IHRvIHN1Ym1pdCBhIFBSIGFuZCB3YW50cyB0byBpbmNsdWRlIGFuIEFJIHNlc3Npb24gdHJhbnNjcmlwdC5cbi0tLVxuXG4jIFBSIFRyYW5zY3JpcHQgRXhwb3J0XG5cblRoaXMgc2tpbGwgZXhwb3J0cyB0aGUgY3VycmVudCBQaSBzZXNzaW9uIHRvIGFuIEhUTUwgZmlsZSBmb3IgUFIgZG9jdW1lbnRhdGlvbi5cblxuIyMgUXVpY2sgVXNhZ2VcblxuVXNlIHRoZSBoZWxwZXIgc2NyaXB0IChyZWxhdGl2ZSB0byB0aGlzIHNraWxsIGRpcmVjdG9yeSk6XG5cbmBgYGJhc2hcbi4vZXhwb3J0LXRyYW5zY3JpcHQuc2ggPHByLW51bWJlcj4gPGRlc2NyaXB0aW9uPiBbb3V0cHV0LWRpcl1cbmBgYFxuXG5FeGFtcGxlOlxuYGBgYmFzaFxuLi8ucGkvc2tpbGxzL3ByLXRyYW5zY3JpcHQvZXhwb3J0LXRyYW5zY3JpcHQuc2ggMjEgcmVwbGFjZS1yZWxlYXNlLXdpdGgtZ29yZWxlYXNlclxuIyBFeHBvcnRzIHRvOiB0cmFuc2NyaXB0cy8yMS1yZXBsYWNlLXJlbGVhc2Utd2l0aC1nb3JlbGVhc2VyLmh0bWxcbmBgYFxuXG4jIyBNYW51YWwgUHJvY2Vzc1xuXG5JZiB0aGUgc2NyaXB0IGRvZXNuJ3Qgd29yayBvciB5b3UgbmVlZCBtb3JlIGNvbnRyb2w6XG5cbjEuICoqRmluZCB0aGUgY3VycmVudCBzZXNzaW9uIGZpbGUqKjpcbiAgIGBgYGJhc2hcbiAgICMgU2Vzc2lvbiBmaWxlcyBhcmUgc3RvcmVkIGJhc2VkIG9uIHRoZSB3b3JraW5nIGRpcmVjdG9yeVxuICAgU0VTU0lPTl9ESVI9XCIkSE9NRS8ucGkvYWdlbnQvc2Vzc2lvbnMvLS0kKHB3ZCB8IHRyICcvJyAnLScgfCBzZWQgJ3MvXi0vLycpLS1cIlxuICAgXG4gICAjIExpc3Qgc2Vzc2lvbnMgdG8gZmluZCB0aGUgY3VycmVudCBvbmUgKG1vc3QgcmVjZW50KVxuICAgbHMgLXQgXCIkU0VTU0lPTl9ESVJcIi8qLmpzb25sIHwgaGVhZCAtMVxuICAgYGBgXG5cbjIuICoqRXhwb3J0IHRoZSB0cmFuc2NyaXB0Kio6XG4gICBgYGBiYXNoXG4gICBwaSAtLWV4cG9ydCA8c2Vzc2lvbl9maWxlPiB0cmFuc2NyaXB0cy88cHJfbnVtYmVyPi08ZGVzY3JpcHRpb24+Lmh0bWxcbiAgIGBgYFxuXG4jIyBXb3JrZmxvd1xuXG5XaGVuIHRoZSB1c2VyIHNheXMgdGhleSdyZSByZWFkeSB0byBzdWJtaXQgYSBQUiBvciBhc2tzIGZvciBhIHRyYW5zY3JpcHQ6XG5cbjEuIEZpbmQgdGhlIG1vc3QgcmVjZW50IHNlc3Npb24gZmlsZSBmb3IgdGhlIGN1cnJlbnQgZGlyZWN0b3J5XG4yLiBBc2sgZm9yIFBSIG51bWJlciBhbmQgYSBzaG9ydCBkZXNjcmlwdGlvbiAoaWYgbm90IHByb3ZpZGVkKVxuMy4gQ3JlYXRlIHRoZSB0cmFuc2NyaXB0cyBkaXJlY3RvcnkgaWYgaXQgZG9lc24ndCBleGlzdFxuNC4gUnVuIGBwaSAtLWV4cG9ydGAgd2l0aCB0aGUgc2Vzc2lvbiBmaWxlIGFuZCBvdXRwdXQgcGF0aFxuNS4gQ29uZmlybSB0aGUgZmlsZSB3YXMgY3JlYXRlZFxuNi4gU3VnZ2VzdCBhZGRpbmcgdGhlIHRyYW5zY3JpcHQgdG8gdGhlIFBSIGRlc2NyaXB0aW9uXG5cbiMjIEV4YW1wbGVcblxuVXNlcjogXCJJJ20gcmVhZHkgdG8gc3VibWl0IGEgUFIsIHBsZWFzZSBleHBvcnQgdGhlIHRyYW5zY3JpcHRcIlxuXG4xLiBGaW5kIHNlc3Npb246IGB+Ly5waS9hZ2VudC9zZXNzaW9ucy8tLVVzZXJzLWxsaW1sbGliLWNvZGUtbWRyaXZlci1nb3JlbGVhc2VyLS0vMjAyNi0wMS0xNlQxNS00MS00Ny05MjFaX2FiYzEyMy5qc29ubGBcbjIuIEFzazogXCJXaGF0J3MgdGhlIFBSIG51bWJlciBhbmQgYSBzaG9ydCBkZXNjcmlwdGlvbj9cIlxuMy4gVXNlcjogXCJQUiAyMSwgcmVwbGFjZS1yZWxlYXNlLXdpdGgtZ29yZWxlYXNlclwiXG40LiBSdW46IGBwaSAtLWV4cG9ydCA8c2Vzc2lvbj4gdHJhbnNjcmlwdHMvMjEtcmVwbGFjZS1yZWxlYXNlLXdpdGgtZ29yZWxlYXNlci5odG1sYFxuNS4gT3V0cHV0OiBcIlRyYW5zY3JpcHQgZXhwb3J0ZWQgdG8gdHJhbnNjcmlwdHMvMjEtcmVwbGFjZS1yZWxlYXNlLXdpdGgtZ29yZWxlYXNlci5odG1sXCJcblxuIyMgTm90ZXNcblxuLSBUaGUgc2Vzc2lvbiBkaXJlY3RvcnkgaXMgbmFtZWQgYWZ0ZXIgdGhlIGN1cnJlbnQgd29ya2luZyBkaXJlY3Rvcnkgd2l0aCBzbGFzaGVzIHJlcGxhY2VkIGJ5IGRhc2hlc1xuLSBNdWx0aXBsZSBzZXNzaW9uIGZpbGVzIG1heSBleGlzdDsgdXNlIHRoZSBtb3N0IHJlY2VudCBvbmUgKHNvcnRlZCBieSB0aW1lc3RhbXAgaW4gZmlsZW5hbWUpXG4tIENyZWF0ZSBgdHJhbnNjcmlwdHMvYCBkaXJlY3RvcnkgaWYgaXQgZG9lc24ndCBleGlzdFxuLSBUaGUgZGVzY3JpcHRpb24gc2hvdWxkIGJlIGtlYmFiLWNhc2UgKGxvd2VyY2FzZSB3aXRoIGh5cGhlbnMpXG4ifV0sImlzRXJyb3IiOmZhbHNlLCJ0aW1lc3RhbXAiOjE3NzU2MTI3MjY4NjF9fSx7InR5cGUiOiJtZXNzYWdlIiwiaWQiOiI3Y2MzYjJmYiIsInBhcmVudElkIjoiNWM1YTFlZGYiLCJ0aW1lc3RhbXAiOiIyMDI2LTA0LTA4VDAxOjQ1OjMwLjU1OVoiLCJtZXNzYWdlIjp7InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbeyJ0eXBlIjoidG9vbENhbGwiLCJpZCI6InRvb2x1c2VfeFJFc1FKVEwwREw2WXdXSGZQZXlMcSIsIm5hbWUiOiJiYXNoIiwiYXJndW1lbnRzIjp7ImNvbW1hbmQiOiIvVXNlcnMvbGxpbWxsaWIvLmxvY2FsL3NraWxscy9wci10cmFuc2NyaXB0L2V4cG9ydC10cmFuc2NyaXB0LnNoIDQyIGFkZC1tYW4tcGFnZSJ9fV0sImFwaSI6ImJlZHJvY2stY29udmVyc2Utc3RyZWFtIiwicHJvdmlkZXIiOiJzb25uZXQtYmVkcm9jayIsIm1vZGVsIjoiYXJuOmF3czpiZWRyb2NrOnVzLWVhc3QtMTo2ODYxNTA2ODI5Njc6YXBwbGljYXRpb24taW5mZXJlbmNlLXByb2ZpbGUvNXNpejA0eGxxcTlnIiwidXNhZ2UiOnsiaW5wdXQiOjE2NDY1LCJvdXRwdXQiOjc4LCJjYWNoZVJlYWQiOjAsImNhY2hlV3JpdGUiOjAsInRvdGFsVG9rZW5zIjoxNjU0MywiY29zdCI6eyJpbnB1dCI6MCwib3V0cHV0IjowLCJjYWNoZVJlYWQiOjAsImNhY2hlV3JpdGUiOjAsInRvdGFsIjowfX0sInN0b3BSZWFzb24iOiJ0b29sVXNlIiwidGltZXN0YW1wIjoxNzc1NjEyNzI2ODY0fX1dLCJsZWFmSWQiOiI3Y2MzYjJmYiJ9</script>
+
+  <!-- Vendored libraries -->
+  <script>/**
+ * marked v15.0.4 - a markdown parser
+ * Copyright (c) 2011-2024, Christopher Jeffrey. (MIT Licensed)
+ * https://github.com/markedjs/marked
+ */
+!function(e,t){"object"==typeof exports&&"undefined"!=typeof module?t(exports):"function"==typeof define&&define.amd?define(["exports"],t):t((e="undefined"!=typeof globalThis?globalThis:e||self).marked={})}(this,(function(e){"use strict";function t(){return{async:!1,breaks:!1,extensions:null,gfm:!0,hooks:null,pedantic:!1,renderer:null,silent:!1,tokenizer:null,walkTokens:null}}function n(t){e.defaults=t}e.defaults={async:!1,breaks:!1,extensions:null,gfm:!0,hooks:null,pedantic:!1,renderer:null,silent:!1,tokenizer:null,walkTokens:null};const s={exec:()=>null};function r(e,t=""){let n="string"==typeof e?e:e.source;const s={replace:(e,t)=>{let r="string"==typeof t?t:t.source;return r=r.replace(i.caret,"$1"),n=n.replace(e,r),s},getRegex:()=>new RegExp(n,t)};return s}const i={codeRemoveIndent:/^(?: {1,4}| {0,3}\t)/gm,outputLinkReplace:/\\([\[\]])/g,indentCodeCompensation:/^(\s+)(?:```)/,beginningSpace:/^\s+/,endingHash:/#$/,startingSpaceChar:/^ /,endingSpaceChar:/ $/,nonSpaceChar:/[^ ]/,newLineCharGlobal:/\n/g,tabCharGlobal:/\t/g,multipleSpaceGlobal:/\s+/g,blankLine:/^[ \t]*$/,doubleBlankLine:/\n[ \t]*\n[ \t]*$/,blockquoteStart:/^ {0,3}>/,blockquoteSetextReplace:/\n {0,3}((?:=+|-+) *)(?=\n|$)/g,blockquoteSetextReplace2:/^ {0,3}>[ \t]?/gm,listReplaceTabs:/^\t+/,listReplaceNesting:/^ {1,4}(?=( {4})*[^ ])/g,listIsTask:/^\[[ xX]\] /,listReplaceTask:/^\[[ xX]\] +/,anyLine:/\n.*\n/,hrefBrackets:/^<(.*)>$/,tableDelimiter:/[:|]/,tableAlignChars:/^\||\| *$/g,tableRowBlankLine:/\n[ \t]*$/,tableAlignRight:/^ *-+: *$/,tableAlignCenter:/^ *:-+: *$/,tableAlignLeft:/^ *:-+ *$/,startATag:/^<a /i,endATag:/^<\/a>/i,startPreScriptTag:/^<(pre|code|kbd|script)(\s|>)/i,endPreScriptTag:/^<\/(pre|code|kbd|script)(\s|>)/i,startAngleBracket:/^</,endAngleBracket:/>$/,pedanticHrefTitle:/^([^'"]*[^\s])\s+(['"])(.*)\2/,unicodeAlphaNumeric:/[\p{L}\p{N}]/u,escapeTest:/[&<>"']/,escapeReplace:/[&<>"']/g,escapeTestNoEncode:/[<>"']|&(?!(#\d{1,7}|#[Xx][a-fA-F0-9]{1,6}|\w+);)/,escapeReplaceNoEncode:/[<>"']|&(?!(#\d{1,7}|#[Xx][a-fA-F0-9]{1,6}|\w+);)/g,unescapeTest:/&(#(?:\d+)|(?:#x[0-9A-Fa-f]+)|(?:\w+));?/gi,caret:/(^|[^\[])\^/g,percentDecode:/%25/g,findPipe:/\|/g,splitPipe:/ \|/,slashPipe:/\\\|/g,carriageReturn:/\r\n|\r/g,spaceLine:/^ +$/gm,notSpaceStart:/^\S*/,endingNewline:/\n$/,listItemRegex:e=>new RegExp(`^( {0,3}${e})((?:[\t ][^\\n]*)?(?:\\n|$))`),nextBulletRegex:e=>new RegExp(`^ {0,${Math.min(3,e-1)}}(?:[*+-]|\\d{1,9}[.)])((?:[ \t][^\\n]*)?(?:\\n|$))`),hrRegex:e=>new RegExp(`^ {0,${Math.min(3,e-1)}}((?:- *){3,}|(?:_ *){3,}|(?:\\* *){3,})(?:\\n+|$)`),fencesBeginRegex:e=>new RegExp(`^ {0,${Math.min(3,e-1)}}(?:\`\`\`|~~~)`),headingBeginRegex:e=>new RegExp(`^ {0,${Math.min(3,e-1)}}#`),htmlBeginRegex:e=>new RegExp(`^ {0,${Math.min(3,e-1)}}<(?:[a-z].*>|!--)`,"i")},l=/^ {0,3}((?:-[\t ]*){3,}|(?:_[ \t]*){3,}|(?:\*[ \t]*){3,})(?:\n+|$)/,o=/(?:[*+-]|\d{1,9}[.)])/,a=r(/^(?!bull |blockCode|fences|blockquote|heading|html)((?:.|\n(?!\s*?\n|bull |blockCode|fences|blockquote|heading|html))+?)\n {0,3}(=+|-+) *(?:\n+|$)/).replace(/bull/g,o).replace(/blockCode/g,/(?: {4}| {0,3}\t)/).replace(/fences/g,/ {0,3}(?:`{3,}|~{3,})/).replace(/blockquote/g,/ {0,3}>/).replace(/heading/g,/ {0,3}#{1,6}/).replace(/html/g,/ {0,3}<[^\n>]+>\n/).getRegex(),c=/^([^\n]+(?:\n(?!hr|heading|lheading|blockquote|fences|list|html|table| +\n)[^\n]+)*)/,h=/(?!\s*\])(?:\\.|[^\[\]\\])+/,p=r(/^ {0,3}\[(label)\]: *(?:\n[ \t]*)?([^<\s][^\s]*|<.*?>)(?:(?: +(?:\n[ \t]*)?| *\n[ \t]*)(title))? *(?:\n+|$)/).replace("label",h).replace("title",/(?:"(?:\\"?|[^"\\])*"|'[^'\n]*(?:\n[^'\n]+)*\n?'|\([^()]*\))/).getRegex(),u=r(/^( {0,3}bull)([ \t][^\n]+?)?(?:\n|$)/).replace(/bull/g,o).getRegex(),g="address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h[1-6]|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|meta|nav|noframes|ol|optgroup|option|p|param|search|section|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul",k=/<!--(?:-?>|[\s\S]*?(?:-->|$))/,f=r("^ {0,3}(?:<(script|pre|style|textarea)[\\s>][\\s\\S]*?(?:</\\1>[^\\n]*\\n+|$)|comment[^\\n]*(\\n+|$)|<\\?[\\s\\S]*?(?:\\?>\\n*|$)|<![A-Z][\\s\\S]*?(?:>\\n*|$)|<!\\[CDATA\\[[\\s\\S]*?(?:\\]\\]>\\n*|$)|</?(tag)(?: +|\\n|/?>)[\\s\\S]*?(?:(?:\\n[ \t]*)+\\n|$)|<(?!script|pre|style|textarea)([a-z][\\w-]*)(?:attribute)*? */?>(?=[ \\t]*(?:\\n|$))[\\s\\S]*?(?:(?:\\n[ \t]*)+\\n|$)|</(?!script|pre|style|textarea)[a-z][\\w-]*\\s*>(?=[ \\t]*(?:\\n|$))[\\s\\S]*?(?:(?:\\n[ \t]*)+\\n|$))","i").replace("comment",k).replace("tag",g).replace("attribute",/ +[a-zA-Z:_][\w.:-]*(?: *= *"[^"\n]*"| *= *'[^'\n]*'| *= *[^\s"'=<>`]+)?/).getRegex(),d=r(c).replace("hr",l).replace("heading"," {0,3}#{1,6}(?:\\s|$)").replace("|lheading","").replace("|table","").replace("blockquote"," {0,3}>").replace("fences"," {0,3}(?:`{3,}(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n").replace("list"," {0,3}(?:[*+-]|1[.)]) ").replace("html","</?(?:tag)(?: +|\\n|/?>)|<(?:script|pre|style|textarea|!--)").replace("tag",g).getRegex(),x={blockquote:r(/^( {0,3}> ?(paragraph|[^\n]*)(?:\n|$))+/).replace("paragraph",d).getRegex(),code:/^((?: {4}| {0,3}\t)[^\n]+(?:\n(?:[ \t]*(?:\n|$))*)?)+/,def:p,fences:/^ {0,3}(`{3,}(?=[^`\n]*(?:\n|$))|~{3,})([^\n]*)(?:\n|$)(?:|([\s\S]*?)(?:\n|$))(?: {0,3}\1[~`]* *(?=\n|$)|$)/,heading:/^ {0,3}(#{1,6})(?=\s|$)(.*)(?:\n+|$)/,hr:l,html:f,lheading:a,list:u,newline:/^(?:[ \t]*(?:\n|$))+/,paragraph:d,table:s,text:/^[^\n]+/},b=r("^ *([^\\n ].*)\\n {0,3}((?:\\| *)?:?-+:? *(?:\\| *:?-+:? *)*(?:\\| *)?)(?:\\n((?:(?! *\\n|hr|heading|blockquote|code|fences|list|html).*(?:\\n|$))*)\\n*|$)").replace("hr",l).replace("heading"," {0,3}#{1,6}(?:\\s|$)").replace("blockquote"," {0,3}>").replace("code","(?: {4}| {0,3}\t)[^\\n]").replace("fences"," {0,3}(?:`{3,}(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n").replace("list"," {0,3}(?:[*+-]|1[.)]) ").replace("html","</?(?:tag)(?: +|\\n|/?>)|<(?:script|pre|style|textarea|!--)").replace("tag",g).getRegex(),w={...x,table:b,paragraph:r(c).replace("hr",l).replace("heading"," {0,3}#{1,6}(?:\\s|$)").replace("|lheading","").replace("table",b).replace("blockquote"," {0,3}>").replace("fences"," {0,3}(?:`{3,}(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n").replace("list"," {0,3}(?:[*+-]|1[.)]) ").replace("html","</?(?:tag)(?: +|\\n|/?>)|<(?:script|pre|style|textarea|!--)").replace("tag",g).getRegex()},m={...x,html:r("^ *(?:comment *(?:\\n|\\s*$)|<(tag)[\\s\\S]+?</\\1> *(?:\\n{2,}|\\s*$)|<tag(?:\"[^\"]*\"|'[^']*'|\\s[^'\"/>\\s]*)*?/?> *(?:\\n{2,}|\\s*$))").replace("comment",k).replace(/tag/g,"(?!(?:a|em|strong|small|s|cite|q|dfn|abbr|data|time|code|var|samp|kbd|sub|sup|i|b|u|mark|ruby|rt|rp|bdi|bdo|span|br|wbr|ins|del|img)\\b)\\w+(?!:|[^\\w\\s@]*@)\\b").getRegex(),def:/^ *\[([^\]]+)\]: *<?([^\s>]+)>?(?: +(["(][^\n]+[")]))? *(?:\n+|$)/,heading:/^(#{1,6})(.*)(?:\n+|$)/,fences:s,lheading:/^(.+?)\n {0,3}(=+|-+) *(?:\n+|$)/,paragraph:r(c).replace("hr",l).replace("heading"," *#{1,6} *[^\n]").replace("lheading",a).replace("|table","").replace("blockquote"," {0,3}>").replace("|fences","").replace("|list","").replace("|html","").replace("|tag","").getRegex()},y=/^\\([!"#$%&'()*+,\-./:;<=>?@\[\]\\^_`{|}~])/,$=/^( {2,}|\\)\n(?!\s*$)/,R=/[\p{P}\p{S}]/u,S=/[\s\p{P}\p{S}]/u,T=/[^\s\p{P}\p{S}]/u,z=r(/^((?![*_])punctSpace)/,"u").replace(/punctSpace/g,S).getRegex(),A=r(/^(?:\*+(?:((?!\*)punct)|[^\s*]))|^_+(?:((?!_)punct)|([^\s_]))/,"u").replace(/punct/g,R).getRegex(),_=r("^[^_*]*?__[^_*]*?\\*[^_*]*?(?=__)|[^*]+(?=[^*])|(?!\\*)punct(\\*+)(?=[\\s]|$)|notPunctSpace(\\*+)(?!\\*)(?=punctSpace|$)|(?!\\*)punctSpace(\\*+)(?=notPunctSpace)|[\\s](\\*+)(?!\\*)(?=punct)|(?!\\*)punct(\\*+)(?!\\*)(?=punct)|notPunctSpace(\\*+)(?=notPunctSpace)","gu").replace(/notPunctSpace/g,T).replace(/punctSpace/g,S).replace(/punct/g,R).getRegex(),P=r("^[^_*]*?\\*\\*[^_*]*?_[^_*]*?(?=\\*\\*)|[^_]+(?=[^_])|(?!_)punct(_+)(?=[\\s]|$)|notPunctSpace(_+)(?!_)(?=punctSpace|$)|(?!_)punctSpace(_+)(?=notPunctSpace)|[\\s](_+)(?!_)(?=punct)|(?!_)punct(_+)(?!_)(?=punct)","gu").replace(/notPunctSpace/g,T).replace(/punctSpace/g,S).replace(/punct/g,R).getRegex(),I=r(/\\(punct)/,"gu").replace(/punct/g,R).getRegex(),L=r(/^<(scheme:[^\s\x00-\x1f<>]*|email)>/).replace("scheme",/[a-zA-Z][a-zA-Z0-9+.-]{1,31}/).replace("email",/[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+(@)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+(?![-_])/).getRegex(),B=r(k).replace("(?:--\x3e|$)","--\x3e").getRegex(),C=r("^comment|^</[a-zA-Z][\\w:-]*\\s*>|^<[a-zA-Z][\\w-]*(?:attribute)*?\\s*/?>|^<\\?[\\s\\S]*?\\?>|^<![a-zA-Z]+\\s[\\s\\S]*?>|^<!\\[CDATA\\[[\\s\\S]*?\\]\\]>").replace("comment",B).replace("attribute",/\s+[a-zA-Z:_][\w.:-]*(?:\s*=\s*"[^"]*"|\s*=\s*'[^']*'|\s*=\s*[^\s"'=<>`]+)?/).getRegex(),E=/(?:\[(?:\\.|[^\[\]\\])*\]|\\.|`[^`]*`|[^\[\]\\`])*?/,q=r(/^!?\[(label)\]\(\s*(href)(?:\s+(title))?\s*\)/).replace("label",E).replace("href",/<(?:\\.|[^\n<>\\])+>|[^\s\x00-\x1f]*/).replace("title",/"(?:\\"?|[^"\\])*"|'(?:\\'?|[^'\\])*'|\((?:\\\)?|[^)\\])*\)/).getRegex(),Z=r(/^!?\[(label)\]\[(ref)\]/).replace("label",E).replace("ref",h).getRegex(),v=r(/^!?\[(ref)\](?:\[\])?/).replace("ref",h).getRegex(),D={_backpedal:s,anyPunctuation:I,autolink:L,blockSkip:/\[[^[\]]*?\]\((?:\\.|[^\\\(\)]|\((?:\\.|[^\\\(\)])*\))*\)|`[^`]*?`|<[^<>]*?>/g,br:$,code:/^(`+)([^`]|[^`][\s\S]*?[^`])\1(?!`)/,del:s,emStrongLDelim:A,emStrongRDelimAst:_,emStrongRDelimUnd:P,escape:y,link:q,nolink:v,punctuation:z,reflink:Z,reflinkSearch:r("reflink|nolink(?!\\()","g").replace("reflink",Z).replace("nolink",v).getRegex(),tag:C,text:/^(`+|[^`])(?:(?= {2,}\n)|[\s\S]*?(?:(?=[\\<!\[`*_]|\b_|$)|[^ ](?= {2,}\n)))/,url:s},M={...D,link:r(/^!?\[(label)\]\((.*?)\)/).replace("label",E).getRegex(),reflink:r(/^!?\[(label)\]\s*\[([^\]]*)\]/).replace("label",E).getRegex()},O={...D,escape:r(y).replace("])","~|])").getRegex(),url:r(/^((?:ftp|https?):\/\/|www\.)(?:[a-zA-Z0-9\-]+\.?)+[^\s<]*|^email/,"i").replace("email",/[A-Za-z0-9._+-]+(@)[a-zA-Z0-9-_]+(?:\.[a-zA-Z0-9-_]*[a-zA-Z0-9])+(?![-_])/).getRegex(),_backpedal:/(?:[^?!.,:;*_'"~()&]+|\([^)]*\)|&(?![a-zA-Z0-9]+;$)|[?!.,:;*_'"~)]+(?!$))+/,del:/^(~~?)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/,text:/^([`~]+|[^`~])(?:(?= {2,}\n)|(?=[a-zA-Z0-9.!#$%&'*+\/=?_`{\|}~-]+@)|[\s\S]*?(?:(?=[\\<!\[`*~_]|\b_|https?:\/\/|ftp:\/\/|www\.|$)|[^ ](?= {2,}\n)|[^a-zA-Z0-9.!#$%&'*+\/=?_`{\|}~-](?=[a-zA-Z0-9.!#$%&'*+\/=?_`{\|}~-]+@)))/},Q={...O,br:r($).replace("{2,}","*").getRegex(),text:r(O.text).replace("\\b_","\\b_| {2,}\\n").replace(/\{2,\}/g,"*").getRegex()},j={normal:x,gfm:w,pedantic:m},N={normal:D,gfm:O,breaks:Q,pedantic:M},G={"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"},H=e=>G[e];function X(e,t){if(t){if(i.escapeTest.test(e))return e.replace(i.escapeReplace,H)}else if(i.escapeTestNoEncode.test(e))return e.replace(i.escapeReplaceNoEncode,H);return e}function F(e){try{e=encodeURI(e).replace(i.percentDecode,"%")}catch{return null}return e}function U(e,t){const n=e.replace(i.findPipe,((e,t,n)=>{let s=!1,r=t;for(;--r>=0&&"\\"===n[r];)s=!s;return s?"|":" |"})).split(i.splitPipe);let s=0;if(n[0].trim()||n.shift(),n.length>0&&!n.at(-1)?.trim()&&n.pop(),t)if(n.length>t)n.splice(t);else for(;n.length<t;)n.push("");for(;s<n.length;s++)n[s]=n[s].trim().replace(i.slashPipe,"|");return n}function J(e,t,n){const s=e.length;if(0===s)return"";let r=0;for(;r<s;){const i=e.charAt(s-r-1);if(i!==t||n){if(i===t||!n)break;r++}else r++}return e.slice(0,s-r)}function K(e,t,n,s,r){const i=t.href,l=t.title||null,o=e[1].replace(r.other.outputLinkReplace,"$1");if("!"!==e[0].charAt(0)){s.state.inLink=!0;const e={type:"link",raw:n,href:i,title:l,text:o,tokens:s.inlineTokens(o)};return s.state.inLink=!1,e}return{type:"image",raw:n,href:i,title:l,text:o}}class V{options;rules;lexer;constructor(t){this.options=t||e.defaults}space(e){const t=this.rules.block.newline.exec(e);if(t&&t[0].length>0)return{type:"space",raw:t[0]}}code(e){const t=this.rules.block.code.exec(e);if(t){const e=t[0].replace(this.rules.other.codeRemoveIndent,"");return{type:"code",raw:t[0],codeBlockStyle:"indented",text:this.options.pedantic?e:J(e,"\n")}}}fences(e){const t=this.rules.block.fences.exec(e);if(t){const e=t[0],n=function(e,t,n){const s=e.match(n.other.indentCodeCompensation);if(null===s)return t;const r=s[1];return t.split("\n").map((e=>{const t=e.match(n.other.beginningSpace);if(null===t)return e;const[s]=t;return s.length>=r.length?e.slice(r.length):e})).join("\n")}(e,t[3]||"",this.rules);return{type:"code",raw:e,lang:t[2]?t[2].trim().replace(this.rules.inline.anyPunctuation,"$1"):t[2],text:n}}}heading(e){const t=this.rules.block.heading.exec(e);if(t){let e=t[2].trim();if(this.rules.other.endingHash.test(e)){const t=J(e,"#");this.options.pedantic?e=t.trim():t&&!this.rules.other.endingSpaceChar.test(t)||(e=t.trim())}return{type:"heading",raw:t[0],depth:t[1].length,text:e,tokens:this.lexer.inline(e)}}}hr(e){const t=this.rules.block.hr.exec(e);if(t)return{type:"hr",raw:J(t[0],"\n")}}blockquote(e){const t=this.rules.block.blockquote.exec(e);if(t){let e=J(t[0],"\n").split("\n"),n="",s="";const r=[];for(;e.length>0;){let t=!1;const i=[];let l;for(l=0;l<e.length;l++)if(this.rules.other.blockquoteStart.test(e[l]))i.push(e[l]),t=!0;else{if(t)break;i.push(e[l])}e=e.slice(l);const o=i.join("\n"),a=o.replace(this.rules.other.blockquoteSetextReplace,"\n    $1").replace(this.rules.other.blockquoteSetextReplace2,"");n=n?`${n}\n${o}`:o,s=s?`${s}\n${a}`:a;const c=this.lexer.state.top;if(this.lexer.state.top=!0,this.lexer.blockTokens(a,r,!0),this.lexer.state.top=c,0===e.length)break;const h=r.at(-1);if("code"===h?.type)break;if("blockquote"===h?.type){const t=h,i=t.raw+"\n"+e.join("\n"),l=this.blockquote(i);r[r.length-1]=l,n=n.substring(0,n.length-t.raw.length)+l.raw,s=s.substring(0,s.length-t.text.length)+l.text;break}if("list"!==h?.type);else{const t=h,i=t.raw+"\n"+e.join("\n"),l=this.list(i);r[r.length-1]=l,n=n.substring(0,n.length-h.raw.length)+l.raw,s=s.substring(0,s.length-t.raw.length)+l.raw,e=i.substring(r.at(-1).raw.length).split("\n")}}return{type:"blockquote",raw:n,tokens:r,text:s}}}list(e){let t=this.rules.block.list.exec(e);if(t){let n=t[1].trim();const s=n.length>1,r={type:"list",raw:"",ordered:s,start:s?+n.slice(0,-1):"",loose:!1,items:[]};n=s?`\\d{1,9}\\${n.slice(-1)}`:`\\${n}`,this.options.pedantic&&(n=s?n:"[*+-]");const i=this.rules.other.listItemRegex(n);let l=!1;for(;e;){let n=!1,s="",o="";if(!(t=i.exec(e)))break;if(this.rules.block.hr.test(e))break;s=t[0],e=e.substring(s.length);let a=t[2].split("\n",1)[0].replace(this.rules.other.listReplaceTabs,(e=>" ".repeat(3*e.length))),c=e.split("\n",1)[0],h=!a.trim(),p=0;if(this.options.pedantic?(p=2,o=a.trimStart()):h?p=t[1].length+1:(p=t[2].search(this.rules.other.nonSpaceChar),p=p>4?1:p,o=a.slice(p),p+=t[1].length),h&&this.rules.other.blankLine.test(c)&&(s+=c+"\n",e=e.substring(c.length+1),n=!0),!n){const t=this.rules.other.nextBulletRegex(p),n=this.rules.other.hrRegex(p),r=this.rules.other.fencesBeginRegex(p),i=this.rules.other.headingBeginRegex(p),l=this.rules.other.htmlBeginRegex(p);for(;e;){const u=e.split("\n",1)[0];let g;if(c=u,this.options.pedantic?(c=c.replace(this.rules.other.listReplaceNesting,"  "),g=c):g=c.replace(this.rules.other.tabCharGlobal,"    "),r.test(c))break;if(i.test(c))break;if(l.test(c))break;if(t.test(c))break;if(n.test(c))break;if(g.search(this.rules.other.nonSpaceChar)>=p||!c.trim())o+="\n"+g.slice(p);else{if(h)break;if(a.replace(this.rules.other.tabCharGlobal,"    ").search(this.rules.other.nonSpaceChar)>=4)break;if(r.test(a))break;if(i.test(a))break;if(n.test(a))break;o+="\n"+c}h||c.trim()||(h=!0),s+=u+"\n",e=e.substring(u.length+1),a=g.slice(p)}}r.loose||(l?r.loose=!0:this.rules.other.doubleBlankLine.test(s)&&(l=!0));let u,g=null;this.options.gfm&&(g=this.rules.other.listIsTask.exec(o),g&&(u="[ ] "!==g[0],o=o.replace(this.rules.other.listReplaceTask,""))),r.items.push({type:"list_item",raw:s,task:!!g,checked:u,loose:!1,text:o,tokens:[]}),r.raw+=s}const o=r.items.at(-1);if(!o)return;o.raw=o.raw.trimEnd(),o.text=o.text.trimEnd(),r.raw=r.raw.trimEnd();for(let e=0;e<r.items.length;e++)if(this.lexer.state.top=!1,r.items[e].tokens=this.lexer.blockTokens(r.items[e].text,[]),!r.loose){const t=r.items[e].tokens.filter((e=>"space"===e.type)),n=t.length>0&&t.some((e=>this.rules.other.anyLine.test(e.raw)));r.loose=n}if(r.loose)for(let e=0;e<r.items.length;e++)r.items[e].loose=!0;return r}}html(e){const t=this.rules.block.html.exec(e);if(t){return{type:"html",block:!0,raw:t[0],pre:"pre"===t[1]||"script"===t[1]||"style"===t[1],text:t[0]}}}def(e){const t=this.rules.block.def.exec(e);if(t){const e=t[1].toLowerCase().replace(this.rules.other.multipleSpaceGlobal," "),n=t[2]?t[2].replace(this.rules.other.hrefBrackets,"$1").replace(this.rules.inline.anyPunctuation,"$1"):"",s=t[3]?t[3].substring(1,t[3].length-1).replace(this.rules.inline.anyPunctuation,"$1"):t[3];return{type:"def",tag:e,raw:t[0],href:n,title:s}}}table(e){const t=this.rules.block.table.exec(e);if(!t)return;if(!this.rules.other.tableDelimiter.test(t[2]))return;const n=U(t[1]),s=t[2].replace(this.rules.other.tableAlignChars,"").split("|"),r=t[3]?.trim()?t[3].replace(this.rules.other.tableRowBlankLine,"").split("\n"):[],i={type:"table",raw:t[0],header:[],align:[],rows:[]};if(n.length===s.length){for(const e of s)this.rules.other.tableAlignRight.test(e)?i.align.push("right"):this.rules.other.tableAlignCenter.test(e)?i.align.push("center"):this.rules.other.tableAlignLeft.test(e)?i.align.push("left"):i.align.push(null);for(let e=0;e<n.length;e++)i.header.push({text:n[e],tokens:this.lexer.inline(n[e]),header:!0,align:i.align[e]});for(const e of r)i.rows.push(U(e,i.header.length).map(((e,t)=>({text:e,tokens:this.lexer.inline(e),header:!1,align:i.align[t]}))));return i}}lheading(e){const t=this.rules.block.lheading.exec(e);if(t)return{type:"heading",raw:t[0],depth:"="===t[2].charAt(0)?1:2,text:t[1],tokens:this.lexer.inline(t[1])}}paragraph(e){const t=this.rules.block.paragraph.exec(e);if(t){const e="\n"===t[1].charAt(t[1].length-1)?t[1].slice(0,-1):t[1];return{type:"paragraph",raw:t[0],text:e,tokens:this.lexer.inline(e)}}}text(e){const t=this.rules.block.text.exec(e);if(t)return{type:"text",raw:t[0],text:t[0],tokens:this.lexer.inline(t[0])}}escape(e){const t=this.rules.inline.escape.exec(e);if(t)return{type:"escape",raw:t[0],text:t[1]}}tag(e){const t=this.rules.inline.tag.exec(e);if(t)return!this.lexer.state.inLink&&this.rules.other.startATag.test(t[0])?this.lexer.state.inLink=!0:this.lexer.state.inLink&&this.rules.other.endATag.test(t[0])&&(this.lexer.state.inLink=!1),!this.lexer.state.inRawBlock&&this.rules.other.startPreScriptTag.test(t[0])?this.lexer.state.inRawBlock=!0:this.lexer.state.inRawBlock&&this.rules.other.endPreScriptTag.test(t[0])&&(this.lexer.state.inRawBlock=!1),{type:"html",raw:t[0],inLink:this.lexer.state.inLink,inRawBlock:this.lexer.state.inRawBlock,block:!1,text:t[0]}}link(e){const t=this.rules.inline.link.exec(e);if(t){const e=t[2].trim();if(!this.options.pedantic&&this.rules.other.startAngleBracket.test(e)){if(!this.rules.other.endAngleBracket.test(e))return;const t=J(e.slice(0,-1),"\\");if((e.length-t.length)%2==0)return}else{const e=function(e,t){if(-1===e.indexOf(t[1]))return-1;let n=0;for(let s=0;s<e.length;s++)if("\\"===e[s])s++;else if(e[s]===t[0])n++;else if(e[s]===t[1]&&(n--,n<0))return s;return-1}(t[2],"()");if(e>-1){const n=(0===t[0].indexOf("!")?5:4)+t[1].length+e;t[2]=t[2].substring(0,e),t[0]=t[0].substring(0,n).trim(),t[3]=""}}let n=t[2],s="";if(this.options.pedantic){const e=this.rules.other.pedanticHrefTitle.exec(n);e&&(n=e[1],s=e[3])}else s=t[3]?t[3].slice(1,-1):"";return n=n.trim(),this.rules.other.startAngleBracket.test(n)&&(n=this.options.pedantic&&!this.rules.other.endAngleBracket.test(e)?n.slice(1):n.slice(1,-1)),K(t,{href:n?n.replace(this.rules.inline.anyPunctuation,"$1"):n,title:s?s.replace(this.rules.inline.anyPunctuation,"$1"):s},t[0],this.lexer,this.rules)}}reflink(e,t){let n;if((n=this.rules.inline.reflink.exec(e))||(n=this.rules.inline.nolink.exec(e))){const e=t[(n[2]||n[1]).replace(this.rules.other.multipleSpaceGlobal," ").toLowerCase()];if(!e){const e=n[0].charAt(0);return{type:"text",raw:e,text:e}}return K(n,e,n[0],this.lexer,this.rules)}}emStrong(e,t,n=""){let s=this.rules.inline.emStrongLDelim.exec(e);if(!s)return;if(s[3]&&n.match(this.rules.other.unicodeAlphaNumeric))return;if(!(s[1]||s[2]||"")||!n||this.rules.inline.punctuation.exec(n)){const n=[...s[0]].length-1;let r,i,l=n,o=0;const a="*"===s[0][0]?this.rules.inline.emStrongRDelimAst:this.rules.inline.emStrongRDelimUnd;for(a.lastIndex=0,t=t.slice(-1*e.length+n);null!=(s=a.exec(t));){if(r=s[1]||s[2]||s[3]||s[4]||s[5]||s[6],!r)continue;if(i=[...r].length,s[3]||s[4]){l+=i;continue}if((s[5]||s[6])&&n%3&&!((n+i)%3)){o+=i;continue}if(l-=i,l>0)continue;i=Math.min(i,i+l+o);const t=[...s[0]][0].length,a=e.slice(0,n+s.index+t+i);if(Math.min(n,i)%2){const e=a.slice(1,-1);return{type:"em",raw:a,text:e,tokens:this.lexer.inlineTokens(e)}}const c=a.slice(2,-2);return{type:"strong",raw:a,text:c,tokens:this.lexer.inlineTokens(c)}}}}codespan(e){const t=this.rules.inline.code.exec(e);if(t){let e=t[2].replace(this.rules.other.newLineCharGlobal," ");const n=this.rules.other.nonSpaceChar.test(e),s=this.rules.other.startingSpaceChar.test(e)&&this.rules.other.endingSpaceChar.test(e);return n&&s&&(e=e.substring(1,e.length-1)),{type:"codespan",raw:t[0],text:e}}}br(e){const t=this.rules.inline.br.exec(e);if(t)return{type:"br",raw:t[0]}}del(e){const t=this.rules.inline.del.exec(e);if(t)return{type:"del",raw:t[0],text:t[2],tokens:this.lexer.inlineTokens(t[2])}}autolink(e){const t=this.rules.inline.autolink.exec(e);if(t){let e,n;return"@"===t[2]?(e=t[1],n="mailto:"+e):(e=t[1],n=e),{type:"link",raw:t[0],text:e,href:n,tokens:[{type:"text",raw:e,text:e}]}}}url(e){let t;if(t=this.rules.inline.url.exec(e)){let e,n;if("@"===t[2])e=t[0],n="mailto:"+e;else{let s;do{s=t[0],t[0]=this.rules.inline._backpedal.exec(t[0])?.[0]??""}while(s!==t[0]);e=t[0],n="www."===t[1]?"http://"+t[0]:t[0]}return{type:"link",raw:t[0],text:e,href:n,tokens:[{type:"text",raw:e,text:e}]}}}inlineText(e){const t=this.rules.inline.text.exec(e);if(t){const e=this.lexer.state.inRawBlock;return{type:"text",raw:t[0],text:t[0],escaped:e}}}}class W{tokens;options;state;tokenizer;inlineQueue;constructor(t){this.tokens=[],this.tokens.links=Object.create(null),this.options=t||e.defaults,this.options.tokenizer=this.options.tokenizer||new V,this.tokenizer=this.options.tokenizer,this.tokenizer.options=this.options,this.tokenizer.lexer=this,this.inlineQueue=[],this.state={inLink:!1,inRawBlock:!1,top:!0};const n={other:i,block:j.normal,inline:N.normal};this.options.pedantic?(n.block=j.pedantic,n.inline=N.pedantic):this.options.gfm&&(n.block=j.gfm,this.options.breaks?n.inline=N.breaks:n.inline=N.gfm),this.tokenizer.rules=n}static get rules(){return{block:j,inline:N}}static lex(e,t){return new W(t).lex(e)}static lexInline(e,t){return new W(t).inlineTokens(e)}lex(e){e=e.replace(i.carriageReturn,"\n"),this.blockTokens(e,this.tokens);for(let e=0;e<this.inlineQueue.length;e++){const t=this.inlineQueue[e];this.inlineTokens(t.src,t.tokens)}return this.inlineQueue=[],this.tokens}blockTokens(e,t=[],n=!1){for(this.options.pedantic&&(e=e.replace(i.tabCharGlobal,"    ").replace(i.spaceLine,""));e;){let s;if(this.options.extensions?.block?.some((n=>!!(s=n.call({lexer:this},e,t))&&(e=e.substring(s.raw.length),t.push(s),!0))))continue;if(s=this.tokenizer.space(e)){e=e.substring(s.raw.length);const n=t.at(-1);1===s.raw.length&&void 0!==n?n.raw+="\n":t.push(s);continue}if(s=this.tokenizer.code(e)){e=e.substring(s.raw.length);const n=t.at(-1);"paragraph"===n?.type||"text"===n?.type?(n.raw+="\n"+s.raw,n.text+="\n"+s.text,this.inlineQueue.at(-1).src=n.text):t.push(s);continue}if(s=this.tokenizer.fences(e)){e=e.substring(s.raw.length),t.push(s);continue}if(s=this.tokenizer.heading(e)){e=e.substring(s.raw.length),t.push(s);continue}if(s=this.tokenizer.hr(e)){e=e.substring(s.raw.length),t.push(s);continue}if(s=this.tokenizer.blockquote(e)){e=e.substring(s.raw.length),t.push(s);continue}if(s=this.tokenizer.list(e)){e=e.substring(s.raw.length),t.push(s);continue}if(s=this.tokenizer.html(e)){e=e.substring(s.raw.length),t.push(s);continue}if(s=this.tokenizer.def(e)){e=e.substring(s.raw.length);const n=t.at(-1);"paragraph"===n?.type||"text"===n?.type?(n.raw+="\n"+s.raw,n.text+="\n"+s.raw,this.inlineQueue.at(-1).src=n.text):this.tokens.links[s.tag]||(this.tokens.links[s.tag]={href:s.href,title:s.title});continue}if(s=this.tokenizer.table(e)){e=e.substring(s.raw.length),t.push(s);continue}if(s=this.tokenizer.lheading(e)){e=e.substring(s.raw.length),t.push(s);continue}let r=e;if(this.options.extensions?.startBlock){let t=1/0;const n=e.slice(1);let s;this.options.extensions.startBlock.forEach((e=>{s=e.call({lexer:this},n),"number"==typeof s&&s>=0&&(t=Math.min(t,s))})),t<1/0&&t>=0&&(r=e.substring(0,t+1))}if(this.state.top&&(s=this.tokenizer.paragraph(r))){const i=t.at(-1);n&&"paragraph"===i?.type?(i.raw+="\n"+s.raw,i.text+="\n"+s.text,this.inlineQueue.pop(),this.inlineQueue.at(-1).src=i.text):t.push(s),n=r.length!==e.length,e=e.substring(s.raw.length)}else if(s=this.tokenizer.text(e)){e=e.substring(s.raw.length);const n=t.at(-1);"text"===n?.type?(n.raw+="\n"+s.raw,n.text+="\n"+s.text,this.inlineQueue.pop(),this.inlineQueue.at(-1).src=n.text):t.push(s)}else if(e){const t="Infinite loop on byte: "+e.charCodeAt(0);if(this.options.silent){console.error(t);break}throw new Error(t)}}return this.state.top=!0,t}inline(e,t=[]){return this.inlineQueue.push({src:e,tokens:t}),t}inlineTokens(e,t=[]){let n=e,s=null;if(this.tokens.links){const e=Object.keys(this.tokens.links);if(e.length>0)for(;null!=(s=this.tokenizer.rules.inline.reflinkSearch.exec(n));)e.includes(s[0].slice(s[0].lastIndexOf("[")+1,-1))&&(n=n.slice(0,s.index)+"["+"a".repeat(s[0].length-2)+"]"+n.slice(this.tokenizer.rules.inline.reflinkSearch.lastIndex))}for(;null!=(s=this.tokenizer.rules.inline.blockSkip.exec(n));)n=n.slice(0,s.index)+"["+"a".repeat(s[0].length-2)+"]"+n.slice(this.tokenizer.rules.inline.blockSkip.lastIndex);for(;null!=(s=this.tokenizer.rules.inline.anyPunctuation.exec(n));)n=n.slice(0,s.index)+"++"+n.slice(this.tokenizer.rules.inline.anyPunctuation.lastIndex);let r=!1,i="";for(;e;){let s;if(r||(i=""),r=!1,this.options.extensions?.inline?.some((n=>!!(s=n.call({lexer:this},e,t))&&(e=e.substring(s.raw.length),t.push(s),!0))))continue;if(s=this.tokenizer.escape(e)){e=e.substring(s.raw.length),t.push(s);continue}if(s=this.tokenizer.tag(e)){e=e.substring(s.raw.length),t.push(s);continue}if(s=this.tokenizer.link(e)){e=e.substring(s.raw.length),t.push(s);continue}if(s=this.tokenizer.reflink(e,this.tokens.links)){e=e.substring(s.raw.length);const n=t.at(-1);"text"===s.type&&"text"===n?.type?(n.raw+=s.raw,n.text+=s.text):t.push(s);continue}if(s=this.tokenizer.emStrong(e,n,i)){e=e.substring(s.raw.length),t.push(s);continue}if(s=this.tokenizer.codespan(e)){e=e.substring(s.raw.length),t.push(s);continue}if(s=this.tokenizer.br(e)){e=e.substring(s.raw.length),t.push(s);continue}if(s=this.tokenizer.del(e)){e=e.substring(s.raw.length),t.push(s);continue}if(s=this.tokenizer.autolink(e)){e=e.substring(s.raw.length),t.push(s);continue}if(!this.state.inLink&&(s=this.tokenizer.url(e))){e=e.substring(s.raw.length),t.push(s);continue}let l=e;if(this.options.extensions?.startInline){let t=1/0;const n=e.slice(1);let s;this.options.extensions.startInline.forEach((e=>{s=e.call({lexer:this},n),"number"==typeof s&&s>=0&&(t=Math.min(t,s))})),t<1/0&&t>=0&&(l=e.substring(0,t+1))}if(s=this.tokenizer.inlineText(l)){e=e.substring(s.raw.length),"_"!==s.raw.slice(-1)&&(i=s.raw.slice(-1)),r=!0;const n=t.at(-1);"text"===n?.type?(n.raw+=s.raw,n.text+=s.text):t.push(s)}else if(e){const t="Infinite loop on byte: "+e.charCodeAt(0);if(this.options.silent){console.error(t);break}throw new Error(t)}}return t}}class Y{options;parser;constructor(t){this.options=t||e.defaults}space(e){return""}code({text:e,lang:t,escaped:n}){const s=(t||"").match(i.notSpaceStart)?.[0],r=e.replace(i.endingNewline,"")+"\n";return s?'<pre><code class="language-'+X(s)+'">'+(n?r:X(r,!0))+"</code></pre>\n":"<pre><code>"+(n?r:X(r,!0))+"</code></pre>\n"}blockquote({tokens:e}){return`<blockquote>\n${this.parser.parse(e)}</blockquote>\n`}html({text:e}){return e}heading({tokens:e,depth:t}){return`<h${t}>${this.parser.parseInline(e)}</h${t}>\n`}hr(e){return"<hr>\n"}list(e){const t=e.ordered,n=e.start;let s="";for(let t=0;t<e.items.length;t++){const n=e.items[t];s+=this.listitem(n)}const r=t?"ol":"ul";return"<"+r+(t&&1!==n?' start="'+n+'"':"")+">\n"+s+"</"+r+">\n"}listitem(e){let t="";if(e.task){const n=this.checkbox({checked:!!e.checked});e.loose?"paragraph"===e.tokens[0]?.type?(e.tokens[0].text=n+" "+e.tokens[0].text,e.tokens[0].tokens&&e.tokens[0].tokens.length>0&&"text"===e.tokens[0].tokens[0].type&&(e.tokens[0].tokens[0].text=n+" "+X(e.tokens[0].tokens[0].text),e.tokens[0].tokens[0].escaped=!0)):e.tokens.unshift({type:"text",raw:n+" ",text:n+" ",escaped:!0}):t+=n+" "}return t+=this.parser.parse(e.tokens,!!e.loose),`<li>${t}</li>\n`}checkbox({checked:e}){return"<input "+(e?'checked="" ':"")+'disabled="" type="checkbox">'}paragraph({tokens:e}){return`<p>${this.parser.parseInline(e)}</p>\n`}table(e){let t="",n="";for(let t=0;t<e.header.length;t++)n+=this.tablecell(e.header[t]);t+=this.tablerow({text:n});let s="";for(let t=0;t<e.rows.length;t++){const r=e.rows[t];n="";for(let e=0;e<r.length;e++)n+=this.tablecell(r[e]);s+=this.tablerow({text:n})}return s&&(s=`<tbody>${s}</tbody>`),"<table>\n<thead>\n"+t+"</thead>\n"+s+"</table>\n"}tablerow({text:e}){return`<tr>\n${e}</tr>\n`}tablecell(e){const t=this.parser.parseInline(e.tokens),n=e.header?"th":"td";return(e.align?`<${n} align="${e.align}">`:`<${n}>`)+t+`</${n}>\n`}strong({tokens:e}){return`<strong>${this.parser.parseInline(e)}</strong>`}em({tokens:e}){return`<em>${this.parser.parseInline(e)}</em>`}codespan({text:e}){return`<code>${X(e,!0)}</code>`}br(e){return"<br>"}del({tokens:e}){return`<del>${this.parser.parseInline(e)}</del>`}link({href:e,title:t,tokens:n}){const s=this.parser.parseInline(n),r=F(e);if(null===r)return s;let i='<a href="'+(e=r)+'"';return t&&(i+=' title="'+X(t)+'"'),i+=">"+s+"</a>",i}image({href:e,title:t,text:n}){const s=F(e);if(null===s)return X(n);let r=`<img src="${e=s}" alt="${n}"`;return t&&(r+=` title="${X(t)}"`),r+=">",r}text(e){return"tokens"in e&&e.tokens?this.parser.parseInline(e.tokens):"escaped"in e&&e.escaped?e.text:X(e.text)}}class ee{strong({text:e}){return e}em({text:e}){return e}codespan({text:e}){return e}del({text:e}){return e}html({text:e}){return e}text({text:e}){return e}link({text:e}){return""+e}image({text:e}){return""+e}br(){return""}}class te{options;renderer;textRenderer;constructor(t){this.options=t||e.defaults,this.options.renderer=this.options.renderer||new Y,this.renderer=this.options.renderer,this.renderer.options=this.options,this.renderer.parser=this,this.textRenderer=new ee}static parse(e,t){return new te(t).parse(e)}static parseInline(e,t){return new te(t).parseInline(e)}parse(e,t=!0){let n="";for(let s=0;s<e.length;s++){const r=e[s];if(this.options.extensions?.renderers?.[r.type]){const e=r,t=this.options.extensions.renderers[e.type].call({parser:this},e);if(!1!==t||!["space","hr","heading","code","table","blockquote","list","html","paragraph","text"].includes(e.type)){n+=t||"";continue}}const i=r;switch(i.type){case"space":n+=this.renderer.space(i);continue;case"hr":n+=this.renderer.hr(i);continue;case"heading":n+=this.renderer.heading(i);continue;case"code":n+=this.renderer.code(i);continue;case"table":n+=this.renderer.table(i);continue;case"blockquote":n+=this.renderer.blockquote(i);continue;case"list":n+=this.renderer.list(i);continue;case"html":n+=this.renderer.html(i);continue;case"paragraph":n+=this.renderer.paragraph(i);continue;case"text":{let r=i,l=this.renderer.text(r);for(;s+1<e.length&&"text"===e[s+1].type;)r=e[++s],l+="\n"+this.renderer.text(r);n+=t?this.renderer.paragraph({type:"paragraph",raw:l,text:l,tokens:[{type:"text",raw:l,text:l,escaped:!0}]}):l;continue}default:{const e='Token with "'+i.type+'" type was not found.';if(this.options.silent)return console.error(e),"";throw new Error(e)}}}return n}parseInline(e,t=this.renderer){let n="";for(let s=0;s<e.length;s++){const r=e[s];if(this.options.extensions?.renderers?.[r.type]){const e=this.options.extensions.renderers[r.type].call({parser:this},r);if(!1!==e||!["escape","html","link","image","strong","em","codespan","br","del","text"].includes(r.type)){n+=e||"";continue}}const i=r;switch(i.type){case"escape":case"text":n+=t.text(i);break;case"html":n+=t.html(i);break;case"link":n+=t.link(i);break;case"image":n+=t.image(i);break;case"strong":n+=t.strong(i);break;case"em":n+=t.em(i);break;case"codespan":n+=t.codespan(i);break;case"br":n+=t.br(i);break;case"del":n+=t.del(i);break;default:{const e='Token with "'+i.type+'" type was not found.';if(this.options.silent)return console.error(e),"";throw new Error(e)}}}return n}}class ne{options;block;constructor(t){this.options=t||e.defaults}static passThroughHooks=new Set(["preprocess","postprocess","processAllTokens"]);preprocess(e){return e}postprocess(e){return e}processAllTokens(e){return e}provideLexer(){return this.block?W.lex:W.lexInline}provideParser(){return this.block?te.parse:te.parseInline}}class se{defaults={async:!1,breaks:!1,extensions:null,gfm:!0,hooks:null,pedantic:!1,renderer:null,silent:!1,tokenizer:null,walkTokens:null};options=this.setOptions;parse=this.parseMarkdown(!0);parseInline=this.parseMarkdown(!1);Parser=te;Renderer=Y;TextRenderer=ee;Lexer=W;Tokenizer=V;Hooks=ne;constructor(...e){this.use(...e)}walkTokens(e,t){let n=[];for(const s of e)switch(n=n.concat(t.call(this,s)),s.type){case"table":{const e=s;for(const s of e.header)n=n.concat(this.walkTokens(s.tokens,t));for(const s of e.rows)for(const e of s)n=n.concat(this.walkTokens(e.tokens,t));break}case"list":{const e=s;n=n.concat(this.walkTokens(e.items,t));break}default:{const e=s;this.defaults.extensions?.childTokens?.[e.type]?this.defaults.extensions.childTokens[e.type].forEach((s=>{const r=e[s].flat(1/0);n=n.concat(this.walkTokens(r,t))})):e.tokens&&(n=n.concat(this.walkTokens(e.tokens,t)))}}return n}use(...e){const t=this.defaults.extensions||{renderers:{},childTokens:{}};return e.forEach((e=>{const n={...e};if(n.async=this.defaults.async||n.async||!1,e.extensions&&(e.extensions.forEach((e=>{if(!e.name)throw new Error("extension name required");if("renderer"in e){const n=t.renderers[e.name];t.renderers[e.name]=n?function(...t){let s=e.renderer.apply(this,t);return!1===s&&(s=n.apply(this,t)),s}:e.renderer}if("tokenizer"in e){if(!e.level||"block"!==e.level&&"inline"!==e.level)throw new Error("extension level must be 'block' or 'inline'");const n=t[e.level];n?n.unshift(e.tokenizer):t[e.level]=[e.tokenizer],e.start&&("block"===e.level?t.startBlock?t.startBlock.push(e.start):t.startBlock=[e.start]:"inline"===e.level&&(t.startInline?t.startInline.push(e.start):t.startInline=[e.start]))}"childTokens"in e&&e.childTokens&&(t.childTokens[e.name]=e.childTokens)})),n.extensions=t),e.renderer){const t=this.defaults.renderer||new Y(this.defaults);for(const n in e.renderer){if(!(n in t))throw new Error(`renderer '${n}' does not exist`);if(["options","parser"].includes(n))continue;const s=n,r=e.renderer[s],i=t[s];t[s]=(...e)=>{let n=r.apply(t,e);return!1===n&&(n=i.apply(t,e)),n||""}}n.renderer=t}if(e.tokenizer){const t=this.defaults.tokenizer||new V(this.defaults);for(const n in e.tokenizer){if(!(n in t))throw new Error(`tokenizer '${n}' does not exist`);if(["options","rules","lexer"].includes(n))continue;const s=n,r=e.tokenizer[s],i=t[s];t[s]=(...e)=>{let n=r.apply(t,e);return!1===n&&(n=i.apply(t,e)),n}}n.tokenizer=t}if(e.hooks){const t=this.defaults.hooks||new ne;for(const n in e.hooks){if(!(n in t))throw new Error(`hook '${n}' does not exist`);if(["options","block"].includes(n))continue;const s=n,r=e.hooks[s],i=t[s];ne.passThroughHooks.has(n)?t[s]=e=>{if(this.defaults.async)return Promise.resolve(r.call(t,e)).then((e=>i.call(t,e)));const n=r.call(t,e);return i.call(t,n)}:t[s]=(...e)=>{let n=r.apply(t,e);return!1===n&&(n=i.apply(t,e)),n}}n.hooks=t}if(e.walkTokens){const t=this.defaults.walkTokens,s=e.walkTokens;n.walkTokens=function(e){let n=[];return n.push(s.call(this,e)),t&&(n=n.concat(t.call(this,e))),n}}this.defaults={...this.defaults,...n}})),this}setOptions(e){return this.defaults={...this.defaults,...e},this}lexer(e,t){return W.lex(e,t??this.defaults)}parser(e,t){return te.parse(e,t??this.defaults)}parseMarkdown(e){return(t,n)=>{const s={...n},r={...this.defaults,...s},i=this.onError(!!r.silent,!!r.async);if(!0===this.defaults.async&&!1===s.async)return i(new Error("marked(): The async option was set to true by an extension. Remove async: false from the parse options object to return a Promise."));if(null==t)return i(new Error("marked(): input parameter is undefined or null"));if("string"!=typeof t)return i(new Error("marked(): input parameter is of type "+Object.prototype.toString.call(t)+", string expected"));r.hooks&&(r.hooks.options=r,r.hooks.block=e);const l=r.hooks?r.hooks.provideLexer():e?W.lex:W.lexInline,o=r.hooks?r.hooks.provideParser():e?te.parse:te.parseInline;if(r.async)return Promise.resolve(r.hooks?r.hooks.preprocess(t):t).then((e=>l(e,r))).then((e=>r.hooks?r.hooks.processAllTokens(e):e)).then((e=>r.walkTokens?Promise.all(this.walkTokens(e,r.walkTokens)).then((()=>e)):e)).then((e=>o(e,r))).then((e=>r.hooks?r.hooks.postprocess(e):e)).catch(i);try{r.hooks&&(t=r.hooks.preprocess(t));let e=l(t,r);r.hooks&&(e=r.hooks.processAllTokens(e)),r.walkTokens&&this.walkTokens(e,r.walkTokens);let n=o(e,r);return r.hooks&&(n=r.hooks.postprocess(n)),n}catch(e){return i(e)}}}onError(e,t){return n=>{if(n.message+="\nPlease report this to https://github.com/markedjs/marked.",e){const e="<p>An error occurred:</p><pre>"+X(n.message+"",!0)+"</pre>";return t?Promise.resolve(e):e}if(t)return Promise.reject(n);throw n}}}const re=new se;function ie(e,t){return re.parse(e,t)}ie.options=ie.setOptions=function(e){return re.setOptions(e),ie.defaults=re.defaults,n(ie.defaults),ie},ie.getDefaults=t,ie.defaults=e.defaults,ie.use=function(...e){return re.use(...e),ie.defaults=re.defaults,n(ie.defaults),ie},ie.walkTokens=function(e,t){return re.walkTokens(e,t)},ie.parseInline=re.parseInline,ie.Parser=te,ie.parser=te.parse,ie.Renderer=Y,ie.TextRenderer=ee,ie.Lexer=W,ie.lexer=W.lex,ie.Tokenizer=V,ie.Hooks=ne,ie.parse=ie;const le=ie.options,oe=ie.setOptions,ae=ie.use,ce=ie.walkTokens,he=ie.parseInline,pe=ie,ue=te.parse,ge=W.lex;e.Hooks=ne,e.Lexer=W,e.Marked=se,e.Parser=te,e.Renderer=Y,e.TextRenderer=ee,e.Tokenizer=V,e.getDefaults=t,e.lexer=ge,e.marked=ie,e.options=le,e.parse=pe,e.parseInline=he,e.parser=ue,e.setOptions=oe,e.use=ae,e.walkTokens=ce}));
+</script>
+
+  <!-- highlight.js -->
+  <script>/*!
+  Highlight.js v11.9.0 (git: f47103d4f1)
+  (c) 2006-2023 undefined and other contributors
+  License: BSD-3-Clause
+ */
+var hljs=function(){"use strict";function e(n){
+return n instanceof Map?n.clear=n.delete=n.set=()=>{
+throw Error("map is read-only")}:n instanceof Set&&(n.add=n.clear=n.delete=()=>{
+throw Error("set is read-only")
+}),Object.freeze(n),Object.getOwnPropertyNames(n).forEach((t=>{
+const a=n[t],i=typeof a;"object"!==i&&"function"!==i||Object.isFrozen(a)||e(a)
+})),n}class n{constructor(e){
+void 0===e.data&&(e.data={}),this.data=e.data,this.isMatchIgnored=!1}
+ignoreMatch(){this.isMatchIgnored=!0}}function t(e){
+return e.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#x27;")
+}function a(e,...n){const t=Object.create(null);for(const n in e)t[n]=e[n]
+;return n.forEach((e=>{for(const n in e)t[n]=e[n]})),t}const i=e=>!!e.scope
+;class r{constructor(e,n){
+this.buffer="",this.classPrefix=n.classPrefix,e.walk(this)}addText(e){
+this.buffer+=t(e)}openNode(e){if(!i(e))return;const n=((e,{prefix:n})=>{
+if(e.startsWith("language:"))return e.replace("language:","language-")
+;if(e.includes(".")){const t=e.split(".")
+;return[`${n}${t.shift()}`,...t.map(((e,n)=>`${e}${"_".repeat(n+1)}`))].join(" ")
+}return`${n}${e}`})(e.scope,{prefix:this.classPrefix});this.span(n)}
+closeNode(e){i(e)&&(this.buffer+="</span>")}value(){return this.buffer}span(e){
+this.buffer+=`<span class="${e}">`}}const s=(e={})=>{const n={children:[]}
+;return Object.assign(n,e),n};class o{constructor(){
+this.rootNode=s(),this.stack=[this.rootNode]}get top(){
+return this.stack[this.stack.length-1]}get root(){return this.rootNode}add(e){
+this.top.children.push(e)}openNode(e){const n=s({scope:e})
+;this.add(n),this.stack.push(n)}closeNode(){
+if(this.stack.length>1)return this.stack.pop()}closeAllNodes(){
+for(;this.closeNode(););}toJSON(){return JSON.stringify(this.rootNode,null,4)}
+walk(e){return this.constructor._walk(e,this.rootNode)}static _walk(e,n){
+return"string"==typeof n?e.addText(n):n.children&&(e.openNode(n),
+n.children.forEach((n=>this._walk(e,n))),e.closeNode(n)),e}static _collapse(e){
+"string"!=typeof e&&e.children&&(e.children.every((e=>"string"==typeof e))?e.children=[e.children.join("")]:e.children.forEach((e=>{
+o._collapse(e)})))}}class l extends o{constructor(e){super(),this.options=e}
+addText(e){""!==e&&this.add(e)}startScope(e){this.openNode(e)}endScope(){
+this.closeNode()}__addSublanguage(e,n){const t=e.root
+;n&&(t.scope="language:"+n),this.add(t)}toHTML(){
+return new r(this,this.options).value()}finalize(){
+return this.closeAllNodes(),!0}}function c(e){
+return e?"string"==typeof e?e:e.source:null}function d(e){return b("(?=",e,")")}
+function g(e){return b("(?:",e,")*")}function u(e){return b("(?:",e,")?")}
+function b(...e){return e.map((e=>c(e))).join("")}function m(...e){const n=(e=>{
+const n=e[e.length-1]
+;return"object"==typeof n&&n.constructor===Object?(e.splice(e.length-1,1),n):{}
+})(e);return"("+(n.capture?"":"?:")+e.map((e=>c(e))).join("|")+")"}
+function p(e){return RegExp(e.toString()+"|").exec("").length-1}
+const _=/\[(?:[^\\\]]|\\.)*\]|\(\??|\\([1-9][0-9]*)|\\./
+;function h(e,{joinWith:n}){let t=0;return e.map((e=>{t+=1;const n=t
+;let a=c(e),i="";for(;a.length>0;){const e=_.exec(a);if(!e){i+=a;break}
+i+=a.substring(0,e.index),
+a=a.substring(e.index+e[0].length),"\\"===e[0][0]&&e[1]?i+="\\"+(Number(e[1])+n):(i+=e[0],
+"("===e[0]&&t++)}return i})).map((e=>`(${e})`)).join(n)}
+const f="[a-zA-Z]\\w*",E="[a-zA-Z_]\\w*",y="\\b\\d+(\\.\\d+)?",N="(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)",w="\\b(0b[01]+)",v={
+begin:"\\\\[\\s\\S]",relevance:0},O={scope:"string",begin:"'",end:"'",
+illegal:"\\n",contains:[v]},k={scope:"string",begin:'"',end:'"',illegal:"\\n",
+contains:[v]},x=(e,n,t={})=>{const i=a({scope:"comment",begin:e,end:n,
+contains:[]},t);i.contains.push({scope:"doctag",
+begin:"[ ]*(?=(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):)",
+end:/(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):/,excludeBegin:!0,relevance:0})
+;const r=m("I","a","is","so","us","to","at","if","in","it","on",/[A-Za-z]+['](d|ve|re|ll|t|s|n)/,/[A-Za-z]+[-][a-z]+/,/[A-Za-z][a-z]{2,}/)
+;return i.contains.push({begin:b(/[ ]+/,"(",r,/[.]?[:]?([.][ ]|[ ])/,"){3}")}),i
+},M=x("//","$"),S=x("/\\*","\\*/"),A=x("#","$");var C=Object.freeze({
+__proto__:null,APOS_STRING_MODE:O,BACKSLASH_ESCAPE:v,BINARY_NUMBER_MODE:{
+scope:"number",begin:w,relevance:0},BINARY_NUMBER_RE:w,COMMENT:x,
+C_BLOCK_COMMENT_MODE:S,C_LINE_COMMENT_MODE:M,C_NUMBER_MODE:{scope:"number",
+begin:N,relevance:0},C_NUMBER_RE:N,END_SAME_AS_BEGIN:e=>Object.assign(e,{
+"on:begin":(e,n)=>{n.data._beginMatch=e[1]},"on:end":(e,n)=>{
+n.data._beginMatch!==e[1]&&n.ignoreMatch()}}),HASH_COMMENT_MODE:A,IDENT_RE:f,
+MATCH_NOTHING_RE:/\b\B/,METHOD_GUARD:{begin:"\\.\\s*"+E,relevance:0},
+NUMBER_MODE:{scope:"number",begin:y,relevance:0},NUMBER_RE:y,
+PHRASAL_WORDS_MODE:{
+begin:/\b(a|an|the|are|I'm|isn't|don't|doesn't|won't|but|just|should|pretty|simply|enough|gonna|going|wtf|so|such|will|you|your|they|like|more)\b/
+},QUOTE_STRING_MODE:k,REGEXP_MODE:{scope:"regexp",begin:/\/(?=[^/\n]*\/)/,
+end:/\/[gimuy]*/,contains:[v,{begin:/\[/,end:/\]/,relevance:0,contains:[v]}]},
+RE_STARTERS_RE:"!|!=|!==|%|%=|&|&&|&=|\\*|\\*=|\\+|\\+=|,|-|-=|/=|/|:|;|<<|<<=|<=|<|===|==|=|>>>=|>>=|>=|>>>|>>|>|\\?|\\[|\\{|\\(|\\^|\\^=|\\||\\|=|\\|\\||~",
+SHEBANG:(e={})=>{const n=/^#![ ]*\//
+;return e.binary&&(e.begin=b(n,/.*\b/,e.binary,/\b.*/)),a({scope:"meta",begin:n,
+end:/$/,relevance:0,"on:begin":(e,n)=>{0!==e.index&&n.ignoreMatch()}},e)},
+TITLE_MODE:{scope:"title",begin:f,relevance:0},UNDERSCORE_IDENT_RE:E,
+UNDERSCORE_TITLE_MODE:{scope:"title",begin:E,relevance:0}});function T(e,n){
+"."===e.input[e.index-1]&&n.ignoreMatch()}function R(e,n){
+void 0!==e.className&&(e.scope=e.className,delete e.className)}function D(e,n){
+n&&e.beginKeywords&&(e.begin="\\b("+e.beginKeywords.split(" ").join("|")+")(?!\\.)(?=\\b|\\s)",
+e.__beforeBegin=T,e.keywords=e.keywords||e.beginKeywords,delete e.beginKeywords,
+void 0===e.relevance&&(e.relevance=0))}function I(e,n){
+Array.isArray(e.illegal)&&(e.illegal=m(...e.illegal))}function L(e,n){
+if(e.match){
+if(e.begin||e.end)throw Error("begin & end are not supported with match")
+;e.begin=e.match,delete e.match}}function B(e,n){
+void 0===e.relevance&&(e.relevance=1)}const $=(e,n)=>{if(!e.beforeMatch)return
+;if(e.starts)throw Error("beforeMatch cannot be used with starts")
+;const t=Object.assign({},e);Object.keys(e).forEach((n=>{delete e[n]
+})),e.keywords=t.keywords,e.begin=b(t.beforeMatch,d(t.begin)),e.starts={
+relevance:0,contains:[Object.assign(t,{endsParent:!0})]
+},e.relevance=0,delete t.beforeMatch
+},z=["of","and","for","in","not","or","if","then","parent","list","value"],F="keyword"
+;function U(e,n,t=F){const a=Object.create(null)
+;return"string"==typeof e?i(t,e.split(" ")):Array.isArray(e)?i(t,e):Object.keys(e).forEach((t=>{
+Object.assign(a,U(e[t],n,t))})),a;function i(e,t){
+n&&(t=t.map((e=>e.toLowerCase()))),t.forEach((n=>{const t=n.split("|")
+;a[t[0]]=[e,j(t[0],t[1])]}))}}function j(e,n){
+return n?Number(n):(e=>z.includes(e.toLowerCase()))(e)?0:1}const P={},K=e=>{
+console.error(e)},H=(e,...n)=>{console.log("WARN: "+e,...n)},q=(e,n)=>{
+P[`${e}/${n}`]||(console.log(`Deprecated as of ${e}. ${n}`),P[`${e}/${n}`]=!0)
+},G=Error();function Z(e,n,{key:t}){let a=0;const i=e[t],r={},s={}
+;for(let e=1;e<=n.length;e++)s[e+a]=i[e],r[e+a]=!0,a+=p(n[e-1])
+;e[t]=s,e[t]._emit=r,e[t]._multi=!0}function W(e){(e=>{
+e.scope&&"object"==typeof e.scope&&null!==e.scope&&(e.beginScope=e.scope,
+delete e.scope)})(e),"string"==typeof e.beginScope&&(e.beginScope={
+_wrap:e.beginScope}),"string"==typeof e.endScope&&(e.endScope={_wrap:e.endScope
+}),(e=>{if(Array.isArray(e.begin)){
+if(e.skip||e.excludeBegin||e.returnBegin)throw K("skip, excludeBegin, returnBegin not compatible with beginScope: {}"),
+G
+;if("object"!=typeof e.beginScope||null===e.beginScope)throw K("beginScope must be object"),
+G;Z(e,e.begin,{key:"beginScope"}),e.begin=h(e.begin,{joinWith:""})}})(e),(e=>{
+if(Array.isArray(e.end)){
+if(e.skip||e.excludeEnd||e.returnEnd)throw K("skip, excludeEnd, returnEnd not compatible with endScope: {}"),
+G
+;if("object"!=typeof e.endScope||null===e.endScope)throw K("endScope must be object"),
+G;Z(e,e.end,{key:"endScope"}),e.end=h(e.end,{joinWith:""})}})(e)}function Q(e){
+function n(n,t){
+return RegExp(c(n),"m"+(e.case_insensitive?"i":"")+(e.unicodeRegex?"u":"")+(t?"g":""))
+}class t{constructor(){
+this.matchIndexes={},this.regexes=[],this.matchAt=1,this.position=0}
+addRule(e,n){
+n.position=this.position++,this.matchIndexes[this.matchAt]=n,this.regexes.push([n,e]),
+this.matchAt+=p(e)+1}compile(){0===this.regexes.length&&(this.exec=()=>null)
+;const e=this.regexes.map((e=>e[1]));this.matcherRe=n(h(e,{joinWith:"|"
+}),!0),this.lastIndex=0}exec(e){this.matcherRe.lastIndex=this.lastIndex
+;const n=this.matcherRe.exec(e);if(!n)return null
+;const t=n.findIndex(((e,n)=>n>0&&void 0!==e)),a=this.matchIndexes[t]
+;return n.splice(0,t),Object.assign(n,a)}}class i{constructor(){
+this.rules=[],this.multiRegexes=[],
+this.count=0,this.lastIndex=0,this.regexIndex=0}getMatcher(e){
+if(this.multiRegexes[e])return this.multiRegexes[e];const n=new t
+;return this.rules.slice(e).forEach((([e,t])=>n.addRule(e,t))),
+n.compile(),this.multiRegexes[e]=n,n}resumingScanAtSamePosition(){
+return 0!==this.regexIndex}considerAll(){this.regexIndex=0}addRule(e,n){
+this.rules.push([e,n]),"begin"===n.type&&this.count++}exec(e){
+const n=this.getMatcher(this.regexIndex);n.lastIndex=this.lastIndex
+;let t=n.exec(e)
+;if(this.resumingScanAtSamePosition())if(t&&t.index===this.lastIndex);else{
+const n=this.getMatcher(0);n.lastIndex=this.lastIndex+1,t=n.exec(e)}
+return t&&(this.regexIndex+=t.position+1,
+this.regexIndex===this.count&&this.considerAll()),t}}
+if(e.compilerExtensions||(e.compilerExtensions=[]),
+e.contains&&e.contains.includes("self"))throw Error("ERR: contains `self` is not supported at the top-level of a language.  See documentation.")
+;return e.classNameAliases=a(e.classNameAliases||{}),function t(r,s){const o=r
+;if(r.isCompiled)return o
+;[R,L,W,$].forEach((e=>e(r,s))),e.compilerExtensions.forEach((e=>e(r,s))),
+r.__beforeBegin=null,[D,I,B].forEach((e=>e(r,s))),r.isCompiled=!0;let l=null
+;return"object"==typeof r.keywords&&r.keywords.$pattern&&(r.keywords=Object.assign({},r.keywords),
+l=r.keywords.$pattern,
+delete r.keywords.$pattern),l=l||/\w+/,r.keywords&&(r.keywords=U(r.keywords,e.case_insensitive)),
+o.keywordPatternRe=n(l,!0),
+s&&(r.begin||(r.begin=/\B|\b/),o.beginRe=n(o.begin),r.end||r.endsWithParent||(r.end=/\B|\b/),
+r.end&&(o.endRe=n(o.end)),
+o.terminatorEnd=c(o.end)||"",r.endsWithParent&&s.terminatorEnd&&(o.terminatorEnd+=(r.end?"|":"")+s.terminatorEnd)),
+r.illegal&&(o.illegalRe=n(r.illegal)),
+r.contains||(r.contains=[]),r.contains=[].concat(...r.contains.map((e=>(e=>(e.variants&&!e.cachedVariants&&(e.cachedVariants=e.variants.map((n=>a(e,{
+variants:null},n)))),e.cachedVariants?e.cachedVariants:X(e)?a(e,{
+starts:e.starts?a(e.starts):null
+}):Object.isFrozen(e)?a(e):e))("self"===e?r:e)))),r.contains.forEach((e=>{t(e,o)
+})),r.starts&&t(r.starts,s),o.matcher=(e=>{const n=new i
+;return e.contains.forEach((e=>n.addRule(e.begin,{rule:e,type:"begin"
+}))),e.terminatorEnd&&n.addRule(e.terminatorEnd,{type:"end"
+}),e.illegal&&n.addRule(e.illegal,{type:"illegal"}),n})(o),o}(e)}function X(e){
+return!!e&&(e.endsWithParent||X(e.starts))}class V extends Error{
+constructor(e,n){super(e),this.name="HTMLInjectionError",this.html=n}}
+const J=t,Y=a,ee=Symbol("nomatch"),ne=t=>{
+const a=Object.create(null),i=Object.create(null),r=[];let s=!0
+;const o="Could not find the language '{}', did you forget to load/include a language module?",c={
+disableAutodetect:!0,name:"Plain text",contains:[]};let p={
+ignoreUnescapedHTML:!1,throwUnescapedHTML:!1,noHighlightRe:/^(no-?highlight)$/i,
+languageDetectRe:/\blang(?:uage)?-([\w-]+)\b/i,classPrefix:"hljs-",
+cssSelector:"pre code",languages:null,__emitter:l};function _(e){
+return p.noHighlightRe.test(e)}function h(e,n,t){let a="",i=""
+;"object"==typeof n?(a=e,
+t=n.ignoreIllegals,i=n.language):(q("10.7.0","highlight(lang, code, ...args) has been deprecated."),
+q("10.7.0","Please use highlight(code, options) instead.\nhttps://github.com/highlightjs/highlight.js/issues/2277"),
+i=e,a=n),void 0===t&&(t=!0);const r={code:a,language:i};x("before:highlight",r)
+;const s=r.result?r.result:f(r.language,r.code,t)
+;return s.code=r.code,x("after:highlight",s),s}function f(e,t,i,r){
+const l=Object.create(null);function c(){if(!x.keywords)return void S.addText(A)
+;let e=0;x.keywordPatternRe.lastIndex=0;let n=x.keywordPatternRe.exec(A),t=""
+;for(;n;){t+=A.substring(e,n.index)
+;const i=w.case_insensitive?n[0].toLowerCase():n[0],r=(a=i,x.keywords[a]);if(r){
+const[e,a]=r
+;if(S.addText(t),t="",l[i]=(l[i]||0)+1,l[i]<=7&&(C+=a),e.startsWith("_"))t+=n[0];else{
+const t=w.classNameAliases[e]||e;g(n[0],t)}}else t+=n[0]
+;e=x.keywordPatternRe.lastIndex,n=x.keywordPatternRe.exec(A)}var a
+;t+=A.substring(e),S.addText(t)}function d(){null!=x.subLanguage?(()=>{
+if(""===A)return;let e=null;if("string"==typeof x.subLanguage){
+if(!a[x.subLanguage])return void S.addText(A)
+;e=f(x.subLanguage,A,!0,M[x.subLanguage]),M[x.subLanguage]=e._top
+}else e=E(A,x.subLanguage.length?x.subLanguage:null)
+;x.relevance>0&&(C+=e.relevance),S.__addSublanguage(e._emitter,e.language)
+})():c(),A=""}function g(e,n){
+""!==e&&(S.startScope(n),S.addText(e),S.endScope())}function u(e,n){let t=1
+;const a=n.length-1;for(;t<=a;){if(!e._emit[t]){t++;continue}
+const a=w.classNameAliases[e[t]]||e[t],i=n[t];a?g(i,a):(A=i,c(),A=""),t++}}
+function b(e,n){
+return e.scope&&"string"==typeof e.scope&&S.openNode(w.classNameAliases[e.scope]||e.scope),
+e.beginScope&&(e.beginScope._wrap?(g(A,w.classNameAliases[e.beginScope._wrap]||e.beginScope._wrap),
+A=""):e.beginScope._multi&&(u(e.beginScope,n),A="")),x=Object.create(e,{parent:{
+value:x}}),x}function m(e,t,a){let i=((e,n)=>{const t=e&&e.exec(n)
+;return t&&0===t.index})(e.endRe,a);if(i){if(e["on:end"]){const a=new n(e)
+;e["on:end"](t,a),a.isMatchIgnored&&(i=!1)}if(i){
+for(;e.endsParent&&e.parent;)e=e.parent;return e}}
+if(e.endsWithParent)return m(e.parent,t,a)}function _(e){
+return 0===x.matcher.regexIndex?(A+=e[0],1):(D=!0,0)}function h(e){
+const n=e[0],a=t.substring(e.index),i=m(x,e,a);if(!i)return ee;const r=x
+;x.endScope&&x.endScope._wrap?(d(),
+g(n,x.endScope._wrap)):x.endScope&&x.endScope._multi?(d(),
+u(x.endScope,e)):r.skip?A+=n:(r.returnEnd||r.excludeEnd||(A+=n),
+d(),r.excludeEnd&&(A=n));do{
+x.scope&&S.closeNode(),x.skip||x.subLanguage||(C+=x.relevance),x=x.parent
+}while(x!==i.parent);return i.starts&&b(i.starts,e),r.returnEnd?0:n.length}
+let y={};function N(a,r){const o=r&&r[0];if(A+=a,null==o)return d(),0
+;if("begin"===y.type&&"end"===r.type&&y.index===r.index&&""===o){
+if(A+=t.slice(r.index,r.index+1),!s){const n=Error(`0 width match regex (${e})`)
+;throw n.languageName=e,n.badRule=y.rule,n}return 1}
+if(y=r,"begin"===r.type)return(e=>{
+const t=e[0],a=e.rule,i=new n(a),r=[a.__beforeBegin,a["on:begin"]]
+;for(const n of r)if(n&&(n(e,i),i.isMatchIgnored))return _(t)
+;return a.skip?A+=t:(a.excludeBegin&&(A+=t),
+d(),a.returnBegin||a.excludeBegin||(A=t)),b(a,e),a.returnBegin?0:t.length})(r)
+;if("illegal"===r.type&&!i){
+const e=Error('Illegal lexeme "'+o+'" for mode "'+(x.scope||"<unnamed>")+'"')
+;throw e.mode=x,e}if("end"===r.type){const e=h(r);if(e!==ee)return e}
+if("illegal"===r.type&&""===o)return 1
+;if(R>1e5&&R>3*r.index)throw Error("potential infinite loop, way more iterations than matches")
+;return A+=o,o.length}const w=v(e)
+;if(!w)throw K(o.replace("{}",e)),Error('Unknown language: "'+e+'"')
+;const O=Q(w);let k="",x=r||O;const M={},S=new p.__emitter(p);(()=>{const e=[]
+;for(let n=x;n!==w;n=n.parent)n.scope&&e.unshift(n.scope)
+;e.forEach((e=>S.openNode(e)))})();let A="",C=0,T=0,R=0,D=!1;try{
+if(w.__emitTokens)w.__emitTokens(t,S);else{for(x.matcher.considerAll();;){
+R++,D?D=!1:x.matcher.considerAll(),x.matcher.lastIndex=T
+;const e=x.matcher.exec(t);if(!e)break;const n=N(t.substring(T,e.index),e)
+;T=e.index+n}N(t.substring(T))}return S.finalize(),k=S.toHTML(),{language:e,
+value:k,relevance:C,illegal:!1,_emitter:S,_top:x}}catch(n){
+if(n.message&&n.message.includes("Illegal"))return{language:e,value:J(t),
+illegal:!0,relevance:0,_illegalBy:{message:n.message,index:T,
+context:t.slice(T-100,T+100),mode:n.mode,resultSoFar:k},_emitter:S};if(s)return{
+language:e,value:J(t),illegal:!1,relevance:0,errorRaised:n,_emitter:S,_top:x}
+;throw n}}function E(e,n){n=n||p.languages||Object.keys(a);const t=(e=>{
+const n={value:J(e),illegal:!1,relevance:0,_top:c,_emitter:new p.__emitter(p)}
+;return n._emitter.addText(e),n})(e),i=n.filter(v).filter(k).map((n=>f(n,e,!1)))
+;i.unshift(t);const r=i.sort(((e,n)=>{
+if(e.relevance!==n.relevance)return n.relevance-e.relevance
+;if(e.language&&n.language){if(v(e.language).supersetOf===n.language)return 1
+;if(v(n.language).supersetOf===e.language)return-1}return 0})),[s,o]=r,l=s
+;return l.secondBest=o,l}function y(e){let n=null;const t=(e=>{
+let n=e.className+" ";n+=e.parentNode?e.parentNode.className:""
+;const t=p.languageDetectRe.exec(n);if(t){const n=v(t[1])
+;return n||(H(o.replace("{}",t[1])),
+H("Falling back to no-highlight mode for this block.",e)),n?t[1]:"no-highlight"}
+return n.split(/\s+/).find((e=>_(e)||v(e)))})(e);if(_(t))return
+;if(x("before:highlightElement",{el:e,language:t
+}),e.dataset.highlighted)return void console.log("Element previously highlighted. To highlight again, first unset `dataset.highlighted`.",e)
+;if(e.children.length>0&&(p.ignoreUnescapedHTML||(console.warn("One of your code blocks includes unescaped HTML. This is a potentially serious security risk."),
+console.warn("https://github.com/highlightjs/highlight.js/wiki/security"),
+console.warn("The element with unescaped HTML:"),
+console.warn(e)),p.throwUnescapedHTML))throw new V("One of your code blocks includes unescaped HTML.",e.innerHTML)
+;n=e;const a=n.textContent,r=t?h(a,{language:t,ignoreIllegals:!0}):E(a)
+;e.innerHTML=r.value,e.dataset.highlighted="yes",((e,n,t)=>{const a=n&&i[n]||t
+;e.classList.add("hljs"),e.classList.add("language-"+a)
+})(e,t,r.language),e.result={language:r.language,re:r.relevance,
+relevance:r.relevance},r.secondBest&&(e.secondBest={
+language:r.secondBest.language,relevance:r.secondBest.relevance
+}),x("after:highlightElement",{el:e,result:r,text:a})}let N=!1;function w(){
+"loading"!==document.readyState?document.querySelectorAll(p.cssSelector).forEach(y):N=!0
+}function v(e){return e=(e||"").toLowerCase(),a[e]||a[i[e]]}
+function O(e,{languageName:n}){"string"==typeof e&&(e=[e]),e.forEach((e=>{
+i[e.toLowerCase()]=n}))}function k(e){const n=v(e)
+;return n&&!n.disableAutodetect}function x(e,n){const t=e;r.forEach((e=>{
+e[t]&&e[t](n)}))}
+"undefined"!=typeof window&&window.addEventListener&&window.addEventListener("DOMContentLoaded",(()=>{
+N&&w()}),!1),Object.assign(t,{highlight:h,highlightAuto:E,highlightAll:w,
+highlightElement:y,
+highlightBlock:e=>(q("10.7.0","highlightBlock will be removed entirely in v12.0"),
+q("10.7.0","Please use highlightElement now."),y(e)),configure:e=>{p=Y(p,e)},
+initHighlighting:()=>{
+w(),q("10.6.0","initHighlighting() deprecated.  Use highlightAll() now.")},
+initHighlightingOnLoad:()=>{
+w(),q("10.6.0","initHighlightingOnLoad() deprecated.  Use highlightAll() now.")
+},registerLanguage:(e,n)=>{let i=null;try{i=n(t)}catch(n){
+if(K("Language definition for '{}' could not be registered.".replace("{}",e)),
+!s)throw n;K(n),i=c}
+i.name||(i.name=e),a[e]=i,i.rawDefinition=n.bind(null,t),i.aliases&&O(i.aliases,{
+languageName:e})},unregisterLanguage:e=>{delete a[e]
+;for(const n of Object.keys(i))i[n]===e&&delete i[n]},
+listLanguages:()=>Object.keys(a),getLanguage:v,registerAliases:O,
+autoDetection:k,inherit:Y,addPlugin:e=>{(e=>{
+e["before:highlightBlock"]&&!e["before:highlightElement"]&&(e["before:highlightElement"]=n=>{
+e["before:highlightBlock"](Object.assign({block:n.el},n))
+}),e["after:highlightBlock"]&&!e["after:highlightElement"]&&(e["after:highlightElement"]=n=>{
+e["after:highlightBlock"](Object.assign({block:n.el},n))})})(e),r.push(e)},
+removePlugin:e=>{const n=r.indexOf(e);-1!==n&&r.splice(n,1)}}),t.debugMode=()=>{
+s=!1},t.safeMode=()=>{s=!0},t.versionString="11.9.0",t.regex={concat:b,
+lookahead:d,either:m,optional:u,anyNumberOfTimes:g}
+;for(const n in C)"object"==typeof C[n]&&e(C[n]);return Object.assign(t,C),t
+},te=ne({});te.newInstance=()=>ne({});var ae=te;const ie=e=>({IMPORTANT:{
+scope:"meta",begin:"!important"},BLOCK_COMMENT:e.C_BLOCK_COMMENT_MODE,HEXCOLOR:{
+scope:"number",begin:/#(([0-9a-fA-F]{3,4})|(([0-9a-fA-F]{2}){3,4}))\b/},
+FUNCTION_DISPATCH:{className:"built_in",begin:/[\w-]+(?=\()/},
+ATTRIBUTE_SELECTOR_MODE:{scope:"selector-attr",begin:/\[/,end:/\]/,illegal:"$",
+contains:[e.APOS_STRING_MODE,e.QUOTE_STRING_MODE]},CSS_NUMBER_MODE:{
+scope:"number",
+begin:e.NUMBER_RE+"(%|em|ex|ch|rem|vw|vh|vmin|vmax|cm|mm|in|pt|pc|px|deg|grad|rad|turn|s|ms|Hz|kHz|dpi|dpcm|dppx)?",
+relevance:0},CSS_VARIABLE:{className:"attr",begin:/--[A-Za-z_][A-Za-z0-9_-]*/}
+}),re=["a","abbr","address","article","aside","audio","b","blockquote","body","button","canvas","caption","cite","code","dd","del","details","dfn","div","dl","dt","em","fieldset","figcaption","figure","footer","form","h1","h2","h3","h4","h5","h6","header","hgroup","html","i","iframe","img","input","ins","kbd","label","legend","li","main","mark","menu","nav","object","ol","p","q","quote","samp","section","span","strong","summary","sup","table","tbody","td","textarea","tfoot","th","thead","time","tr","ul","var","video"],se=["any-hover","any-pointer","aspect-ratio","color","color-gamut","color-index","device-aspect-ratio","device-height","device-width","display-mode","forced-colors","grid","height","hover","inverted-colors","monochrome","orientation","overflow-block","overflow-inline","pointer","prefers-color-scheme","prefers-contrast","prefers-reduced-motion","prefers-reduced-transparency","resolution","scan","scripting","update","width","min-width","max-width","min-height","max-height"],oe=["active","any-link","blank","checked","current","default","defined","dir","disabled","drop","empty","enabled","first","first-child","first-of-type","fullscreen","future","focus","focus-visible","focus-within","has","host","host-context","hover","indeterminate","in-range","invalid","is","lang","last-child","last-of-type","left","link","local-link","not","nth-child","nth-col","nth-last-child","nth-last-col","nth-last-of-type","nth-of-type","only-child","only-of-type","optional","out-of-range","past","placeholder-shown","read-only","read-write","required","right","root","scope","target","target-within","user-invalid","valid","visited","where"],le=["after","backdrop","before","cue","cue-region","first-letter","first-line","grammar-error","marker","part","placeholder","selection","slotted","spelling-error"],ce=["align-content","align-items","align-self","all","animation","animation-delay","animation-direction","animation-duration","animation-fill-mode","animation-iteration-count","animation-name","animation-play-state","animation-timing-function","backface-visibility","background","background-attachment","background-blend-mode","background-clip","background-color","background-image","background-origin","background-position","background-repeat","background-size","block-size","border","border-block","border-block-color","border-block-end","border-block-end-color","border-block-end-style","border-block-end-width","border-block-start","border-block-start-color","border-block-start-style","border-block-start-width","border-block-style","border-block-width","border-bottom","border-bottom-color","border-bottom-left-radius","border-bottom-right-radius","border-bottom-style","border-bottom-width","border-collapse","border-color","border-image","border-image-outset","border-image-repeat","border-image-slice","border-image-source","border-image-width","border-inline","border-inline-color","border-inline-end","border-inline-end-color","border-inline-end-style","border-inline-end-width","border-inline-start","border-inline-start-color","border-inline-start-style","border-inline-start-width","border-inline-style","border-inline-width","border-left","border-left-color","border-left-style","border-left-width","border-radius","border-right","border-right-color","border-right-style","border-right-width","border-spacing","border-style","border-top","border-top-color","border-top-left-radius","border-top-right-radius","border-top-style","border-top-width","border-width","bottom","box-decoration-break","box-shadow","box-sizing","break-after","break-before","break-inside","caption-side","caret-color","clear","clip","clip-path","clip-rule","color","column-count","column-fill","column-gap","column-rule","column-rule-color","column-rule-style","column-rule-width","column-span","column-width","columns","contain","content","content-visibility","counter-increment","counter-reset","cue","cue-after","cue-before","cursor","direction","display","empty-cells","filter","flex","flex-basis","flex-direction","flex-flow","flex-grow","flex-shrink","flex-wrap","float","flow","font","font-display","font-family","font-feature-settings","font-kerning","font-language-override","font-size","font-size-adjust","font-smoothing","font-stretch","font-style","font-synthesis","font-variant","font-variant-caps","font-variant-east-asian","font-variant-ligatures","font-variant-numeric","font-variant-position","font-variation-settings","font-weight","gap","glyph-orientation-vertical","grid","grid-area","grid-auto-columns","grid-auto-flow","grid-auto-rows","grid-column","grid-column-end","grid-column-start","grid-gap","grid-row","grid-row-end","grid-row-start","grid-template","grid-template-areas","grid-template-columns","grid-template-rows","hanging-punctuation","height","hyphens","icon","image-orientation","image-rendering","image-resolution","ime-mode","inline-size","isolation","justify-content","left","letter-spacing","line-break","line-height","list-style","list-style-image","list-style-position","list-style-type","margin","margin-block","margin-block-end","margin-block-start","margin-bottom","margin-inline","margin-inline-end","margin-inline-start","margin-left","margin-right","margin-top","marks","mask","mask-border","mask-border-mode","mask-border-outset","mask-border-repeat","mask-border-slice","mask-border-source","mask-border-width","mask-clip","mask-composite","mask-image","mask-mode","mask-origin","mask-position","mask-repeat","mask-size","mask-type","max-block-size","max-height","max-inline-size","max-width","min-block-size","min-height","min-inline-size","min-width","mix-blend-mode","nav-down","nav-index","nav-left","nav-right","nav-up","none","normal","object-fit","object-position","opacity","order","orphans","outline","outline-color","outline-offset","outline-style","outline-width","overflow","overflow-wrap","overflow-x","overflow-y","padding","padding-block","padding-block-end","padding-block-start","padding-bottom","padding-inline","padding-inline-end","padding-inline-start","padding-left","padding-right","padding-top","page-break-after","page-break-before","page-break-inside","pause","pause-after","pause-before","perspective","perspective-origin","pointer-events","position","quotes","resize","rest","rest-after","rest-before","right","row-gap","scroll-margin","scroll-margin-block","scroll-margin-block-end","scroll-margin-block-start","scroll-margin-bottom","scroll-margin-inline","scroll-margin-inline-end","scroll-margin-inline-start","scroll-margin-left","scroll-margin-right","scroll-margin-top","scroll-padding","scroll-padding-block","scroll-padding-block-end","scroll-padding-block-start","scroll-padding-bottom","scroll-padding-inline","scroll-padding-inline-end","scroll-padding-inline-start","scroll-padding-left","scroll-padding-right","scroll-padding-top","scroll-snap-align","scroll-snap-stop","scroll-snap-type","scrollbar-color","scrollbar-gutter","scrollbar-width","shape-image-threshold","shape-margin","shape-outside","speak","speak-as","src","tab-size","table-layout","text-align","text-align-all","text-align-last","text-combine-upright","text-decoration","text-decoration-color","text-decoration-line","text-decoration-style","text-emphasis","text-emphasis-color","text-emphasis-position","text-emphasis-style","text-indent","text-justify","text-orientation","text-overflow","text-rendering","text-shadow","text-transform","text-underline-position","top","transform","transform-box","transform-origin","transform-style","transition","transition-delay","transition-duration","transition-property","transition-timing-function","unicode-bidi","vertical-align","visibility","voice-balance","voice-duration","voice-family","voice-pitch","voice-range","voice-rate","voice-stress","voice-volume","white-space","widows","width","will-change","word-break","word-spacing","word-wrap","writing-mode","z-index"].reverse(),de=oe.concat(le)
+;var ge="[0-9](_*[0-9])*",ue=`\\.(${ge})`,be="[0-9a-fA-F](_*[0-9a-fA-F])*",me={
+className:"number",variants:[{
+begin:`(\\b(${ge})((${ue})|\\.)?|(${ue}))[eE][+-]?(${ge})[fFdD]?\\b`},{
+begin:`\\b(${ge})((${ue})[fFdD]?\\b|\\.([fFdD]\\b)?)`},{
+begin:`(${ue})[fFdD]?\\b`},{begin:`\\b(${ge})[fFdD]\\b`},{
+begin:`\\b0[xX]((${be})\\.?|(${be})?\\.(${be}))[pP][+-]?(${ge})[fFdD]?\\b`},{
+begin:"\\b(0|[1-9](_*[0-9])*)[lL]?\\b"},{begin:`\\b0[xX](${be})[lL]?\\b`},{
+begin:"\\b0(_*[0-7])*[lL]?\\b"},{begin:"\\b0[bB][01](_*[01])*[lL]?\\b"}],
+relevance:0};function pe(e,n,t){return-1===t?"":e.replace(n,(a=>pe(e,n,t-1)))}
+const _e="[A-Za-z$_][0-9A-Za-z$_]*",he=["as","in","of","if","for","while","finally","var","new","function","do","return","void","else","break","catch","instanceof","with","throw","case","default","try","switch","continue","typeof","delete","let","yield","const","class","debugger","async","await","static","import","from","export","extends"],fe=["true","false","null","undefined","NaN","Infinity"],Ee=["Object","Function","Boolean","Symbol","Math","Date","Number","BigInt","String","RegExp","Array","Float32Array","Float64Array","Int8Array","Uint8Array","Uint8ClampedArray","Int16Array","Int32Array","Uint16Array","Uint32Array","BigInt64Array","BigUint64Array","Set","Map","WeakSet","WeakMap","ArrayBuffer","SharedArrayBuffer","Atomics","DataView","JSON","Promise","Generator","GeneratorFunction","AsyncFunction","Reflect","Proxy","Intl","WebAssembly"],ye=["Error","EvalError","InternalError","RangeError","ReferenceError","SyntaxError","TypeError","URIError"],Ne=["setInterval","setTimeout","clearInterval","clearTimeout","require","exports","eval","isFinite","isNaN","parseFloat","parseInt","decodeURI","decodeURIComponent","encodeURI","encodeURIComponent","escape","unescape"],we=["arguments","this","super","console","window","document","localStorage","sessionStorage","module","global"],ve=[].concat(Ne,Ee,ye)
+;function Oe(e){const n=e.regex,t=_e,a={begin:/<[A-Za-z0-9\\._:-]+/,
+end:/\/[A-Za-z0-9\\._:-]+>|\/>/,isTrulyOpeningTag:(e,n)=>{
+const t=e[0].length+e.index,a=e.input[t]
+;if("<"===a||","===a)return void n.ignoreMatch();let i
+;">"===a&&(((e,{after:n})=>{const t="</"+e[0].slice(1)
+;return-1!==e.input.indexOf(t,n)})(e,{after:t})||n.ignoreMatch())
+;const r=e.input.substring(t)
+;((i=r.match(/^\s*=/))||(i=r.match(/^\s+extends\s+/))&&0===i.index)&&n.ignoreMatch()
+}},i={$pattern:_e,keyword:he,literal:fe,built_in:ve,"variable.language":we
+},r="[0-9](_?[0-9])*",s=`\\.(${r})`,o="0|[1-9](_?[0-9])*|0[0-7]*[89][0-9]*",l={
+className:"number",variants:[{
+begin:`(\\b(${o})((${s})|\\.)?|(${s}))[eE][+-]?(${r})\\b`},{
+begin:`\\b(${o})\\b((${s})\\b|\\.)?|(${s})\\b`},{
+begin:"\\b(0|[1-9](_?[0-9])*)n\\b"},{
+begin:"\\b0[xX][0-9a-fA-F](_?[0-9a-fA-F])*n?\\b"},{
+begin:"\\b0[bB][0-1](_?[0-1])*n?\\b"},{begin:"\\b0[oO][0-7](_?[0-7])*n?\\b"},{
+begin:"\\b0[0-7]+n?\\b"}],relevance:0},c={className:"subst",begin:"\\$\\{",
+end:"\\}",keywords:i,contains:[]},d={begin:"html`",end:"",starts:{end:"`",
+returnEnd:!1,contains:[e.BACKSLASH_ESCAPE,c],subLanguage:"xml"}},g={
+begin:"css`",end:"",starts:{end:"`",returnEnd:!1,
+contains:[e.BACKSLASH_ESCAPE,c],subLanguage:"css"}},u={begin:"gql`",end:"",
+starts:{end:"`",returnEnd:!1,contains:[e.BACKSLASH_ESCAPE,c],
+subLanguage:"graphql"}},b={className:"string",begin:"`",end:"`",
+contains:[e.BACKSLASH_ESCAPE,c]},m={className:"comment",
+variants:[e.COMMENT(/\/\*\*(?!\/)/,"\\*/",{relevance:0,contains:[{
+begin:"(?=@[A-Za-z]+)",relevance:0,contains:[{className:"doctag",
+begin:"@[A-Za-z]+"},{className:"type",begin:"\\{",end:"\\}",excludeEnd:!0,
+excludeBegin:!0,relevance:0},{className:"variable",begin:t+"(?=\\s*(-)|$)",
+endsParent:!0,relevance:0},{begin:/(?=[^\n])\s/,relevance:0}]}]
+}),e.C_BLOCK_COMMENT_MODE,e.C_LINE_COMMENT_MODE]
+},p=[e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,d,g,u,b,{match:/\$\d+/},l]
+;c.contains=p.concat({begin:/\{/,end:/\}/,keywords:i,contains:["self"].concat(p)
+});const _=[].concat(m,c.contains),h=_.concat([{begin:/\(/,end:/\)/,keywords:i,
+contains:["self"].concat(_)}]),f={className:"params",begin:/\(/,end:/\)/,
+excludeBegin:!0,excludeEnd:!0,keywords:i,contains:h},E={variants:[{
+match:[/class/,/\s+/,t,/\s+/,/extends/,/\s+/,n.concat(t,"(",n.concat(/\./,t),")*")],
+scope:{1:"keyword",3:"title.class",5:"keyword",7:"title.class.inherited"}},{
+match:[/class/,/\s+/,t],scope:{1:"keyword",3:"title.class"}}]},y={relevance:0,
+match:n.either(/\bJSON/,/\b[A-Z][a-z]+([A-Z][a-z]*|\d)*/,/\b[A-Z]{2,}([A-Z][a-z]+|\d)+([A-Z][a-z]*)*/,/\b[A-Z]{2,}[a-z]+([A-Z][a-z]+|\d)*([A-Z][a-z]*)*/),
+className:"title.class",keywords:{_:[...Ee,...ye]}},N={variants:[{
+match:[/function/,/\s+/,t,/(?=\s*\()/]},{match:[/function/,/\s*(?=\()/]}],
+className:{1:"keyword",3:"title.function"},label:"func.def",contains:[f],
+illegal:/%/},w={
+match:n.concat(/\b/,(v=[...Ne,"super","import"],n.concat("(?!",v.join("|"),")")),t,n.lookahead(/\(/)),
+className:"title.function",relevance:0};var v;const O={
+begin:n.concat(/\./,n.lookahead(n.concat(t,/(?![0-9A-Za-z$_(])/))),end:t,
+excludeBegin:!0,keywords:"prototype",className:"property",relevance:0},k={
+match:[/get|set/,/\s+/,t,/(?=\()/],className:{1:"keyword",3:"title.function"},
+contains:[{begin:/\(\)/},f]
+},x="(\\([^()]*(\\([^()]*(\\([^()]*\\)[^()]*)*\\)[^()]*)*\\)|"+e.UNDERSCORE_IDENT_RE+")\\s*=>",M={
+match:[/const|var|let/,/\s+/,t,/\s*/,/=\s*/,/(async\s*)?/,n.lookahead(x)],
+keywords:"async",className:{1:"keyword",3:"title.function"},contains:[f]}
+;return{name:"JavaScript",aliases:["js","jsx","mjs","cjs"],keywords:i,exports:{
+PARAMS_CONTAINS:h,CLASS_REFERENCE:y},illegal:/#(?![$_A-z])/,
+contains:[e.SHEBANG({label:"shebang",binary:"node",relevance:5}),{
+label:"use_strict",className:"meta",relevance:10,
+begin:/^\s*['"]use (strict|asm)['"]/
+},e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,d,g,u,b,m,{match:/\$\d+/},l,y,{
+className:"attr",begin:t+n.lookahead(":"),relevance:0},M,{
+begin:"("+e.RE_STARTERS_RE+"|\\b(case|return|throw)\\b)\\s*",
+keywords:"return throw case",relevance:0,contains:[m,e.REGEXP_MODE,{
+className:"function",begin:x,returnBegin:!0,end:"\\s*=>",contains:[{
+className:"params",variants:[{begin:e.UNDERSCORE_IDENT_RE,relevance:0},{
+className:null,begin:/\(\s*\)/,skip:!0},{begin:/\(/,end:/\)/,excludeBegin:!0,
+excludeEnd:!0,keywords:i,contains:h}]}]},{begin:/,/,relevance:0},{match:/\s+/,
+relevance:0},{variants:[{begin:"<>",end:"</>"},{
+match:/<[A-Za-z0-9\\._:-]+\s*\/>/},{begin:a.begin,
+"on:begin":a.isTrulyOpeningTag,end:a.end}],subLanguage:"xml",contains:[{
+begin:a.begin,end:a.end,skip:!0,contains:["self"]}]}]},N,{
+beginKeywords:"while if switch catch for"},{
+begin:"\\b(?!function)"+e.UNDERSCORE_IDENT_RE+"\\([^()]*(\\([^()]*(\\([^()]*\\)[^()]*)*\\)[^()]*)*\\)\\s*\\{",
+returnBegin:!0,label:"func.def",contains:[f,e.inherit(e.TITLE_MODE,{begin:t,
+className:"title.function"})]},{match:/\.\.\./,relevance:0},O,{match:"\\$"+t,
+relevance:0},{match:[/\bconstructor(?=\s*\()/],className:{1:"title.function"},
+contains:[f]},w,{relevance:0,match:/\b[A-Z][A-Z_0-9]+\b/,
+className:"variable.constant"},E,k,{match:/\$[(.]/}]}}
+const ke=e=>b(/\b/,e,/\w$/.test(e)?/\b/:/\B/),xe=["Protocol","Type"].map(ke),Me=["init","self"].map(ke),Se=["Any","Self"],Ae=["actor","any","associatedtype","async","await",/as\?/,/as!/,"as","borrowing","break","case","catch","class","consume","consuming","continue","convenience","copy","default","defer","deinit","didSet","distributed","do","dynamic","each","else","enum","extension","fallthrough",/fileprivate\(set\)/,"fileprivate","final","for","func","get","guard","if","import","indirect","infix",/init\?/,/init!/,"inout",/internal\(set\)/,"internal","in","is","isolated","nonisolated","lazy","let","macro","mutating","nonmutating",/open\(set\)/,"open","operator","optional","override","postfix","precedencegroup","prefix",/private\(set\)/,"private","protocol",/public\(set\)/,"public","repeat","required","rethrows","return","set","some","static","struct","subscript","super","switch","throws","throw",/try\?/,/try!/,"try","typealias",/unowned\(safe\)/,/unowned\(unsafe\)/,"unowned","var","weak","where","while","willSet"],Ce=["false","nil","true"],Te=["assignment","associativity","higherThan","left","lowerThan","none","right"],Re=["#colorLiteral","#column","#dsohandle","#else","#elseif","#endif","#error","#file","#fileID","#fileLiteral","#filePath","#function","#if","#imageLiteral","#keyPath","#line","#selector","#sourceLocation","#warning"],De=["abs","all","any","assert","assertionFailure","debugPrint","dump","fatalError","getVaList","isKnownUniquelyReferenced","max","min","numericCast","pointwiseMax","pointwiseMin","precondition","preconditionFailure","print","readLine","repeatElement","sequence","stride","swap","swift_unboxFromSwiftValueWithType","transcode","type","unsafeBitCast","unsafeDowncast","withExtendedLifetime","withUnsafeMutablePointer","withUnsafePointer","withVaList","withoutActuallyEscaping","zip"],Ie=m(/[/=\-+!*%<>&|^~?]/,/[\u00A1-\u00A7]/,/[\u00A9\u00AB]/,/[\u00AC\u00AE]/,/[\u00B0\u00B1]/,/[\u00B6\u00BB\u00BF\u00D7\u00F7]/,/[\u2016-\u2017]/,/[\u2020-\u2027]/,/[\u2030-\u203E]/,/[\u2041-\u2053]/,/[\u2055-\u205E]/,/[\u2190-\u23FF]/,/[\u2500-\u2775]/,/[\u2794-\u2BFF]/,/[\u2E00-\u2E7F]/,/[\u3001-\u3003]/,/[\u3008-\u3020]/,/[\u3030]/),Le=m(Ie,/[\u0300-\u036F]/,/[\u1DC0-\u1DFF]/,/[\u20D0-\u20FF]/,/[\uFE00-\uFE0F]/,/[\uFE20-\uFE2F]/),Be=b(Ie,Le,"*"),$e=m(/[a-zA-Z_]/,/[\u00A8\u00AA\u00AD\u00AF\u00B2-\u00B5\u00B7-\u00BA]/,/[\u00BC-\u00BE\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]/,/[\u0100-\u02FF\u0370-\u167F\u1681-\u180D\u180F-\u1DBF]/,/[\u1E00-\u1FFF]/,/[\u200B-\u200D\u202A-\u202E\u203F-\u2040\u2054\u2060-\u206F]/,/[\u2070-\u20CF\u2100-\u218F\u2460-\u24FF\u2776-\u2793]/,/[\u2C00-\u2DFF\u2E80-\u2FFF]/,/[\u3004-\u3007\u3021-\u302F\u3031-\u303F\u3040-\uD7FF]/,/[\uF900-\uFD3D\uFD40-\uFDCF\uFDF0-\uFE1F\uFE30-\uFE44]/,/[\uFE47-\uFEFE\uFF00-\uFFFD]/),ze=m($e,/\d/,/[\u0300-\u036F\u1DC0-\u1DFF\u20D0-\u20FF\uFE20-\uFE2F]/),Fe=b($e,ze,"*"),Ue=b(/[A-Z]/,ze,"*"),je=["attached","autoclosure",b(/convention\(/,m("swift","block","c"),/\)/),"discardableResult","dynamicCallable","dynamicMemberLookup","escaping","freestanding","frozen","GKInspectable","IBAction","IBDesignable","IBInspectable","IBOutlet","IBSegueAction","inlinable","main","nonobjc","NSApplicationMain","NSCopying","NSManaged",b(/objc\(/,Fe,/\)/),"objc","objcMembers","propertyWrapper","requires_stored_property_inits","resultBuilder","Sendable","testable","UIApplicationMain","unchecked","unknown","usableFromInline","warn_unqualified_access"],Pe=["iOS","iOSApplicationExtension","macOS","macOSApplicationExtension","macCatalyst","macCatalystApplicationExtension","watchOS","watchOSApplicationExtension","tvOS","tvOSApplicationExtension","swift"]
+;var Ke=Object.freeze({__proto__:null,grmr_bash:e=>{const n=e.regex,t={},a={
+begin:/\$\{/,end:/\}/,contains:["self",{begin:/:-/,contains:[t]}]}
+;Object.assign(t,{className:"variable",variants:[{
+begin:n.concat(/\$[\w\d#@][\w\d_]*/,"(?![\\w\\d])(?![$])")},a]});const i={
+className:"subst",begin:/\$\(/,end:/\)/,contains:[e.BACKSLASH_ESCAPE]},r={
+begin:/<<-?\s*(?=\w+)/,starts:{contains:[e.END_SAME_AS_BEGIN({begin:/(\w+)/,
+end:/(\w+)/,className:"string"})]}},s={className:"string",begin:/"/,end:/"/,
+contains:[e.BACKSLASH_ESCAPE,t,i]};i.contains.push(s);const o={begin:/\$?\(\(/,
+end:/\)\)/,contains:[{begin:/\d+#[0-9a-f]+/,className:"number"},e.NUMBER_MODE,t]
+},l=e.SHEBANG({binary:"(fish|bash|zsh|sh|csh|ksh|tcsh|dash|scsh)",relevance:10
+}),c={className:"function",begin:/\w[\w\d_]*\s*\(\s*\)\s*\{/,returnBegin:!0,
+contains:[e.inherit(e.TITLE_MODE,{begin:/\w[\w\d_]*/})],relevance:0};return{
+name:"Bash",aliases:["sh"],keywords:{$pattern:/\b[a-z][a-z0-9._-]+\b/,
+keyword:["if","then","else","elif","fi","for","while","until","in","do","done","case","esac","function","select"],
+literal:["true","false"],
+built_in:["break","cd","continue","eval","exec","exit","export","getopts","hash","pwd","readonly","return","shift","test","times","trap","umask","unset","alias","bind","builtin","caller","command","declare","echo","enable","help","let","local","logout","mapfile","printf","read","readarray","source","type","typeset","ulimit","unalias","set","shopt","autoload","bg","bindkey","bye","cap","chdir","clone","comparguments","compcall","compctl","compdescribe","compfiles","compgroups","compquote","comptags","comptry","compvalues","dirs","disable","disown","echotc","echoti","emulate","fc","fg","float","functions","getcap","getln","history","integer","jobs","kill","limit","log","noglob","popd","print","pushd","pushln","rehash","sched","setcap","setopt","stat","suspend","ttyctl","unfunction","unhash","unlimit","unsetopt","vared","wait","whence","where","which","zcompile","zformat","zftp","zle","zmodload","zparseopts","zprof","zpty","zregexparse","zsocket","zstyle","ztcp","chcon","chgrp","chown","chmod","cp","dd","df","dir","dircolors","ln","ls","mkdir","mkfifo","mknod","mktemp","mv","realpath","rm","rmdir","shred","sync","touch","truncate","vdir","b2sum","base32","base64","cat","cksum","comm","csplit","cut","expand","fmt","fold","head","join","md5sum","nl","numfmt","od","paste","ptx","pr","sha1sum","sha224sum","sha256sum","sha384sum","sha512sum","shuf","sort","split","sum","tac","tail","tr","tsort","unexpand","uniq","wc","arch","basename","chroot","date","dirname","du","echo","env","expr","factor","groups","hostid","id","link","logname","nice","nohup","nproc","pathchk","pinky","printenv","printf","pwd","readlink","runcon","seq","sleep","stat","stdbuf","stty","tee","test","timeout","tty","uname","unlink","uptime","users","who","whoami","yes"]
+},contains:[l,e.SHEBANG(),c,o,e.HASH_COMMENT_MODE,r,{match:/(\/[a-z._-]+)+/},s,{
+match:/\\"/},{className:"string",begin:/'/,end:/'/},{match:/\\'/},t]}},
+grmr_c:e=>{const n=e.regex,t=e.COMMENT("//","$",{contains:[{begin:/\\\n/}]
+}),a="decltype\\(auto\\)",i="[a-zA-Z_]\\w*::",r="("+a+"|"+n.optional(i)+"[a-zA-Z_]\\w*"+n.optional("<[^<>]+>")+")",s={
+className:"type",variants:[{begin:"\\b[a-z\\d_]*_t\\b"},{
+match:/\batomic_[a-z]{3,6}\b/}]},o={className:"string",variants:[{
+begin:'(u8?|U|L)?"',end:'"',illegal:"\\n",contains:[e.BACKSLASH_ESCAPE]},{
+begin:"(u8?|U|L)?'(\\\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4,8}|[0-7]{3}|\\S)|.)",
+end:"'",illegal:"."},e.END_SAME_AS_BEGIN({
+begin:/(?:u8?|U|L)?R"([^()\\ ]{0,16})\(/,end:/\)([^()\\ ]{0,16})"/})]},l={
+className:"number",variants:[{begin:"\\b(0b[01']+)"},{
+begin:"(-?)\\b([\\d']+(\\.[\\d']*)?|\\.[\\d']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)"
+},{
+begin:"(-?)(\\b0[xX][a-fA-F0-9']+|(\\b[\\d']+(\\.[\\d']*)?|\\.[\\d']+)([eE][-+]?[\\d']+)?)"
+}],relevance:0},c={className:"meta",begin:/#\s*[a-z]+\b/,end:/$/,keywords:{
+keyword:"if else elif endif define undef warning error line pragma _Pragma ifdef ifndef include"
+},contains:[{begin:/\\\n/,relevance:0},e.inherit(o,{className:"string"}),{
+className:"string",begin:/<.*?>/},t,e.C_BLOCK_COMMENT_MODE]},d={
+className:"title",begin:n.optional(i)+e.IDENT_RE,relevance:0
+},g=n.optional(i)+e.IDENT_RE+"\\s*\\(",u={
+keyword:["asm","auto","break","case","continue","default","do","else","enum","extern","for","fortran","goto","if","inline","register","restrict","return","sizeof","struct","switch","typedef","union","volatile","while","_Alignas","_Alignof","_Atomic","_Generic","_Noreturn","_Static_assert","_Thread_local","alignas","alignof","noreturn","static_assert","thread_local","_Pragma"],
+type:["float","double","signed","unsigned","int","short","long","char","void","_Bool","_Complex","_Imaginary","_Decimal32","_Decimal64","_Decimal128","const","static","complex","bool","imaginary"],
+literal:"true false NULL",
+built_in:"std string wstring cin cout cerr clog stdin stdout stderr stringstream istringstream ostringstream auto_ptr deque list queue stack vector map set pair bitset multiset multimap unordered_set unordered_map unordered_multiset unordered_multimap priority_queue make_pair array shared_ptr abort terminate abs acos asin atan2 atan calloc ceil cosh cos exit exp fabs floor fmod fprintf fputs free frexp fscanf future isalnum isalpha iscntrl isdigit isgraph islower isprint ispunct isspace isupper isxdigit tolower toupper labs ldexp log10 log malloc realloc memchr memcmp memcpy memset modf pow printf putchar puts scanf sinh sin snprintf sprintf sqrt sscanf strcat strchr strcmp strcpy strcspn strlen strncat strncmp strncpy strpbrk strrchr strspn strstr tanh tan vfprintf vprintf vsprintf endl initializer_list unique_ptr"
+},b=[c,s,t,e.C_BLOCK_COMMENT_MODE,l,o],m={variants:[{begin:/=/,end:/;/},{
+begin:/\(/,end:/\)/},{beginKeywords:"new throw return else",end:/;/}],
+keywords:u,contains:b.concat([{begin:/\(/,end:/\)/,keywords:u,
+contains:b.concat(["self"]),relevance:0}]),relevance:0},p={
+begin:"("+r+"[\\*&\\s]+)+"+g,returnBegin:!0,end:/[{;=]/,excludeEnd:!0,
+keywords:u,illegal:/[^\w\s\*&:<>.]/,contains:[{begin:a,keywords:u,relevance:0},{
+begin:g,returnBegin:!0,contains:[e.inherit(d,{className:"title.function"})],
+relevance:0},{relevance:0,match:/,/},{className:"params",begin:/\(/,end:/\)/,
+keywords:u,relevance:0,contains:[t,e.C_BLOCK_COMMENT_MODE,o,l,s,{begin:/\(/,
+end:/\)/,keywords:u,relevance:0,contains:["self",t,e.C_BLOCK_COMMENT_MODE,o,l,s]
+}]},s,t,e.C_BLOCK_COMMENT_MODE,c]};return{name:"C",aliases:["h"],keywords:u,
+disableAutodetect:!0,illegal:"</",contains:[].concat(m,p,b,[c,{
+begin:e.IDENT_RE+"::",keywords:u},{className:"class",
+beginKeywords:"enum class struct union",end:/[{;:<>=]/,contains:[{
+beginKeywords:"final class struct"},e.TITLE_MODE]}]),exports:{preprocessor:c,
+strings:o,keywords:u}}},grmr_cpp:e=>{const n=e.regex,t=e.COMMENT("//","$",{
+contains:[{begin:/\\\n/}]
+}),a="decltype\\(auto\\)",i="[a-zA-Z_]\\w*::",r="(?!struct)("+a+"|"+n.optional(i)+"[a-zA-Z_]\\w*"+n.optional("<[^<>]+>")+")",s={
+className:"type",begin:"\\b[a-z\\d_]*_t\\b"},o={className:"string",variants:[{
+begin:'(u8?|U|L)?"',end:'"',illegal:"\\n",contains:[e.BACKSLASH_ESCAPE]},{
+begin:"(u8?|U|L)?'(\\\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4,8}|[0-7]{3}|\\S)|.)",
+end:"'",illegal:"."},e.END_SAME_AS_BEGIN({
+begin:/(?:u8?|U|L)?R"([^()\\ ]{0,16})\(/,end:/\)([^()\\ ]{0,16})"/})]},l={
+className:"number",variants:[{begin:"\\b(0b[01']+)"},{
+begin:"(-?)\\b([\\d']+(\\.[\\d']*)?|\\.[\\d']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)"
+},{
+begin:"(-?)(\\b0[xX][a-fA-F0-9']+|(\\b[\\d']+(\\.[\\d']*)?|\\.[\\d']+)([eE][-+]?[\\d']+)?)"
+}],relevance:0},c={className:"meta",begin:/#\s*[a-z]+\b/,end:/$/,keywords:{
+keyword:"if else elif endif define undef warning error line pragma _Pragma ifdef ifndef include"
+},contains:[{begin:/\\\n/,relevance:0},e.inherit(o,{className:"string"}),{
+className:"string",begin:/<.*?>/},t,e.C_BLOCK_COMMENT_MODE]},d={
+className:"title",begin:n.optional(i)+e.IDENT_RE,relevance:0
+},g=n.optional(i)+e.IDENT_RE+"\\s*\\(",u={
+type:["bool","char","char16_t","char32_t","char8_t","double","float","int","long","short","void","wchar_t","unsigned","signed","const","static"],
+keyword:["alignas","alignof","and","and_eq","asm","atomic_cancel","atomic_commit","atomic_noexcept","auto","bitand","bitor","break","case","catch","class","co_await","co_return","co_yield","compl","concept","const_cast|10","consteval","constexpr","constinit","continue","decltype","default","delete","do","dynamic_cast|10","else","enum","explicit","export","extern","false","final","for","friend","goto","if","import","inline","module","mutable","namespace","new","noexcept","not","not_eq","nullptr","operator","or","or_eq","override","private","protected","public","reflexpr","register","reinterpret_cast|10","requires","return","sizeof","static_assert","static_cast|10","struct","switch","synchronized","template","this","thread_local","throw","transaction_safe","transaction_safe_dynamic","true","try","typedef","typeid","typename","union","using","virtual","volatile","while","xor","xor_eq"],
+literal:["NULL","false","nullopt","nullptr","true"],built_in:["_Pragma"],
+_type_hints:["any","auto_ptr","barrier","binary_semaphore","bitset","complex","condition_variable","condition_variable_any","counting_semaphore","deque","false_type","future","imaginary","initializer_list","istringstream","jthread","latch","lock_guard","multimap","multiset","mutex","optional","ostringstream","packaged_task","pair","promise","priority_queue","queue","recursive_mutex","recursive_timed_mutex","scoped_lock","set","shared_future","shared_lock","shared_mutex","shared_timed_mutex","shared_ptr","stack","string_view","stringstream","timed_mutex","thread","true_type","tuple","unique_lock","unique_ptr","unordered_map","unordered_multimap","unordered_multiset","unordered_set","variant","vector","weak_ptr","wstring","wstring_view"]
+},b={className:"function.dispatch",relevance:0,keywords:{
+_hint:["abort","abs","acos","apply","as_const","asin","atan","atan2","calloc","ceil","cerr","cin","clog","cos","cosh","cout","declval","endl","exchange","exit","exp","fabs","floor","fmod","forward","fprintf","fputs","free","frexp","fscanf","future","invoke","isalnum","isalpha","iscntrl","isdigit","isgraph","islower","isprint","ispunct","isspace","isupper","isxdigit","labs","launder","ldexp","log","log10","make_pair","make_shared","make_shared_for_overwrite","make_tuple","make_unique","malloc","memchr","memcmp","memcpy","memset","modf","move","pow","printf","putchar","puts","realloc","scanf","sin","sinh","snprintf","sprintf","sqrt","sscanf","std","stderr","stdin","stdout","strcat","strchr","strcmp","strcpy","strcspn","strlen","strncat","strncmp","strncpy","strpbrk","strrchr","strspn","strstr","swap","tan","tanh","terminate","to_underlying","tolower","toupper","vfprintf","visit","vprintf","vsprintf"]
+},
+begin:n.concat(/\b/,/(?!decltype)/,/(?!if)/,/(?!for)/,/(?!switch)/,/(?!while)/,e.IDENT_RE,n.lookahead(/(<[^<>]+>|)\s*\(/))
+},m=[b,c,s,t,e.C_BLOCK_COMMENT_MODE,l,o],p={variants:[{begin:/=/,end:/;/},{
+begin:/\(/,end:/\)/},{beginKeywords:"new throw return else",end:/;/}],
+keywords:u,contains:m.concat([{begin:/\(/,end:/\)/,keywords:u,
+contains:m.concat(["self"]),relevance:0}]),relevance:0},_={className:"function",
+begin:"("+r+"[\\*&\\s]+)+"+g,returnBegin:!0,end:/[{;=]/,excludeEnd:!0,
+keywords:u,illegal:/[^\w\s\*&:<>.]/,contains:[{begin:a,keywords:u,relevance:0},{
+begin:g,returnBegin:!0,contains:[d],relevance:0},{begin:/::/,relevance:0},{
+begin:/:/,endsWithParent:!0,contains:[o,l]},{relevance:0,match:/,/},{
+className:"params",begin:/\(/,end:/\)/,keywords:u,relevance:0,
+contains:[t,e.C_BLOCK_COMMENT_MODE,o,l,s,{begin:/\(/,end:/\)/,keywords:u,
+relevance:0,contains:["self",t,e.C_BLOCK_COMMENT_MODE,o,l,s]}]
+},s,t,e.C_BLOCK_COMMENT_MODE,c]};return{name:"C++",
+aliases:["cc","c++","h++","hpp","hh","hxx","cxx"],keywords:u,illegal:"</",
+classNameAliases:{"function.dispatch":"built_in"},
+contains:[].concat(p,_,b,m,[c,{
+begin:"\\b(deque|list|queue|priority_queue|pair|stack|vector|map|set|bitset|multiset|multimap|unordered_map|unordered_set|unordered_multiset|unordered_multimap|array|tuple|optional|variant|function)\\s*<(?!<)",
+end:">",keywords:u,contains:["self",s]},{begin:e.IDENT_RE+"::",keywords:u},{
+match:[/\b(?:enum(?:\s+(?:class|struct))?|class|struct|union)/,/\s+/,/\w+/],
+className:{1:"keyword",3:"title.class"}}])}},grmr_csharp:e=>{const n={
+keyword:["abstract","as","base","break","case","catch","class","const","continue","do","else","event","explicit","extern","finally","fixed","for","foreach","goto","if","implicit","in","interface","internal","is","lock","namespace","new","operator","out","override","params","private","protected","public","readonly","record","ref","return","scoped","sealed","sizeof","stackalloc","static","struct","switch","this","throw","try","typeof","unchecked","unsafe","using","virtual","void","volatile","while"].concat(["add","alias","and","ascending","async","await","by","descending","equals","from","get","global","group","init","into","join","let","nameof","not","notnull","on","or","orderby","partial","remove","select","set","unmanaged","value|0","var","when","where","with","yield"]),
+built_in:["bool","byte","char","decimal","delegate","double","dynamic","enum","float","int","long","nint","nuint","object","sbyte","short","string","ulong","uint","ushort"],
+literal:["default","false","null","true"]},t=e.inherit(e.TITLE_MODE,{
+begin:"[a-zA-Z](\\.?\\w)*"}),a={className:"number",variants:[{
+begin:"\\b(0b[01']+)"},{
+begin:"(-?)\\b([\\d']+(\\.[\\d']*)?|\\.[\\d']+)(u|U|l|L|ul|UL|f|F|b|B)"},{
+begin:"(-?)(\\b0[xX][a-fA-F0-9']+|(\\b[\\d']+(\\.[\\d']*)?|\\.[\\d']+)([eE][-+]?[\\d']+)?)"
+}],relevance:0},i={className:"string",begin:'@"',end:'"',contains:[{begin:'""'}]
+},r=e.inherit(i,{illegal:/\n/}),s={className:"subst",begin:/\{/,end:/\}/,
+keywords:n},o=e.inherit(s,{illegal:/\n/}),l={className:"string",begin:/\$"/,
+end:'"',illegal:/\n/,contains:[{begin:/\{\{/},{begin:/\}\}/
+},e.BACKSLASH_ESCAPE,o]},c={className:"string",begin:/\$@"/,end:'"',contains:[{
+begin:/\{\{/},{begin:/\}\}/},{begin:'""'},s]},d=e.inherit(c,{illegal:/\n/,
+contains:[{begin:/\{\{/},{begin:/\}\}/},{begin:'""'},o]})
+;s.contains=[c,l,i,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,a,e.C_BLOCK_COMMENT_MODE],
+o.contains=[d,l,r,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,a,e.inherit(e.C_BLOCK_COMMENT_MODE,{
+illegal:/\n/})];const g={variants:[c,l,i,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE]
+},u={begin:"<",end:">",contains:[{beginKeywords:"in out"},t]
+},b=e.IDENT_RE+"(<"+e.IDENT_RE+"(\\s*,\\s*"+e.IDENT_RE+")*>)?(\\[\\])?",m={
+begin:"@"+e.IDENT_RE,relevance:0};return{name:"C#",aliases:["cs","c#"],
+keywords:n,illegal:/::/,contains:[e.COMMENT("///","$",{returnBegin:!0,
+contains:[{className:"doctag",variants:[{begin:"///",relevance:0},{
+begin:"\x3c!--|--\x3e"},{begin:"</?",end:">"}]}]
+}),e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,{className:"meta",begin:"#",
+end:"$",keywords:{
+keyword:"if else elif endif define undef warning error line region endregion pragma checksum"
+}},g,a,{beginKeywords:"class interface",relevance:0,end:/[{;=]/,
+illegal:/[^\s:,]/,contains:[{beginKeywords:"where class"
+},t,u,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{beginKeywords:"namespace",
+relevance:0,end:/[{;=]/,illegal:/[^\s:]/,
+contains:[t,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{
+beginKeywords:"record",relevance:0,end:/[{;=]/,illegal:/[^\s:]/,
+contains:[t,u,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{className:"meta",
+begin:"^\\s*\\[(?=[\\w])",excludeBegin:!0,end:"\\]",excludeEnd:!0,contains:[{
+className:"string",begin:/"/,end:/"/}]},{
+beginKeywords:"new return throw await else",relevance:0},{className:"function",
+begin:"("+b+"\\s+)+"+e.IDENT_RE+"\\s*(<[^=]+>\\s*)?\\(",returnBegin:!0,
+end:/\s*[{;=]/,excludeEnd:!0,keywords:n,contains:[{
+beginKeywords:"public private protected static internal protected abstract async extern override unsafe virtual new sealed partial",
+relevance:0},{begin:e.IDENT_RE+"\\s*(<[^=]+>\\s*)?\\(",returnBegin:!0,
+contains:[e.TITLE_MODE,u],relevance:0},{match:/\(\)/},{className:"params",
+begin:/\(/,end:/\)/,excludeBegin:!0,excludeEnd:!0,keywords:n,relevance:0,
+contains:[g,a,e.C_BLOCK_COMMENT_MODE]
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},m]}},grmr_css:e=>{
+const n=e.regex,t=ie(e),a=[e.APOS_STRING_MODE,e.QUOTE_STRING_MODE];return{
+name:"CSS",case_insensitive:!0,illegal:/[=|'\$]/,keywords:{
+keyframePosition:"from to"},classNameAliases:{keyframePosition:"selector-tag"},
+contains:[t.BLOCK_COMMENT,{begin:/-(webkit|moz|ms|o)-(?=[a-z])/
+},t.CSS_NUMBER_MODE,{className:"selector-id",begin:/#[A-Za-z0-9_-]+/,relevance:0
+},{className:"selector-class",begin:"\\.[a-zA-Z-][a-zA-Z0-9_-]*",relevance:0
+},t.ATTRIBUTE_SELECTOR_MODE,{className:"selector-pseudo",variants:[{
+begin:":("+oe.join("|")+")"},{begin:":(:)?("+le.join("|")+")"}]
+},t.CSS_VARIABLE,{className:"attribute",begin:"\\b("+ce.join("|")+")\\b"},{
+begin:/:/,end:/[;}{]/,
+contains:[t.BLOCK_COMMENT,t.HEXCOLOR,t.IMPORTANT,t.CSS_NUMBER_MODE,...a,{
+begin:/(url|data-uri)\(/,end:/\)/,relevance:0,keywords:{built_in:"url data-uri"
+},contains:[...a,{className:"string",begin:/[^)]/,endsWithParent:!0,
+excludeEnd:!0}]},t.FUNCTION_DISPATCH]},{begin:n.lookahead(/@/),end:"[{;]",
+relevance:0,illegal:/:/,contains:[{className:"keyword",begin:/@-?\w[\w]*(-\w+)*/
+},{begin:/\s/,endsWithParent:!0,excludeEnd:!0,relevance:0,keywords:{
+$pattern:/[a-z-]+/,keyword:"and or not only",attribute:se.join(" ")},contains:[{
+begin:/[a-z-]+(?=:)/,className:"attribute"},...a,t.CSS_NUMBER_MODE]}]},{
+className:"selector-tag",begin:"\\b("+re.join("|")+")\\b"}]}},grmr_diff:e=>{
+const n=e.regex;return{name:"Diff",aliases:["patch"],contains:[{
+className:"meta",relevance:10,
+match:n.either(/^@@ +-\d+,\d+ +\+\d+,\d+ +@@/,/^\*\*\* +\d+,\d+ +\*\*\*\*$/,/^--- +\d+,\d+ +----$/)
+},{className:"comment",variants:[{
+begin:n.either(/Index: /,/^index/,/={3,}/,/^-{3}/,/^\*{3} /,/^\+{3}/,/^diff --git/),
+end:/$/},{match:/^\*{15}$/}]},{className:"addition",begin:/^\+/,end:/$/},{
+className:"deletion",begin:/^-/,end:/$/},{className:"addition",begin:/^!/,
+end:/$/}]}},grmr_go:e=>{const n={
+keyword:["break","case","chan","const","continue","default","defer","else","fallthrough","for","func","go","goto","if","import","interface","map","package","range","return","select","struct","switch","type","var"],
+type:["bool","byte","complex64","complex128","error","float32","float64","int8","int16","int32","int64","string","uint8","uint16","uint32","uint64","int","uint","uintptr","rune"],
+literal:["true","false","iota","nil"],
+built_in:["append","cap","close","complex","copy","imag","len","make","new","panic","print","println","real","recover","delete"]
+};return{name:"Go",aliases:["golang"],keywords:n,illegal:"</",
+contains:[e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,{className:"string",
+variants:[e.QUOTE_STRING_MODE,e.APOS_STRING_MODE,{begin:"`",end:"`"}]},{
+className:"number",variants:[{begin:e.C_NUMBER_RE+"[i]",relevance:1
+},e.C_NUMBER_MODE]},{begin:/:=/},{className:"function",beginKeywords:"func",
+end:"\\s*(\\{|$)",excludeEnd:!0,contains:[e.TITLE_MODE,{className:"params",
+begin:/\(/,end:/\)/,endsParent:!0,keywords:n,illegal:/["']/}]}]}},
+grmr_graphql:e=>{const n=e.regex;return{name:"GraphQL",aliases:["gql"],
+case_insensitive:!0,disableAutodetect:!1,keywords:{
+keyword:["query","mutation","subscription","type","input","schema","directive","interface","union","scalar","fragment","enum","on"],
+literal:["true","false","null"]},
+contains:[e.HASH_COMMENT_MODE,e.QUOTE_STRING_MODE,e.NUMBER_MODE,{
+scope:"punctuation",match:/[.]{3}/,relevance:0},{scope:"punctuation",
+begin:/[\!\(\)\:\=\[\]\{\|\}]{1}/,relevance:0},{scope:"variable",begin:/\$/,
+end:/\W/,excludeEnd:!0,relevance:0},{scope:"meta",match:/@\w+/,excludeEnd:!0},{
+scope:"symbol",begin:n.concat(/[_A-Za-z][_0-9A-Za-z]*/,n.lookahead(/\s*:/)),
+relevance:0}],illegal:[/[;<']/,/BEGIN/]}},grmr_ini:e=>{const n=e.regex,t={
+className:"number",relevance:0,variants:[{begin:/([+-]+)?[\d]+_[\d_]+/},{
+begin:e.NUMBER_RE}]},a=e.COMMENT();a.variants=[{begin:/;/,end:/$/},{begin:/#/,
+end:/$/}];const i={className:"variable",variants:[{begin:/\$[\w\d"][\w\d_]*/},{
+begin:/\$\{(.*?)\}/}]},r={className:"literal",
+begin:/\bon|off|true|false|yes|no\b/},s={className:"string",
+contains:[e.BACKSLASH_ESCAPE],variants:[{begin:"'''",end:"'''",relevance:10},{
+begin:'"""',end:'"""',relevance:10},{begin:'"',end:'"'},{begin:"'",end:"'"}]
+},o={begin:/\[/,end:/\]/,contains:[a,r,i,s,t,"self"],relevance:0
+},l=n.either(/[A-Za-z0-9_-]+/,/"(\\"|[^"])*"/,/'[^']*'/);return{
+name:"TOML, also INI",aliases:["toml"],case_insensitive:!0,illegal:/\S/,
+contains:[a,{className:"section",begin:/\[+/,end:/\]+/},{
+begin:n.concat(l,"(\\s*\\.\\s*",l,")*",n.lookahead(/\s*=\s*[^#\s]/)),
+className:"attr",starts:{end:/$/,contains:[a,o,r,i,s,t]}}]}},grmr_java:e=>{
+const n=e.regex,t="[\xc0-\u02b8a-zA-Z_$][\xc0-\u02b8a-zA-Z_$0-9]*",a=t+pe("(?:<"+t+"~~~(?:\\s*,\\s*"+t+"~~~)*>)?",/~~~/g,2),i={
+keyword:["synchronized","abstract","private","var","static","if","const ","for","while","strictfp","finally","protected","import","native","final","void","enum","else","break","transient","catch","instanceof","volatile","case","assert","package","default","public","try","switch","continue","throws","protected","public","private","module","requires","exports","do","sealed","yield","permits"],
+literal:["false","true","null"],
+type:["char","boolean","long","float","int","byte","short","double"],
+built_in:["super","this"]},r={className:"meta",begin:"@"+t,contains:[{
+begin:/\(/,end:/\)/,contains:["self"]}]},s={className:"params",begin:/\(/,
+end:/\)/,keywords:i,relevance:0,contains:[e.C_BLOCK_COMMENT_MODE],endsParent:!0}
+;return{name:"Java",aliases:["jsp"],keywords:i,illegal:/<\/|#/,
+contains:[e.COMMENT("/\\*\\*","\\*/",{relevance:0,contains:[{begin:/\w+@/,
+relevance:0},{className:"doctag",begin:"@[A-Za-z]+"}]}),{
+begin:/import java\.[a-z]+\./,keywords:"import",relevance:2
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,{begin:/"""/,end:/"""/,
+className:"string",contains:[e.BACKSLASH_ESCAPE]
+},e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,{
+match:[/\b(?:class|interface|enum|extends|implements|new)/,/\s+/,t],className:{
+1:"keyword",3:"title.class"}},{match:/non-sealed/,scope:"keyword"},{
+begin:[n.concat(/(?!else)/,t),/\s+/,t,/\s+/,/=(?!=)/],className:{1:"type",
+3:"variable",5:"operator"}},{begin:[/record/,/\s+/,t],className:{1:"keyword",
+3:"title.class"},contains:[s,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{
+beginKeywords:"new throw return else",relevance:0},{
+begin:["(?:"+a+"\\s+)",e.UNDERSCORE_IDENT_RE,/\s*(?=\()/],className:{
+2:"title.function"},keywords:i,contains:[{className:"params",begin:/\(/,
+end:/\)/,keywords:i,relevance:0,
+contains:[r,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,me,e.C_BLOCK_COMMENT_MODE]
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},me,r]}},grmr_javascript:Oe,
+grmr_json:e=>{const n=["true","false","null"],t={scope:"literal",
+beginKeywords:n.join(" ")};return{name:"JSON",keywords:{literal:n},contains:[{
+className:"attr",begin:/"(\\.|[^\\"\r\n])*"(?=\s*:)/,relevance:1.01},{
+match:/[{}[\],:]/,className:"punctuation",relevance:0
+},e.QUOTE_STRING_MODE,t,e.C_NUMBER_MODE,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE],
+illegal:"\\S"}},grmr_kotlin:e=>{const n={
+keyword:"abstract as val var vararg get set class object open private protected public noinline crossinline dynamic final enum if else do while for when throw try catch finally import package is in fun override companion reified inline lateinit init interface annotation data sealed internal infix operator out by constructor super tailrec where const inner suspend typealias external expect actual",
+built_in:"Byte Short Char Int Long Boolean Float Double Void Unit Nothing",
+literal:"true false null"},t={className:"symbol",begin:e.UNDERSCORE_IDENT_RE+"@"
+},a={className:"subst",begin:/\$\{/,end:/\}/,contains:[e.C_NUMBER_MODE]},i={
+className:"variable",begin:"\\$"+e.UNDERSCORE_IDENT_RE},r={className:"string",
+variants:[{begin:'"""',end:'"""(?=[^"])',contains:[i,a]},{begin:"'",end:"'",
+illegal:/\n/,contains:[e.BACKSLASH_ESCAPE]},{begin:'"',end:'"',illegal:/\n/,
+contains:[e.BACKSLASH_ESCAPE,i,a]}]};a.contains.push(r);const s={
+className:"meta",
+begin:"@(?:file|property|field|get|set|receiver|param|setparam|delegate)\\s*:(?:\\s*"+e.UNDERSCORE_IDENT_RE+")?"
+},o={className:"meta",begin:"@"+e.UNDERSCORE_IDENT_RE,contains:[{begin:/\(/,
+end:/\)/,contains:[e.inherit(r,{className:"string"}),"self"]}]
+},l=me,c=e.COMMENT("/\\*","\\*/",{contains:[e.C_BLOCK_COMMENT_MODE]}),d={
+variants:[{className:"type",begin:e.UNDERSCORE_IDENT_RE},{begin:/\(/,end:/\)/,
+contains:[]}]},g=d;return g.variants[1].contains=[d],d.variants[1].contains=[g],
+{name:"Kotlin",aliases:["kt","kts"],keywords:n,
+contains:[e.COMMENT("/\\*\\*","\\*/",{relevance:0,contains:[{className:"doctag",
+begin:"@[A-Za-z]+"}]}),e.C_LINE_COMMENT_MODE,c,{className:"keyword",
+begin:/\b(break|continue|return|this)\b/,starts:{contains:[{className:"symbol",
+begin:/@\w+/}]}},t,s,o,{className:"function",beginKeywords:"fun",end:"[(]|$",
+returnBegin:!0,excludeEnd:!0,keywords:n,relevance:5,contains:[{
+begin:e.UNDERSCORE_IDENT_RE+"\\s*\\(",returnBegin:!0,relevance:0,
+contains:[e.UNDERSCORE_TITLE_MODE]},{className:"type",begin:/</,end:/>/,
+keywords:"reified",relevance:0},{className:"params",begin:/\(/,end:/\)/,
+endsParent:!0,keywords:n,relevance:0,contains:[{begin:/:/,end:/[=,\/]/,
+endsWithParent:!0,contains:[d,e.C_LINE_COMMENT_MODE,c],relevance:0
+},e.C_LINE_COMMENT_MODE,c,s,o,r,e.C_NUMBER_MODE]},c]},{
+begin:[/class|interface|trait/,/\s+/,e.UNDERSCORE_IDENT_RE],beginScope:{
+3:"title.class"},keywords:"class interface trait",end:/[:\{(]|$/,excludeEnd:!0,
+illegal:"extends implements",contains:[{
+beginKeywords:"public protected internal private constructor"
+},e.UNDERSCORE_TITLE_MODE,{className:"type",begin:/</,end:/>/,excludeBegin:!0,
+excludeEnd:!0,relevance:0},{className:"type",begin:/[,:]\s*/,end:/[<\(,){\s]|$/,
+excludeBegin:!0,returnEnd:!0},s,o]},r,{className:"meta",begin:"^#!/usr/bin/env",
+end:"$",illegal:"\n"},l]}},grmr_less:e=>{
+const n=ie(e),t=de,a="[\\w-]+",i="("+a+"|@\\{"+a+"\\})",r=[],s=[],o=e=>({
+className:"string",begin:"~?"+e+".*?"+e}),l=(e,n,t)=>({className:e,begin:n,
+relevance:t}),c={$pattern:/[a-z-]+/,keyword:"and or not only",
+attribute:se.join(" ")},d={begin:"\\(",end:"\\)",contains:s,keywords:c,
+relevance:0}
+;s.push(e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,o("'"),o('"'),n.CSS_NUMBER_MODE,{
+begin:"(url|data-uri)\\(",starts:{className:"string",end:"[\\)\\n]",
+excludeEnd:!0}
+},n.HEXCOLOR,d,l("variable","@@?"+a,10),l("variable","@\\{"+a+"\\}"),l("built_in","~?`[^`]*?`"),{
+className:"attribute",begin:a+"\\s*:",end:":",returnBegin:!0,excludeEnd:!0
+},n.IMPORTANT,{beginKeywords:"and not"},n.FUNCTION_DISPATCH);const g=s.concat({
+begin:/\{/,end:/\}/,contains:r}),u={beginKeywords:"when",endsWithParent:!0,
+contains:[{beginKeywords:"and not"}].concat(s)},b={begin:i+"\\s*:",
+returnBegin:!0,end:/[;}]/,relevance:0,contains:[{begin:/-(webkit|moz|ms|o)-/
+},n.CSS_VARIABLE,{className:"attribute",begin:"\\b("+ce.join("|")+")\\b",
+end:/(?=:)/,starts:{endsWithParent:!0,illegal:"[<=$]",relevance:0,contains:s}}]
+},m={className:"keyword",
+begin:"@(import|media|charset|font-face|(-[a-z]+-)?keyframes|supports|document|namespace|page|viewport|host)\\b",
+starts:{end:"[;{}]",keywords:c,returnEnd:!0,contains:s,relevance:0}},p={
+className:"variable",variants:[{begin:"@"+a+"\\s*:",relevance:15},{begin:"@"+a
+}],starts:{end:"[;}]",returnEnd:!0,contains:g}},_={variants:[{
+begin:"[\\.#:&\\[>]",end:"[;{}]"},{begin:i,end:/\{/}],returnBegin:!0,
+returnEnd:!0,illegal:"[<='$\"]",relevance:0,
+contains:[e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,u,l("keyword","all\\b"),l("variable","@\\{"+a+"\\}"),{
+begin:"\\b("+re.join("|")+")\\b",className:"selector-tag"
+},n.CSS_NUMBER_MODE,l("selector-tag",i,0),l("selector-id","#"+i),l("selector-class","\\."+i,0),l("selector-tag","&",0),n.ATTRIBUTE_SELECTOR_MODE,{
+className:"selector-pseudo",begin:":("+oe.join("|")+")"},{
+className:"selector-pseudo",begin:":(:)?("+le.join("|")+")"},{begin:/\(/,
+end:/\)/,relevance:0,contains:g},{begin:"!important"},n.FUNCTION_DISPATCH]},h={
+begin:a+":(:)?"+`(${t.join("|")})`,returnBegin:!0,contains:[_]}
+;return r.push(e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,m,p,h,b,_,u,n.FUNCTION_DISPATCH),
+{name:"Less",case_insensitive:!0,illegal:"[=>'/<($\"]",contains:r}},
+grmr_lua:e=>{const n="\\[=*\\[",t="\\]=*\\]",a={begin:n,end:t,contains:["self"]
+},i=[e.COMMENT("--(?!"+n+")","$"),e.COMMENT("--"+n,t,{contains:[a],relevance:10
+})];return{name:"Lua",keywords:{$pattern:e.UNDERSCORE_IDENT_RE,
+literal:"true false nil",
+keyword:"and break do else elseif end for goto if in local not or repeat return then until while",
+built_in:"_G _ENV _VERSION __index __newindex __mode __call __metatable __tostring __len __gc __add __sub __mul __div __mod __pow __concat __unm __eq __lt __le assert collectgarbage dofile error getfenv getmetatable ipairs load loadfile loadstring module next pairs pcall print rawequal rawget rawset require select setfenv setmetatable tonumber tostring type unpack xpcall arg self coroutine resume yield status wrap create running debug getupvalue debug sethook getmetatable gethook setmetatable setlocal traceback setfenv getinfo setupvalue getlocal getregistry getfenv io lines write close flush open output type read stderr stdin input stdout popen tmpfile math log max acos huge ldexp pi cos tanh pow deg tan cosh sinh random randomseed frexp ceil floor rad abs sqrt modf asin min mod fmod log10 atan2 exp sin atan os exit setlocale date getenv difftime remove time clock tmpname rename execute package preload loadlib loaded loaders cpath config path seeall string sub upper len gfind rep find match char dump gmatch reverse byte format gsub lower table setn insert getn foreachi maxn foreach concat sort remove"
+},contains:i.concat([{className:"function",beginKeywords:"function",end:"\\)",
+contains:[e.inherit(e.TITLE_MODE,{
+begin:"([_a-zA-Z]\\w*\\.)*([_a-zA-Z]\\w*:)?[_a-zA-Z]\\w*"}),{className:"params",
+begin:"\\(",endsWithParent:!0,contains:i}].concat(i)
+},e.C_NUMBER_MODE,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,{className:"string",
+begin:n,end:t,contains:[a],relevance:5}])}},grmr_makefile:e=>{const n={
+className:"variable",variants:[{begin:"\\$\\("+e.UNDERSCORE_IDENT_RE+"\\)",
+contains:[e.BACKSLASH_ESCAPE]},{begin:/\$[@%<?\^\+\*]/}]},t={className:"string",
+begin:/"/,end:/"/,contains:[e.BACKSLASH_ESCAPE,n]},a={className:"variable",
+begin:/\$\([\w-]+\s/,end:/\)/,keywords:{
+built_in:"subst patsubst strip findstring filter filter-out sort word wordlist firstword lastword dir notdir suffix basename addsuffix addprefix join wildcard realpath abspath error warning shell origin flavor foreach if or and call eval file value"
+},contains:[n]},i={begin:"^"+e.UNDERSCORE_IDENT_RE+"\\s*(?=[:+?]?=)"},r={
+className:"section",begin:/^[^\s]+:/,end:/$/,contains:[n]};return{
+name:"Makefile",aliases:["mk","mak","make"],keywords:{$pattern:/[\w-]+/,
+keyword:"define endef undefine ifdef ifndef ifeq ifneq else endif include -include sinclude override export unexport private vpath"
+},contains:[e.HASH_COMMENT_MODE,n,t,a,i,{className:"meta",begin:/^\.PHONY:/,
+end:/$/,keywords:{$pattern:/[\.\w]+/,keyword:".PHONY"}},r]}},grmr_markdown:e=>{
+const n={begin:/<\/?[A-Za-z_]/,end:">",subLanguage:"xml",relevance:0},t={
+variants:[{begin:/\[.+?\]\[.*?\]/,relevance:0},{
+begin:/\[.+?\]\(((data|javascript|mailto):|(?:http|ftp)s?:\/\/).*?\)/,
+relevance:2},{
+begin:e.regex.concat(/\[.+?\]\(/,/[A-Za-z][A-Za-z0-9+.-]*/,/:\/\/.*?\)/),
+relevance:2},{begin:/\[.+?\]\([./?&#].*?\)/,relevance:1},{
+begin:/\[.*?\]\(.*?\)/,relevance:0}],returnBegin:!0,contains:[{match:/\[(?=\])/
+},{className:"string",relevance:0,begin:"\\[",end:"\\]",excludeBegin:!0,
+returnEnd:!0},{className:"link",relevance:0,begin:"\\]\\(",end:"\\)",
+excludeBegin:!0,excludeEnd:!0},{className:"symbol",relevance:0,begin:"\\]\\[",
+end:"\\]",excludeBegin:!0,excludeEnd:!0}]},a={className:"strong",contains:[],
+variants:[{begin:/_{2}(?!\s)/,end:/_{2}/},{begin:/\*{2}(?!\s)/,end:/\*{2}/}]
+},i={className:"emphasis",contains:[],variants:[{begin:/\*(?![*\s])/,end:/\*/},{
+begin:/_(?![_\s])/,end:/_/,relevance:0}]},r=e.inherit(a,{contains:[]
+}),s=e.inherit(i,{contains:[]});a.contains.push(s),i.contains.push(r)
+;let o=[n,t];return[a,i,r,s].forEach((e=>{e.contains=e.contains.concat(o)
+})),o=o.concat(a,i),{name:"Markdown",aliases:["md","mkdown","mkd"],contains:[{
+className:"section",variants:[{begin:"^#{1,6}",end:"$",contains:o},{
+begin:"(?=^.+?\\n[=-]{2,}$)",contains:[{begin:"^[=-]*$"},{begin:"^",end:"\\n",
+contains:o}]}]},n,{className:"bullet",begin:"^[ \t]*([*+-]|(\\d+\\.))(?=\\s+)",
+end:"\\s+",excludeEnd:!0},a,i,{className:"quote",begin:"^>\\s+",contains:o,
+end:"$"},{className:"code",variants:[{begin:"(`{3,})[^`](.|\\n)*?\\1`*[ ]*"},{
+begin:"(~{3,})[^~](.|\\n)*?\\1~*[ ]*"},{begin:"```",end:"```+[ ]*$"},{
+begin:"~~~",end:"~~~+[ ]*$"},{begin:"`.+?`"},{begin:"(?=^( {4}|\\t))",
+contains:[{begin:"^( {4}|\\t)",end:"(\\n)$"}],relevance:0}]},{
+begin:"^[-\\*]{3,}",end:"$"},t,{begin:/^\[[^\n]+\]:/,returnBegin:!0,contains:[{
+className:"symbol",begin:/\[/,end:/\]/,excludeBegin:!0,excludeEnd:!0},{
+className:"link",begin:/:\s*/,end:/$/,excludeBegin:!0}]}]}},grmr_objectivec:e=>{
+const n=/[a-zA-Z@][a-zA-Z0-9_]*/,t={$pattern:n,
+keyword:["@interface","@class","@protocol","@implementation"]};return{
+name:"Objective-C",aliases:["mm","objc","obj-c","obj-c++","objective-c++"],
+keywords:{"variable.language":["this","super"],$pattern:n,
+keyword:["while","export","sizeof","typedef","const","struct","for","union","volatile","static","mutable","if","do","return","goto","enum","else","break","extern","asm","case","default","register","explicit","typename","switch","continue","inline","readonly","assign","readwrite","self","@synchronized","id","typeof","nonatomic","IBOutlet","IBAction","strong","weak","copy","in","out","inout","bycopy","byref","oneway","__strong","__weak","__block","__autoreleasing","@private","@protected","@public","@try","@property","@end","@throw","@catch","@finally","@autoreleasepool","@synthesize","@dynamic","@selector","@optional","@required","@encode","@package","@import","@defs","@compatibility_alias","__bridge","__bridge_transfer","__bridge_retained","__bridge_retain","__covariant","__contravariant","__kindof","_Nonnull","_Nullable","_Null_unspecified","__FUNCTION__","__PRETTY_FUNCTION__","__attribute__","getter","setter","retain","unsafe_unretained","nonnull","nullable","null_unspecified","null_resettable","class","instancetype","NS_DESIGNATED_INITIALIZER","NS_UNAVAILABLE","NS_REQUIRES_SUPER","NS_RETURNS_INNER_POINTER","NS_INLINE","NS_AVAILABLE","NS_DEPRECATED","NS_ENUM","NS_OPTIONS","NS_SWIFT_UNAVAILABLE","NS_ASSUME_NONNULL_BEGIN","NS_ASSUME_NONNULL_END","NS_REFINED_FOR_SWIFT","NS_SWIFT_NAME","NS_SWIFT_NOTHROW","NS_DURING","NS_HANDLER","NS_ENDHANDLER","NS_VALUERETURN","NS_VOIDRETURN"],
+literal:["false","true","FALSE","TRUE","nil","YES","NO","NULL"],
+built_in:["dispatch_once_t","dispatch_queue_t","dispatch_sync","dispatch_async","dispatch_once"],
+type:["int","float","char","unsigned","signed","short","long","double","wchar_t","unichar","void","bool","BOOL","id|0","_Bool"]
+},illegal:"</",contains:[{className:"built_in",
+begin:"\\b(AV|CA|CF|CG|CI|CL|CM|CN|CT|MK|MP|MTK|MTL|NS|SCN|SK|UI|WK|XC)\\w+"
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,e.C_NUMBER_MODE,e.QUOTE_STRING_MODE,e.APOS_STRING_MODE,{
+className:"string",variants:[{begin:'@"',end:'"',illegal:"\\n",
+contains:[e.BACKSLASH_ESCAPE]}]},{className:"meta",begin:/#\s*[a-z]+\b/,end:/$/,
+keywords:{
+keyword:"if else elif endif define undef warning error line pragma ifdef ifndef include"
+},contains:[{begin:/\\\n/,relevance:0},e.inherit(e.QUOTE_STRING_MODE,{
+className:"string"}),{className:"string",begin:/<.*?>/,end:/$/,illegal:"\\n"
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{className:"class",
+begin:"("+t.keyword.join("|")+")\\b",end:/(\{|$)/,excludeEnd:!0,keywords:t,
+contains:[e.UNDERSCORE_TITLE_MODE]},{begin:"\\."+e.UNDERSCORE_IDENT_RE,
+relevance:0}]}},grmr_perl:e=>{const n=e.regex,t=/[dualxmsipngr]{0,12}/,a={
+$pattern:/[\w.]+/,
+keyword:"abs accept alarm and atan2 bind binmode bless break caller chdir chmod chomp chop chown chr chroot close closedir connect continue cos crypt dbmclose dbmopen defined delete die do dump each else elsif endgrent endhostent endnetent endprotoent endpwent endservent eof eval exec exists exit exp fcntl fileno flock for foreach fork format formline getc getgrent getgrgid getgrnam gethostbyaddr gethostbyname gethostent getlogin getnetbyaddr getnetbyname getnetent getpeername getpgrp getpriority getprotobyname getprotobynumber getprotoent getpwent getpwnam getpwuid getservbyname getservbyport getservent getsockname getsockopt given glob gmtime goto grep gt hex if index int ioctl join keys kill last lc lcfirst length link listen local localtime log lstat lt ma map mkdir msgctl msgget msgrcv msgsnd my ne next no not oct open opendir or ord our pack package pipe pop pos print printf prototype push q|0 qq quotemeta qw qx rand read readdir readline readlink readpipe recv redo ref rename require reset return reverse rewinddir rindex rmdir say scalar seek seekdir select semctl semget semop send setgrent sethostent setnetent setpgrp setpriority setprotoent setpwent setservent setsockopt shift shmctl shmget shmread shmwrite shutdown sin sleep socket socketpair sort splice split sprintf sqrt srand stat state study sub substr symlink syscall sysopen sysread sysseek system syswrite tell telldir tie tied time times tr truncate uc ucfirst umask undef unless unlink unpack unshift untie until use utime values vec wait waitpid wantarray warn when while write x|0 xor y|0"
+},i={className:"subst",begin:"[$@]\\{",end:"\\}",keywords:a},r={begin:/->\{/,
+end:/\}/},s={variants:[{begin:/\$\d/},{
+begin:n.concat(/[$%@](\^\w\b|#\w+(::\w+)*|\{\w+\}|\w+(::\w*)*)/,"(?![A-Za-z])(?![@$%])")
+},{begin:/[$%@][^\s\w{]/,relevance:0}]
+},o=[e.BACKSLASH_ESCAPE,i,s],l=[/!/,/\//,/\|/,/\?/,/'/,/"/,/#/],c=(e,a,i="\\1")=>{
+const r="\\1"===i?i:n.concat(i,a)
+;return n.concat(n.concat("(?:",e,")"),a,/(?:\\.|[^\\\/])*?/,r,/(?:\\.|[^\\\/])*?/,i,t)
+},d=(e,a,i)=>n.concat(n.concat("(?:",e,")"),a,/(?:\\.|[^\\\/])*?/,i,t),g=[s,e.HASH_COMMENT_MODE,e.COMMENT(/^=\w/,/=cut/,{
+endsWithParent:!0}),r,{className:"string",contains:o,variants:[{
+begin:"q[qwxr]?\\s*\\(",end:"\\)",relevance:5},{begin:"q[qwxr]?\\s*\\[",
+end:"\\]",relevance:5},{begin:"q[qwxr]?\\s*\\{",end:"\\}",relevance:5},{
+begin:"q[qwxr]?\\s*\\|",end:"\\|",relevance:5},{begin:"q[qwxr]?\\s*<",end:">",
+relevance:5},{begin:"qw\\s+q",end:"q",relevance:5},{begin:"'",end:"'",
+contains:[e.BACKSLASH_ESCAPE]},{begin:'"',end:'"'},{begin:"`",end:"`",
+contains:[e.BACKSLASH_ESCAPE]},{begin:/\{\w+\}/,relevance:0},{
+begin:"-?\\w+\\s*=>",relevance:0}]},{className:"number",
+begin:"(\\b0[0-7_]+)|(\\b0x[0-9a-fA-F_]+)|(\\b[1-9][0-9_]*(\\.[0-9_]+)?)|[0_]\\b",
+relevance:0},{
+begin:"(\\/\\/|"+e.RE_STARTERS_RE+"|\\b(split|return|print|reverse|grep)\\b)\\s*",
+keywords:"split return print reverse grep",relevance:0,
+contains:[e.HASH_COMMENT_MODE,{className:"regexp",variants:[{
+begin:c("s|tr|y",n.either(...l,{capture:!0}))},{begin:c("s|tr|y","\\(","\\)")},{
+begin:c("s|tr|y","\\[","\\]")},{begin:c("s|tr|y","\\{","\\}")}],relevance:2},{
+className:"regexp",variants:[{begin:/(m|qr)\/\//,relevance:0},{
+begin:d("(?:m|qr)?",/\//,/\//)},{begin:d("m|qr",n.either(...l,{capture:!0
+}),/\1/)},{begin:d("m|qr",/\(/,/\)/)},{begin:d("m|qr",/\[/,/\]/)},{
+begin:d("m|qr",/\{/,/\}/)}]}]},{className:"function",beginKeywords:"sub",
+end:"(\\s*\\(.*?\\))?[;{]",excludeEnd:!0,relevance:5,contains:[e.TITLE_MODE]},{
+begin:"-\\w\\b",relevance:0},{begin:"^__DATA__$",end:"^__END__$",
+subLanguage:"mojolicious",contains:[{begin:"^@@.*",end:"$",className:"comment"}]
+}];return i.contains=g,r.contains=g,{name:"Perl",aliases:["pl","pm"],keywords:a,
+contains:g}},grmr_php:e=>{
+const n=e.regex,t=/(?![A-Za-z0-9])(?![$])/,a=n.concat(/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/,t),i=n.concat(/(\\?[A-Z][a-z0-9_\x7f-\xff]+|\\?[A-Z]+(?=[A-Z][a-z0-9_\x7f-\xff])){1,}/,t),r={
+scope:"variable",match:"\\$+"+a},s={scope:"subst",variants:[{begin:/\$\w+/},{
+begin:/\{\$/,end:/\}/}]},o=e.inherit(e.APOS_STRING_MODE,{illegal:null
+}),l="[ \t\n]",c={scope:"string",variants:[e.inherit(e.QUOTE_STRING_MODE,{
+illegal:null,contains:e.QUOTE_STRING_MODE.contains.concat(s)}),o,{
+begin:/<<<[ \t]*(?:(\w+)|"(\w+)")\n/,end:/[ \t]*(\w+)\b/,
+contains:e.QUOTE_STRING_MODE.contains.concat(s),"on:begin":(e,n)=>{
+n.data._beginMatch=e[1]||e[2]},"on:end":(e,n)=>{
+n.data._beginMatch!==e[1]&&n.ignoreMatch()}},e.END_SAME_AS_BEGIN({
+begin:/<<<[ \t]*'(\w+)'\n/,end:/[ \t]*(\w+)\b/})]},d={scope:"number",variants:[{
+begin:"\\b0[bB][01]+(?:_[01]+)*\\b"},{begin:"\\b0[oO][0-7]+(?:_[0-7]+)*\\b"},{
+begin:"\\b0[xX][\\da-fA-F]+(?:_[\\da-fA-F]+)*\\b"},{
+begin:"(?:\\b\\d+(?:_\\d+)*(\\.(?:\\d+(?:_\\d+)*))?|\\B\\.\\d+)(?:[eE][+-]?\\d+)?"
+}],relevance:0
+},g=["false","null","true"],u=["__CLASS__","__DIR__","__FILE__","__FUNCTION__","__COMPILER_HALT_OFFSET__","__LINE__","__METHOD__","__NAMESPACE__","__TRAIT__","die","echo","exit","include","include_once","print","require","require_once","array","abstract","and","as","binary","bool","boolean","break","callable","case","catch","class","clone","const","continue","declare","default","do","double","else","elseif","empty","enddeclare","endfor","endforeach","endif","endswitch","endwhile","enum","eval","extends","final","finally","float","for","foreach","from","global","goto","if","implements","instanceof","insteadof","int","integer","interface","isset","iterable","list","match|0","mixed","new","never","object","or","private","protected","public","readonly","real","return","string","switch","throw","trait","try","unset","use","var","void","while","xor","yield"],b=["Error|0","AppendIterator","ArgumentCountError","ArithmeticError","ArrayIterator","ArrayObject","AssertionError","BadFunctionCallException","BadMethodCallException","CachingIterator","CallbackFilterIterator","CompileError","Countable","DirectoryIterator","DivisionByZeroError","DomainException","EmptyIterator","ErrorException","Exception","FilesystemIterator","FilterIterator","GlobIterator","InfiniteIterator","InvalidArgumentException","IteratorIterator","LengthException","LimitIterator","LogicException","MultipleIterator","NoRewindIterator","OutOfBoundsException","OutOfRangeException","OuterIterator","OverflowException","ParentIterator","ParseError","RangeException","RecursiveArrayIterator","RecursiveCachingIterator","RecursiveCallbackFilterIterator","RecursiveDirectoryIterator","RecursiveFilterIterator","RecursiveIterator","RecursiveIteratorIterator","RecursiveRegexIterator","RecursiveTreeIterator","RegexIterator","RuntimeException","SeekableIterator","SplDoublyLinkedList","SplFileInfo","SplFileObject","SplFixedArray","SplHeap","SplMaxHeap","SplMinHeap","SplObjectStorage","SplObserver","SplPriorityQueue","SplQueue","SplStack","SplSubject","SplTempFileObject","TypeError","UnderflowException","UnexpectedValueException","UnhandledMatchError","ArrayAccess","BackedEnum","Closure","Fiber","Generator","Iterator","IteratorAggregate","Serializable","Stringable","Throwable","Traversable","UnitEnum","WeakReference","WeakMap","Directory","__PHP_Incomplete_Class","parent","php_user_filter","self","static","stdClass"],m={
+keyword:u,literal:(e=>{const n=[];return e.forEach((e=>{
+n.push(e),e.toLowerCase()===e?n.push(e.toUpperCase()):n.push(e.toLowerCase())
+})),n})(g),built_in:b},p=e=>e.map((e=>e.replace(/\|\d+$/,""))),_={variants:[{
+match:[/new/,n.concat(l,"+"),n.concat("(?!",p(b).join("\\b|"),"\\b)"),i],scope:{
+1:"keyword",4:"title.class"}}]},h=n.concat(a,"\\b(?!\\()"),f={variants:[{
+match:[n.concat(/::/,n.lookahead(/(?!class\b)/)),h],scope:{2:"variable.constant"
+}},{match:[/::/,/class/],scope:{2:"variable.language"}},{
+match:[i,n.concat(/::/,n.lookahead(/(?!class\b)/)),h],scope:{1:"title.class",
+3:"variable.constant"}},{match:[i,n.concat("::",n.lookahead(/(?!class\b)/))],
+scope:{1:"title.class"}},{match:[i,/::/,/class/],scope:{1:"title.class",
+3:"variable.language"}}]},E={scope:"attr",
+match:n.concat(a,n.lookahead(":"),n.lookahead(/(?!::)/))},y={relevance:0,
+begin:/\(/,end:/\)/,keywords:m,contains:[E,r,f,e.C_BLOCK_COMMENT_MODE,c,d,_]
+},N={relevance:0,
+match:[/\b/,n.concat("(?!fn\\b|function\\b|",p(u).join("\\b|"),"|",p(b).join("\\b|"),"\\b)"),a,n.concat(l,"*"),n.lookahead(/(?=\()/)],
+scope:{3:"title.function.invoke"},contains:[y]};y.contains.push(N)
+;const w=[E,f,e.C_BLOCK_COMMENT_MODE,c,d,_];return{case_insensitive:!1,
+keywords:m,contains:[{begin:n.concat(/#\[\s*/,i),beginScope:"meta",end:/]/,
+endScope:"meta",keywords:{literal:g,keyword:["new","array"]},contains:[{
+begin:/\[/,end:/]/,keywords:{literal:g,keyword:["new","array"]},
+contains:["self",...w]},...w,{scope:"meta",match:i}]
+},e.HASH_COMMENT_MODE,e.COMMENT("//","$"),e.COMMENT("/\\*","\\*/",{contains:[{
+scope:"doctag",match:"@[A-Za-z]+"}]}),{match:/__halt_compiler\(\);/,
+keywords:"__halt_compiler",starts:{scope:"comment",end:e.MATCH_NOTHING_RE,
+contains:[{match:/\?>/,scope:"meta",endsParent:!0}]}},{scope:"meta",variants:[{
+begin:/<\?php/,relevance:10},{begin:/<\?=/},{begin:/<\?/,relevance:.1},{
+begin:/\?>/}]},{scope:"variable.language",match:/\$this\b/},r,N,f,{
+match:[/const/,/\s/,a],scope:{1:"keyword",3:"variable.constant"}},_,{
+scope:"function",relevance:0,beginKeywords:"fn function",end:/[;{]/,
+excludeEnd:!0,illegal:"[$%\\[]",contains:[{beginKeywords:"use"
+},e.UNDERSCORE_TITLE_MODE,{begin:"=>",endsParent:!0},{scope:"params",
+begin:"\\(",end:"\\)",excludeBegin:!0,excludeEnd:!0,keywords:m,
+contains:["self",r,f,e.C_BLOCK_COMMENT_MODE,c,d]}]},{scope:"class",variants:[{
+beginKeywords:"enum",illegal:/[($"]/},{beginKeywords:"class interface trait",
+illegal:/[:($"]/}],relevance:0,end:/\{/,excludeEnd:!0,contains:[{
+beginKeywords:"extends implements"},e.UNDERSCORE_TITLE_MODE]},{
+beginKeywords:"namespace",relevance:0,end:";",illegal:/[.']/,
+contains:[e.inherit(e.UNDERSCORE_TITLE_MODE,{scope:"title.class"})]},{
+beginKeywords:"use",relevance:0,end:";",contains:[{
+match:/\b(as|const|function)\b/,scope:"keyword"},e.UNDERSCORE_TITLE_MODE]},c,d]}
+},grmr_php_template:e=>({name:"PHP template",subLanguage:"xml",contains:[{
+begin:/<\?(php|=)?/,end:/\?>/,subLanguage:"php",contains:[{begin:"/\\*",
+end:"\\*/",skip:!0},{begin:'b"',end:'"',skip:!0},{begin:"b'",end:"'",skip:!0
+},e.inherit(e.APOS_STRING_MODE,{illegal:null,className:null,contains:null,
+skip:!0}),e.inherit(e.QUOTE_STRING_MODE,{illegal:null,className:null,
+contains:null,skip:!0})]}]}),grmr_plaintext:e=>({name:"Plain text",
+aliases:["text","txt"],disableAutodetect:!0}),grmr_python:e=>{
+const n=e.regex,t=/[\p{XID_Start}_]\p{XID_Continue}*/u,a=["and","as","assert","async","await","break","case","class","continue","def","del","elif","else","except","finally","for","from","global","if","import","in","is","lambda","match","nonlocal|10","not","or","pass","raise","return","try","while","with","yield"],i={
+$pattern:/[A-Za-z]\w+|__\w+__/,keyword:a,
+built_in:["__import__","abs","all","any","ascii","bin","bool","breakpoint","bytearray","bytes","callable","chr","classmethod","compile","complex","delattr","dict","dir","divmod","enumerate","eval","exec","filter","float","format","frozenset","getattr","globals","hasattr","hash","help","hex","id","input","int","isinstance","issubclass","iter","len","list","locals","map","max","memoryview","min","next","object","oct","open","ord","pow","print","property","range","repr","reversed","round","set","setattr","slice","sorted","staticmethod","str","sum","super","tuple","type","vars","zip"],
+literal:["__debug__","Ellipsis","False","None","NotImplemented","True"],
+type:["Any","Callable","Coroutine","Dict","List","Literal","Generic","Optional","Sequence","Set","Tuple","Type","Union"]
+},r={className:"meta",begin:/^(>>>|\.\.\.) /},s={className:"subst",begin:/\{/,
+end:/\}/,keywords:i,illegal:/#/},o={begin:/\{\{/,relevance:0},l={
+className:"string",contains:[e.BACKSLASH_ESCAPE],variants:[{
+begin:/([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?'''/,end:/'''/,
+contains:[e.BACKSLASH_ESCAPE,r],relevance:10},{
+begin:/([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?"""/,end:/"""/,
+contains:[e.BACKSLASH_ESCAPE,r],relevance:10},{
+begin:/([fF][rR]|[rR][fF]|[fF])'''/,end:/'''/,
+contains:[e.BACKSLASH_ESCAPE,r,o,s]},{begin:/([fF][rR]|[rR][fF]|[fF])"""/,
+end:/"""/,contains:[e.BACKSLASH_ESCAPE,r,o,s]},{begin:/([uU]|[rR])'/,end:/'/,
+relevance:10},{begin:/([uU]|[rR])"/,end:/"/,relevance:10},{
+begin:/([bB]|[bB][rR]|[rR][bB])'/,end:/'/},{begin:/([bB]|[bB][rR]|[rR][bB])"/,
+end:/"/},{begin:/([fF][rR]|[rR][fF]|[fF])'/,end:/'/,
+contains:[e.BACKSLASH_ESCAPE,o,s]},{begin:/([fF][rR]|[rR][fF]|[fF])"/,end:/"/,
+contains:[e.BACKSLASH_ESCAPE,o,s]},e.APOS_STRING_MODE,e.QUOTE_STRING_MODE]
+},c="[0-9](_?[0-9])*",d=`(\\b(${c}))?\\.(${c})|\\b(${c})\\.`,g="\\b|"+a.join("|"),u={
+className:"number",relevance:0,variants:[{
+begin:`(\\b(${c})|(${d}))[eE][+-]?(${c})[jJ]?(?=${g})`},{begin:`(${d})[jJ]?`},{
+begin:`\\b([1-9](_?[0-9])*|0+(_?0)*)[lLjJ]?(?=${g})`},{
+begin:`\\b0[bB](_?[01])+[lL]?(?=${g})`},{begin:`\\b0[oO](_?[0-7])+[lL]?(?=${g})`
+},{begin:`\\b0[xX](_?[0-9a-fA-F])+[lL]?(?=${g})`},{begin:`\\b(${c})[jJ](?=${g})`
+}]},b={className:"comment",begin:n.lookahead(/# type:/),end:/$/,keywords:i,
+contains:[{begin:/# type:/},{begin:/#/,end:/\b\B/,endsWithParent:!0}]},m={
+className:"params",variants:[{className:"",begin:/\(\s*\)/,skip:!0},{begin:/\(/,
+end:/\)/,excludeBegin:!0,excludeEnd:!0,keywords:i,
+contains:["self",r,u,l,e.HASH_COMMENT_MODE]}]};return s.contains=[l,u,r],{
+name:"Python",aliases:["py","gyp","ipython"],unicodeRegex:!0,keywords:i,
+illegal:/(<\/|\?)|=>/,contains:[r,u,{begin:/\bself\b/},{beginKeywords:"if",
+relevance:0},l,b,e.HASH_COMMENT_MODE,{match:[/\bdef/,/\s+/,t],scope:{
+1:"keyword",3:"title.function"},contains:[m]},{variants:[{
+match:[/\bclass/,/\s+/,t,/\s*/,/\(\s*/,t,/\s*\)/]},{match:[/\bclass/,/\s+/,t]}],
+scope:{1:"keyword",3:"title.class",6:"title.class.inherited"}},{
+className:"meta",begin:/^[\t ]*@/,end:/(?=#)|$/,contains:[u,m,l]}]}},
+grmr_python_repl:e=>({aliases:["pycon"],contains:[{className:"meta.prompt",
+starts:{end:/ |$/,starts:{end:"$",subLanguage:"python"}},variants:[{
+begin:/^>>>(?=[ ]|$)/},{begin:/^\.\.\.(?=[ ]|$)/}]}]}),grmr_r:e=>{
+const n=e.regex,t=/(?:(?:[a-zA-Z]|\.[._a-zA-Z])[._a-zA-Z0-9]*)|\.(?!\d)/,a=n.either(/0[xX][0-9a-fA-F]+\.[0-9a-fA-F]*[pP][+-]?\d+i?/,/0[xX][0-9a-fA-F]+(?:[pP][+-]?\d+)?[Li]?/,/(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?[Li]?/),i=/[=!<>:]=|\|\||&&|:::?|<-|<<-|->>|->|\|>|[-+*\/?!{{HIGHLIGHT_JS}}|:<=>@^~]|\*\*/,r=n.either(/[()]/,/[{}]/,/\[\[/,/[[\]]/,/\\/,/,/)
+;return{name:"R",keywords:{$pattern:t,
+keyword:"function if in break next repeat else for while",
+literal:"NULL NA TRUE FALSE Inf NaN NA_integer_|10 NA_real_|10 NA_character_|10 NA_complex_|10",
+built_in:"LETTERS letters month.abb month.name pi T F abs acos acosh all any anyNA Arg as.call as.character as.complex as.double as.environment as.integer as.logical as.null.default as.numeric as.raw asin asinh atan atanh attr attributes baseenv browser c call ceiling class Conj cos cosh cospi cummax cummin cumprod cumsum digamma dim dimnames emptyenv exp expression floor forceAndCall gamma gc.time globalenv Im interactive invisible is.array is.atomic is.call is.character is.complex is.double is.environment is.expression is.finite is.function is.infinite is.integer is.language is.list is.logical is.matrix is.na is.name is.nan is.null is.numeric is.object is.pairlist is.raw is.recursive is.single is.symbol lazyLoadDBfetch length lgamma list log max min missing Mod names nargs nzchar oldClass on.exit pos.to.env proc.time prod quote range Re rep retracemem return round seq_along seq_len seq.int sign signif sin sinh sinpi sqrt standardGeneric substitute sum switch tan tanh tanpi tracemem trigamma trunc unclass untracemem UseMethod xtfrm"
+},contains:[e.COMMENT(/#'/,/$/,{contains:[{scope:"doctag",match:/@examples/,
+starts:{end:n.lookahead(n.either(/\n^#'\s*(?=@[a-zA-Z]+)/,/\n^(?!#')/)),
+endsParent:!0}},{scope:"doctag",begin:"@param",end:/$/,contains:[{
+scope:"variable",variants:[{match:t},{match:/`(?:\\.|[^`\\])+`/}],endsParent:!0
+}]},{scope:"doctag",match:/@[a-zA-Z]+/},{scope:"keyword",match:/\\[a-zA-Z]+/}]
+}),e.HASH_COMMENT_MODE,{scope:"string",contains:[e.BACKSLASH_ESCAPE],
+variants:[e.END_SAME_AS_BEGIN({begin:/[rR]"(-*)\(/,end:/\)(-*)"/
+}),e.END_SAME_AS_BEGIN({begin:/[rR]"(-*)\{/,end:/\}(-*)"/
+}),e.END_SAME_AS_BEGIN({begin:/[rR]"(-*)\[/,end:/\](-*)"/
+}),e.END_SAME_AS_BEGIN({begin:/[rR]'(-*)\(/,end:/\)(-*)'/
+}),e.END_SAME_AS_BEGIN({begin:/[rR]'(-*)\{/,end:/\}(-*)'/
+}),e.END_SAME_AS_BEGIN({begin:/[rR]'(-*)\[/,end:/\](-*)'/}),{begin:'"',end:'"',
+relevance:0},{begin:"'",end:"'",relevance:0}]},{relevance:0,variants:[{scope:{
+1:"operator",2:"number"},match:[i,a]},{scope:{1:"operator",2:"number"},
+match:[/%[^%]*%/,a]},{scope:{1:"punctuation",2:"number"},match:[r,a]},{scope:{
+2:"number"},match:[/[^a-zA-Z0-9._]|^/,a]}]},{scope:{3:"operator"},
+match:[t,/\s+/,/<-/,/\s+/]},{scope:"operator",relevance:0,variants:[{match:i},{
+match:/%[^%]*%/}]},{scope:"punctuation",relevance:0,match:r},{begin:"`",end:"`",
+contains:[{begin:/\\./}]}]}},grmr_ruby:e=>{
+const n=e.regex,t="([a-zA-Z_]\\w*[!?=]?|[-+~]@|<<|>>|=~|===?|<=>|[<>]=?|\\*\\*|[-/+%^&*~`|]|\\[\\]=?)",a=n.either(/\b([A-Z]+[a-z0-9]+)+/,/\b([A-Z]+[a-z0-9]+)+[A-Z]+/),i=n.concat(a,/(::\w+)*/),r={
+"variable.constant":["__FILE__","__LINE__","__ENCODING__"],
+"variable.language":["self","super"],
+keyword:["alias","and","begin","BEGIN","break","case","class","defined","do","else","elsif","end","END","ensure","for","if","in","module","next","not","or","redo","require","rescue","retry","return","then","undef","unless","until","when","while","yield","include","extend","prepend","public","private","protected","raise","throw"],
+built_in:["proc","lambda","attr_accessor","attr_reader","attr_writer","define_method","private_constant","module_function"],
+literal:["true","false","nil"]},s={className:"doctag",begin:"@[A-Za-z]+"},o={
+begin:"#<",end:">"},l=[e.COMMENT("#","$",{contains:[s]
+}),e.COMMENT("^=begin","^=end",{contains:[s],relevance:10
+}),e.COMMENT("^__END__",e.MATCH_NOTHING_RE)],c={className:"subst",begin:/#\{/,
+end:/\}/,keywords:r},d={className:"string",contains:[e.BACKSLASH_ESCAPE,c],
+variants:[{begin:/'/,end:/'/},{begin:/"/,end:/"/},{begin:/`/,end:/`/},{
+begin:/%[qQwWx]?\(/,end:/\)/},{begin:/%[qQwWx]?\[/,end:/\]/},{
+begin:/%[qQwWx]?\{/,end:/\}/},{begin:/%[qQwWx]?</,end:/>/},{begin:/%[qQwWx]?\//,
+end:/\//},{begin:/%[qQwWx]?%/,end:/%/},{begin:/%[qQwWx]?-/,end:/-/},{
+begin:/%[qQwWx]?\|/,end:/\|/},{begin:/\B\?(\\\d{1,3})/},{
+begin:/\B\?(\\x[A-Fa-f0-9]{1,2})/},{begin:/\B\?(\\u\{?[A-Fa-f0-9]{1,6}\}?)/},{
+begin:/\B\?(\\M-\\C-|\\M-\\c|\\c\\M-|\\M-|\\C-\\M-)[\x20-\x7e]/},{
+begin:/\B\?\\(c|C-)[\x20-\x7e]/},{begin:/\B\?\\?\S/},{
+begin:n.concat(/<<[-~]?'?/,n.lookahead(/(\w+)(?=\W)[^\n]*\n(?:[^\n]*\n)*?\s*\1\b/)),
+contains:[e.END_SAME_AS_BEGIN({begin:/(\w+)/,end:/(\w+)/,
+contains:[e.BACKSLASH_ESCAPE,c]})]}]},g="[0-9](_?[0-9])*",u={className:"number",
+relevance:0,variants:[{
+begin:`\\b([1-9](_?[0-9])*|0)(\\.(${g}))?([eE][+-]?(${g})|r)?i?\\b`},{
+begin:"\\b0[dD][0-9](_?[0-9])*r?i?\\b"},{begin:"\\b0[bB][0-1](_?[0-1])*r?i?\\b"
+},{begin:"\\b0[oO][0-7](_?[0-7])*r?i?\\b"},{
+begin:"\\b0[xX][0-9a-fA-F](_?[0-9a-fA-F])*r?i?\\b"},{
+begin:"\\b0(_?[0-7])+r?i?\\b"}]},b={variants:[{match:/\(\)/},{
+className:"params",begin:/\(/,end:/(?=\))/,excludeBegin:!0,endsParent:!0,
+keywords:r}]},m=[d,{variants:[{match:[/class\s+/,i,/\s+<\s+/,i]},{
+match:[/\b(class|module)\s+/,i]}],scope:{2:"title.class",
+4:"title.class.inherited"},keywords:r},{match:[/(include|extend)\s+/,i],scope:{
+2:"title.class"},keywords:r},{relevance:0,match:[i,/\.new[. (]/],scope:{
+1:"title.class"}},{relevance:0,match:/\b[A-Z][A-Z_0-9]+\b/,
+className:"variable.constant"},{relevance:0,match:a,scope:"title.class"},{
+match:[/def/,/\s+/,t],scope:{1:"keyword",3:"title.function"},contains:[b]},{
+begin:e.IDENT_RE+"::"},{className:"symbol",
+begin:e.UNDERSCORE_IDENT_RE+"(!|\\?)?:",relevance:0},{className:"symbol",
+begin:":(?!\\s)",contains:[d,{begin:t}],relevance:0},u,{className:"variable",
+begin:"(\\$\\W)|((\\$|@@?)(\\w+))(?=[^@$?])(?![A-Za-z])(?![@$?'])"},{
+className:"params",begin:/\|/,end:/\|/,excludeBegin:!0,excludeEnd:!0,
+relevance:0,keywords:r},{begin:"("+e.RE_STARTERS_RE+"|unless)\\s*",
+keywords:"unless",contains:[{className:"regexp",contains:[e.BACKSLASH_ESCAPE,c],
+illegal:/\n/,variants:[{begin:"/",end:"/[a-z]*"},{begin:/%r\{/,end:/\}[a-z]*/},{
+begin:"%r\\(",end:"\\)[a-z]*"},{begin:"%r!",end:"![a-z]*"},{begin:"%r\\[",
+end:"\\][a-z]*"}]}].concat(o,l),relevance:0}].concat(o,l)
+;c.contains=m,b.contains=m;const p=[{begin:/^\s*=>/,starts:{end:"$",contains:m}
+},{className:"meta.prompt",
+begin:"^([>?]>|[\\w#]+\\(\\w+\\):\\d+:\\d+[>*]|(\\w+-)?\\d+\\.\\d+\\.\\d+(p\\d+)?[^\\d][^>]+>)(?=[ ])",
+starts:{end:"$",keywords:r,contains:m}}];return l.unshift(o),{name:"Ruby",
+aliases:["rb","gemspec","podspec","thor","irb"],keywords:r,illegal:/\/\*/,
+contains:[e.SHEBANG({binary:"ruby"})].concat(p).concat(l).concat(m)}},
+grmr_rust:e=>{const n=e.regex,t={className:"title.function.invoke",relevance:0,
+begin:n.concat(/\b/,/(?!let|for|while|if|else|match\b)/,e.IDENT_RE,n.lookahead(/\s*\(/))
+},a="([ui](8|16|32|64|128|size)|f(32|64))?",i=["drop ","Copy","Send","Sized","Sync","Drop","Fn","FnMut","FnOnce","ToOwned","Clone","Debug","PartialEq","PartialOrd","Eq","Ord","AsRef","AsMut","Into","From","Default","Iterator","Extend","IntoIterator","DoubleEndedIterator","ExactSizeIterator","SliceConcatExt","ToString","assert!","assert_eq!","bitflags!","bytes!","cfg!","col!","concat!","concat_idents!","debug_assert!","debug_assert_eq!","env!","eprintln!","panic!","file!","format!","format_args!","include_bytes!","include_str!","line!","local_data_key!","module_path!","option_env!","print!","println!","select!","stringify!","try!","unimplemented!","unreachable!","vec!","write!","writeln!","macro_rules!","assert_ne!","debug_assert_ne!"],r=["i8","i16","i32","i64","i128","isize","u8","u16","u32","u64","u128","usize","f32","f64","str","char","bool","Box","Option","Result","String","Vec"]
+;return{name:"Rust",aliases:["rs"],keywords:{$pattern:e.IDENT_RE+"!?",type:r,
+keyword:["abstract","as","async","await","become","box","break","const","continue","crate","do","dyn","else","enum","extern","false","final","fn","for","if","impl","in","let","loop","macro","match","mod","move","mut","override","priv","pub","ref","return","self","Self","static","struct","super","trait","true","try","type","typeof","unsafe","unsized","use","virtual","where","while","yield"],
+literal:["true","false","Some","None","Ok","Err"],built_in:i},illegal:"</",
+contains:[e.C_LINE_COMMENT_MODE,e.COMMENT("/\\*","\\*/",{contains:["self"]
+}),e.inherit(e.QUOTE_STRING_MODE,{begin:/b?"/,illegal:null}),{
+className:"string",variants:[{begin:/b?r(#*)"(.|\n)*?"\1(?!#)/},{
+begin:/b?'\\?(x\w{2}|u\w{4}|U\w{8}|.)'/}]},{className:"symbol",
+begin:/'[a-zA-Z_][a-zA-Z0-9_]*/},{className:"number",variants:[{
+begin:"\\b0b([01_]+)"+a},{begin:"\\b0o([0-7_]+)"+a},{
+begin:"\\b0x([A-Fa-f0-9_]+)"+a},{
+begin:"\\b(\\d[\\d_]*(\\.[0-9_]+)?([eE][+-]?[0-9_]+)?)"+a}],relevance:0},{
+begin:[/fn/,/\s+/,e.UNDERSCORE_IDENT_RE],className:{1:"keyword",
+3:"title.function"}},{className:"meta",begin:"#!?\\[",end:"\\]",contains:[{
+className:"string",begin:/"/,end:/"/}]},{
+begin:[/let/,/\s+/,/(?:mut\s+)?/,e.UNDERSCORE_IDENT_RE],className:{1:"keyword",
+3:"keyword",4:"variable"}},{
+begin:[/for/,/\s+/,e.UNDERSCORE_IDENT_RE,/\s+/,/in/],className:{1:"keyword",
+3:"variable",5:"keyword"}},{begin:[/type/,/\s+/,e.UNDERSCORE_IDENT_RE],
+className:{1:"keyword",3:"title.class"}},{
+begin:[/(?:trait|enum|struct|union|impl|for)/,/\s+/,e.UNDERSCORE_IDENT_RE],
+className:{1:"keyword",3:"title.class"}},{begin:e.IDENT_RE+"::",keywords:{
+keyword:"Self",built_in:i,type:r}},{className:"punctuation",begin:"->"},t]}},
+grmr_scss:e=>{const n=ie(e),t=le,a=oe,i="@[a-z-]+",r={className:"variable",
+begin:"(\\$[a-zA-Z-][a-zA-Z0-9_-]*)\\b",relevance:0};return{name:"SCSS",
+case_insensitive:!0,illegal:"[=/|']",
+contains:[e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,n.CSS_NUMBER_MODE,{
+className:"selector-id",begin:"#[A-Za-z0-9_-]+",relevance:0},{
+className:"selector-class",begin:"\\.[A-Za-z0-9_-]+",relevance:0
+},n.ATTRIBUTE_SELECTOR_MODE,{className:"selector-tag",
+begin:"\\b("+re.join("|")+")\\b",relevance:0},{className:"selector-pseudo",
+begin:":("+a.join("|")+")"},{className:"selector-pseudo",
+begin:":(:)?("+t.join("|")+")"},r,{begin:/\(/,end:/\)/,
+contains:[n.CSS_NUMBER_MODE]},n.CSS_VARIABLE,{className:"attribute",
+begin:"\\b("+ce.join("|")+")\\b"},{
+begin:"\\b(whitespace|wait|w-resize|visible|vertical-text|vertical-ideographic|uppercase|upper-roman|upper-alpha|underline|transparent|top|thin|thick|text|text-top|text-bottom|tb-rl|table-header-group|table-footer-group|sw-resize|super|strict|static|square|solid|small-caps|separate|se-resize|scroll|s-resize|rtl|row-resize|ridge|right|repeat|repeat-y|repeat-x|relative|progress|pointer|overline|outside|outset|oblique|nowrap|not-allowed|normal|none|nw-resize|no-repeat|no-drop|newspaper|ne-resize|n-resize|move|middle|medium|ltr|lr-tb|lowercase|lower-roman|lower-alpha|loose|list-item|line|line-through|line-edge|lighter|left|keep-all|justify|italic|inter-word|inter-ideograph|inside|inset|inline|inline-block|inherit|inactive|ideograph-space|ideograph-parenthesis|ideograph-numeric|ideograph-alpha|horizontal|hidden|help|hand|groove|fixed|ellipsis|e-resize|double|dotted|distribute|distribute-space|distribute-letter|distribute-all-lines|disc|disabled|default|decimal|dashed|crosshair|collapse|col-resize|circle|char|center|capitalize|break-word|break-all|bottom|both|bolder|bold|block|bidi-override|below|baseline|auto|always|all-scroll|absolute|table|table-cell)\\b"
+},{begin:/:/,end:/[;}{]/,relevance:0,
+contains:[n.BLOCK_COMMENT,r,n.HEXCOLOR,n.CSS_NUMBER_MODE,e.QUOTE_STRING_MODE,e.APOS_STRING_MODE,n.IMPORTANT,n.FUNCTION_DISPATCH]
+},{begin:"@(page|font-face)",keywords:{$pattern:i,keyword:"@page @font-face"}},{
+begin:"@",end:"[{;]",returnBegin:!0,keywords:{$pattern:/[a-z-]+/,
+keyword:"and or not only",attribute:se.join(" ")},contains:[{begin:i,
+className:"keyword"},{begin:/[a-z-]+(?=:)/,className:"attribute"
+},r,e.QUOTE_STRING_MODE,e.APOS_STRING_MODE,n.HEXCOLOR,n.CSS_NUMBER_MODE]
+},n.FUNCTION_DISPATCH]}},grmr_shell:e=>({name:"Shell Session",
+aliases:["console","shellsession"],contains:[{className:"meta.prompt",
+begin:/^\s{0,3}[/~\w\d[\]()@-]*[>%$#][ ]?/,starts:{end:/[^\\](?=\s*$)/,
+subLanguage:"bash"}}]}),grmr_sql:e=>{
+const n=e.regex,t=e.COMMENT("--","$"),a=["true","false","unknown"],i=["bigint","binary","blob","boolean","char","character","clob","date","dec","decfloat","decimal","float","int","integer","interval","nchar","nclob","national","numeric","real","row","smallint","time","timestamp","varchar","varying","varbinary"],r=["abs","acos","array_agg","asin","atan","avg","cast","ceil","ceiling","coalesce","corr","cos","cosh","count","covar_pop","covar_samp","cume_dist","dense_rank","deref","element","exp","extract","first_value","floor","json_array","json_arrayagg","json_exists","json_object","json_objectagg","json_query","json_table","json_table_primitive","json_value","lag","last_value","lead","listagg","ln","log","log10","lower","max","min","mod","nth_value","ntile","nullif","percent_rank","percentile_cont","percentile_disc","position","position_regex","power","rank","regr_avgx","regr_avgy","regr_count","regr_intercept","regr_r2","regr_slope","regr_sxx","regr_sxy","regr_syy","row_number","sin","sinh","sqrt","stddev_pop","stddev_samp","substring","substring_regex","sum","tan","tanh","translate","translate_regex","treat","trim","trim_array","unnest","upper","value_of","var_pop","var_samp","width_bucket"],s=["create table","insert into","primary key","foreign key","not null","alter table","add constraint","grouping sets","on overflow","character set","respect nulls","ignore nulls","nulls first","nulls last","depth first","breadth first"],o=r,l=["abs","acos","all","allocate","alter","and","any","are","array","array_agg","array_max_cardinality","as","asensitive","asin","asymmetric","at","atan","atomic","authorization","avg","begin","begin_frame","begin_partition","between","bigint","binary","blob","boolean","both","by","call","called","cardinality","cascaded","case","cast","ceil","ceiling","char","char_length","character","character_length","check","classifier","clob","close","coalesce","collate","collect","column","commit","condition","connect","constraint","contains","convert","copy","corr","corresponding","cos","cosh","count","covar_pop","covar_samp","create","cross","cube","cume_dist","current","current_catalog","current_date","current_default_transform_group","current_path","current_role","current_row","current_schema","current_time","current_timestamp","current_path","current_role","current_transform_group_for_type","current_user","cursor","cycle","date","day","deallocate","dec","decimal","decfloat","declare","default","define","delete","dense_rank","deref","describe","deterministic","disconnect","distinct","double","drop","dynamic","each","element","else","empty","end","end_frame","end_partition","end-exec","equals","escape","every","except","exec","execute","exists","exp","external","extract","false","fetch","filter","first_value","float","floor","for","foreign","frame_row","free","from","full","function","fusion","get","global","grant","group","grouping","groups","having","hold","hour","identity","in","indicator","initial","inner","inout","insensitive","insert","int","integer","intersect","intersection","interval","into","is","join","json_array","json_arrayagg","json_exists","json_object","json_objectagg","json_query","json_table","json_table_primitive","json_value","lag","language","large","last_value","lateral","lead","leading","left","like","like_regex","listagg","ln","local","localtime","localtimestamp","log","log10","lower","match","match_number","match_recognize","matches","max","member","merge","method","min","minute","mod","modifies","module","month","multiset","national","natural","nchar","nclob","new","no","none","normalize","not","nth_value","ntile","null","nullif","numeric","octet_length","occurrences_regex","of","offset","old","omit","on","one","only","open","or","order","out","outer","over","overlaps","overlay","parameter","partition","pattern","per","percent","percent_rank","percentile_cont","percentile_disc","period","portion","position","position_regex","power","precedes","precision","prepare","primary","procedure","ptf","range","rank","reads","real","recursive","ref","references","referencing","regr_avgx","regr_avgy","regr_count","regr_intercept","regr_r2","regr_slope","regr_sxx","regr_sxy","regr_syy","release","result","return","returns","revoke","right","rollback","rollup","row","row_number","rows","running","savepoint","scope","scroll","search","second","seek","select","sensitive","session_user","set","show","similar","sin","sinh","skip","smallint","some","specific","specifictype","sql","sqlexception","sqlstate","sqlwarning","sqrt","start","static","stddev_pop","stddev_samp","submultiset","subset","substring","substring_regex","succeeds","sum","symmetric","system","system_time","system_user","table","tablesample","tan","tanh","then","time","timestamp","timezone_hour","timezone_minute","to","trailing","translate","translate_regex","translation","treat","trigger","trim","trim_array","true","truncate","uescape","union","unique","unknown","unnest","update","upper","user","using","value","values","value_of","var_pop","var_samp","varbinary","varchar","varying","versioning","when","whenever","where","width_bucket","window","with","within","without","year","add","asc","collation","desc","final","first","last","view"].filter((e=>!r.includes(e))),c={
+begin:n.concat(/\b/,n.either(...o),/\s*\(/),relevance:0,keywords:{built_in:o}}
+;return{name:"SQL",case_insensitive:!0,illegal:/[{}]|<\//,keywords:{
+$pattern:/\b[\w\.]+/,keyword:((e,{exceptions:n,when:t}={})=>{const a=t
+;return n=n||[],e.map((e=>e.match(/\|\d+$/)||n.includes(e)?e:a(e)?e+"|0":e))
+})(l,{when:e=>e.length<3}),literal:a,type:i,
+built_in:["current_catalog","current_date","current_default_transform_group","current_path","current_role","current_schema","current_transform_group_for_type","current_user","session_user","system_time","system_user","current_time","localtime","current_timestamp","localtimestamp"]
+},contains:[{begin:n.either(...s),relevance:0,keywords:{$pattern:/[\w\.]+/,
+keyword:l.concat(s),literal:a,type:i}},{className:"type",
+begin:n.either("double precision","large object","with timezone","without timezone")
+},c,{className:"variable",begin:/@[a-z0-9][a-z0-9_]*/},{className:"string",
+variants:[{begin:/'/,end:/'/,contains:[{begin:/''/}]}]},{begin:/"/,end:/"/,
+contains:[{begin:/""/}]},e.C_NUMBER_MODE,e.C_BLOCK_COMMENT_MODE,t,{
+className:"operator",begin:/[-+*/=%^~]|&&?|\|\|?|!=?|<(?:=>?|<|>)?|>[>=]?/,
+relevance:0}]}},grmr_swift:e=>{const n={match:/\s+/,relevance:0
+},t=e.COMMENT("/\\*","\\*/",{contains:["self"]}),a=[e.C_LINE_COMMENT_MODE,t],i={
+match:[/\./,m(...xe,...Me)],className:{2:"keyword"}},r={match:b(/\./,m(...Ae)),
+relevance:0},s=Ae.filter((e=>"string"==typeof e)).concat(["_|0"]),o={variants:[{
+className:"keyword",
+match:m(...Ae.filter((e=>"string"!=typeof e)).concat(Se).map(ke),...Me)}]},l={
+$pattern:m(/\b\w+/,/#\w+/),keyword:s.concat(Re),literal:Ce},c=[i,r,o],g=[{
+match:b(/\./,m(...De)),relevance:0},{className:"built_in",
+match:b(/\b/,m(...De),/(?=\()/)}],u={match:/->/,relevance:0},p=[u,{
+className:"operator",relevance:0,variants:[{match:Be},{match:`\\.(\\.|${Le})+`}]
+}],_="([0-9]_*)+",h="([0-9a-fA-F]_*)+",f={className:"number",relevance:0,
+variants:[{match:`\\b(${_})(\\.(${_}))?([eE][+-]?(${_}))?\\b`},{
+match:`\\b0x(${h})(\\.(${h}))?([pP][+-]?(${_}))?\\b`},{match:/\b0o([0-7]_*)+\b/
+},{match:/\b0b([01]_*)+\b/}]},E=(e="")=>({className:"subst",variants:[{
+match:b(/\\/,e,/[0\\tnr"']/)},{match:b(/\\/,e,/u\{[0-9a-fA-F]{1,8}\}/)}]
+}),y=(e="")=>({className:"subst",match:b(/\\/,e,/[\t ]*(?:[\r\n]|\r\n)/)
+}),N=(e="")=>({className:"subst",label:"interpol",begin:b(/\\/,e,/\(/),end:/\)/
+}),w=(e="")=>({begin:b(e,/"""/),end:b(/"""/,e),contains:[E(e),y(e),N(e)]
+}),v=(e="")=>({begin:b(e,/"/),end:b(/"/,e),contains:[E(e),N(e)]}),O={
+className:"string",
+variants:[w(),w("#"),w("##"),w("###"),v(),v("#"),v("##"),v("###")]
+},k=[e.BACKSLASH_ESCAPE,{begin:/\[/,end:/\]/,relevance:0,
+contains:[e.BACKSLASH_ESCAPE]}],x={begin:/\/[^\s](?=[^/\n]*\/)/,end:/\//,
+contains:k},M=e=>{const n=b(e,/\//),t=b(/\//,e);return{begin:n,end:t,
+contains:[...k,{scope:"comment",begin:`#(?!.*${t})`,end:/$/}]}},S={
+scope:"regexp",variants:[M("###"),M("##"),M("#"),x]},A={match:b(/`/,Fe,/`/)
+},C=[A,{className:"variable",match:/\$\d+/},{className:"variable",
+match:`\\${ze}+`}],T=[{match:/(@|#(un)?)available/,scope:"keyword",starts:{
+contains:[{begin:/\(/,end:/\)/,keywords:Pe,contains:[...p,f,O]}]}},{
+scope:"keyword",match:b(/@/,m(...je))},{scope:"meta",match:b(/@/,Fe)}],R={
+match:d(/\b[A-Z]/),relevance:0,contains:[{className:"type",
+match:b(/(AV|CA|CF|CG|CI|CL|CM|CN|CT|MK|MP|MTK|MTL|NS|SCN|SK|UI|WK|XC)/,ze,"+")
+},{className:"type",match:Ue,relevance:0},{match:/[?!]+/,relevance:0},{
+match:/\.\.\./,relevance:0},{match:b(/\s+&\s+/,d(Ue)),relevance:0}]},D={
+begin:/</,end:/>/,keywords:l,contains:[...a,...c,...T,u,R]};R.contains.push(D)
+;const I={begin:/\(/,end:/\)/,relevance:0,keywords:l,contains:["self",{
+match:b(Fe,/\s*:/),keywords:"_|0",relevance:0
+},...a,S,...c,...g,...p,f,O,...C,...T,R]},L={begin:/</,end:/>/,
+keywords:"repeat each",contains:[...a,R]},B={begin:/\(/,end:/\)/,keywords:l,
+contains:[{begin:m(d(b(Fe,/\s*:/)),d(b(Fe,/\s+/,Fe,/\s*:/))),end:/:/,
+relevance:0,contains:[{className:"keyword",match:/\b_\b/},{className:"params",
+match:Fe}]},...a,...c,...p,f,O,...T,R,I],endsParent:!0,illegal:/["']/},$={
+match:[/(func|macro)/,/\s+/,m(A.match,Fe,Be)],className:{1:"keyword",
+3:"title.function"},contains:[L,B,n],illegal:[/\[/,/%/]},z={
+match:[/\b(?:subscript|init[?!]?)/,/\s*(?=[<(])/],className:{1:"keyword"},
+contains:[L,B,n],illegal:/\[|%/},F={match:[/operator/,/\s+/,Be],className:{
+1:"keyword",3:"title"}},U={begin:[/precedencegroup/,/\s+/,Ue],className:{
+1:"keyword",3:"title"},contains:[R],keywords:[...Te,...Ce],end:/}/}
+;for(const e of O.variants){const n=e.contains.find((e=>"interpol"===e.label))
+;n.keywords=l;const t=[...c,...g,...p,f,O,...C];n.contains=[...t,{begin:/\(/,
+end:/\)/,contains:["self",...t]}]}return{name:"Swift",keywords:l,
+contains:[...a,$,z,{beginKeywords:"struct protocol class extension enum actor",
+end:"\\{",excludeEnd:!0,keywords:l,contains:[e.inherit(e.TITLE_MODE,{
+className:"title.class",begin:/[A-Za-z$_][\u00C0-\u02B80-9A-Za-z$_]*/}),...c]
+},F,U,{beginKeywords:"import",end:/$/,contains:[...a],relevance:0
+},S,...c,...g,...p,f,O,...C,...T,R,I]}},grmr_typescript:e=>{
+const n=Oe(e),t=_e,a=["any","void","number","boolean","string","object","never","symbol","bigint","unknown"],i={
+beginKeywords:"namespace",end:/\{/,excludeEnd:!0,
+contains:[n.exports.CLASS_REFERENCE]},r={beginKeywords:"interface",end:/\{/,
+excludeEnd:!0,keywords:{keyword:"interface extends",built_in:a},
+contains:[n.exports.CLASS_REFERENCE]},s={$pattern:_e,
+keyword:he.concat(["type","namespace","interface","public","private","protected","implements","declare","abstract","readonly","enum","override"]),
+literal:fe,built_in:ve.concat(a),"variable.language":we},o={className:"meta",
+begin:"@"+t},l=(e,n,t)=>{const a=e.contains.findIndex((e=>e.label===n))
+;if(-1===a)throw Error("can not find mode to replace");e.contains.splice(a,1,t)}
+;return Object.assign(n.keywords,s),
+n.exports.PARAMS_CONTAINS.push(o),n.contains=n.contains.concat([o,i,r]),
+l(n,"shebang",e.SHEBANG()),l(n,"use_strict",{className:"meta",relevance:10,
+begin:/^\s*['"]use strict['"]/
+}),n.contains.find((e=>"func.def"===e.label)).relevance=0,Object.assign(n,{
+name:"TypeScript",aliases:["ts","tsx","mts","cts"]}),n},grmr_vbnet:e=>{
+const n=e.regex,t=/\d{1,2}\/\d{1,2}\/\d{4}/,a=/\d{4}-\d{1,2}-\d{1,2}/,i=/(\d|1[012])(:\d+){0,2} *(AM|PM)/,r=/\d{1,2}(:\d{1,2}){1,2}/,s={
+className:"literal",variants:[{begin:n.concat(/# */,n.either(a,t),/ *#/)},{
+begin:n.concat(/# */,r,/ *#/)},{begin:n.concat(/# */,i,/ *#/)},{
+begin:n.concat(/# */,n.either(a,t),/ +/,n.either(i,r),/ *#/)}]
+},o=e.COMMENT(/'''/,/$/,{contains:[{className:"doctag",begin:/<\/?/,end:/>/}]
+}),l=e.COMMENT(null,/$/,{variants:[{begin:/'/},{begin:/([\t ]|^)REM(?=\s)/}]})
+;return{name:"Visual Basic .NET",aliases:["vb"],case_insensitive:!0,
+classNameAliases:{label:"symbol"},keywords:{
+keyword:"addhandler alias aggregate ansi as async assembly auto binary by byref byval call case catch class compare const continue custom declare default delegate dim distinct do each equals else elseif end enum erase error event exit explicit finally for friend from function get global goto group handles if implements imports in inherits interface into iterator join key let lib loop me mid module mustinherit mustoverride mybase myclass namespace narrowing new next notinheritable notoverridable of off on operator option optional order overloads overridable overrides paramarray partial preserve private property protected public raiseevent readonly redim removehandler resume return select set shadows shared skip static step stop structure strict sub synclock take text then throw to try unicode until using when where while widening with withevents writeonly yield",
+built_in:"addressof and andalso await directcast gettype getxmlnamespace is isfalse isnot istrue like mod nameof new not or orelse trycast typeof xor cbool cbyte cchar cdate cdbl cdec cint clng cobj csbyte cshort csng cstr cuint culng cushort",
+type:"boolean byte char date decimal double integer long object sbyte short single string uinteger ulong ushort",
+literal:"true false nothing"},
+illegal:"//|\\{|\\}|endif|gosub|variant|wend|^\\$ ",contains:[{
+className:"string",begin:/"(""|[^/n])"C\b/},{className:"string",begin:/"/,
+end:/"/,illegal:/\n/,contains:[{begin:/""/}]},s,{className:"number",relevance:0,
+variants:[{begin:/\b\d[\d_]*((\.[\d_]+(E[+-]?[\d_]+)?)|(E[+-]?[\d_]+))[RFD@!#]?/
+},{begin:/\b\d[\d_]*((U?[SIL])|[%&])?/},{begin:/&H[\dA-F_]+((U?[SIL])|[%&])?/},{
+begin:/&O[0-7_]+((U?[SIL])|[%&])?/},{begin:/&B[01_]+((U?[SIL])|[%&])?/}]},{
+className:"label",begin:/^\w+:/},o,l,{className:"meta",
+begin:/[\t ]*#(const|disable|else|elseif|enable|end|externalsource|if|region)\b/,
+end:/$/,keywords:{
+keyword:"const disable else elseif enable end externalsource if region then"},
+contains:[l]}]}},grmr_wasm:e=>{e.regex;const n=e.COMMENT(/\(;/,/;\)/)
+;return n.contains.push("self"),{name:"WebAssembly",keywords:{$pattern:/[\w.]+/,
+keyword:["anyfunc","block","br","br_if","br_table","call","call_indirect","data","drop","elem","else","end","export","func","global.get","global.set","local.get","local.set","local.tee","get_global","get_local","global","if","import","local","loop","memory","memory.grow","memory.size","module","mut","nop","offset","param","result","return","select","set_global","set_local","start","table","tee_local","then","type","unreachable"]
+},contains:[e.COMMENT(/;;/,/$/),n,{match:[/(?:offset|align)/,/\s*/,/=/],
+className:{1:"keyword",3:"operator"}},{className:"variable",begin:/\$[\w_]+/},{
+match:/(\((?!;)|\))+/,className:"punctuation",relevance:0},{
+begin:[/(?:func|call|call_indirect)/,/\s+/,/\$[^\s)]+/],className:{1:"keyword",
+3:"title.function"}},e.QUOTE_STRING_MODE,{match:/(i32|i64|f32|f64)(?!\.)/,
+className:"type"},{className:"keyword",
+match:/\b(f32|f64|i32|i64)(?:\.(?:abs|add|and|ceil|clz|const|convert_[su]\/i(?:32|64)|copysign|ctz|demote\/f64|div(?:_[su])?|eqz?|extend_[su]\/i32|floor|ge(?:_[su])?|gt(?:_[su])?|le(?:_[su])?|load(?:(?:8|16|32)_[su])?|lt(?:_[su])?|max|min|mul|nearest|neg?|or|popcnt|promote\/f32|reinterpret\/[fi](?:32|64)|rem_[su]|rot[lr]|shl|shr_[su]|store(?:8|16|32)?|sqrt|sub|trunc(?:_[su]\/f(?:32|64))?|wrap\/i64|xor))\b/
+},{className:"number",relevance:0,
+match:/[+-]?\b(?:\d(?:_?\d)*(?:\.\d(?:_?\d)*)?(?:[eE][+-]?\d(?:_?\d)*)?|0x[\da-fA-F](?:_?[\da-fA-F])*(?:\.[\da-fA-F](?:_?[\da-fA-D])*)?(?:[pP][+-]?\d(?:_?\d)*)?)\b|\binf\b|\bnan(?::0x[\da-fA-F](?:_?[\da-fA-D])*)?\b/
+}]}},grmr_xml:e=>{
+const n=e.regex,t=n.concat(/[\p{L}_]/u,n.optional(/[\p{L}0-9_.-]*:/u),/[\p{L}0-9_.-]*/u),a={
+className:"symbol",begin:/&[a-z]+;|&#[0-9]+;|&#x[a-f0-9]+;/},i={begin:/\s/,
+contains:[{className:"keyword",begin:/#?[a-z_][a-z1-9_-]+/,illegal:/\n/}]
+},r=e.inherit(i,{begin:/\(/,end:/\)/}),s=e.inherit(e.APOS_STRING_MODE,{
+className:"string"}),o=e.inherit(e.QUOTE_STRING_MODE,{className:"string"}),l={
+endsWithParent:!0,illegal:/</,relevance:0,contains:[{className:"attr",
+begin:/[\p{L}0-9._:-]+/u,relevance:0},{begin:/=\s*/,relevance:0,contains:[{
+className:"string",endsParent:!0,variants:[{begin:/"/,end:/"/,contains:[a]},{
+begin:/'/,end:/'/,contains:[a]},{begin:/[^\s"'=<>`]+/}]}]}]};return{
+name:"HTML, XML",
+aliases:["html","xhtml","rss","atom","xjb","xsd","xsl","plist","wsf","svg"],
+case_insensitive:!0,unicodeRegex:!0,contains:[{className:"meta",begin:/<![a-z]/,
+end:/>/,relevance:10,contains:[i,o,s,r,{begin:/\[/,end:/\]/,contains:[{
+className:"meta",begin:/<![a-z]/,end:/>/,contains:[i,r,o,s]}]}]
+},e.COMMENT(/<!--/,/-->/,{relevance:10}),{begin:/<!\[CDATA\[/,end:/\]\]>/,
+relevance:10},a,{className:"meta",end:/\?>/,variants:[{begin:/<\?xml/,
+relevance:10,contains:[o]},{begin:/<\?[a-z][a-z0-9]+/}]},{className:"tag",
+begin:/<style(?=\s|>)/,end:/>/,keywords:{name:"style"},contains:[l],starts:{
+end:/<\/style>/,returnEnd:!0,subLanguage:["css","xml"]}},{className:"tag",
+begin:/<script(?=\s|>)/,end:/>/,keywords:{name:"script"},contains:[l],starts:{
+end:/<\/script>/,returnEnd:!0,subLanguage:["javascript","handlebars","xml"]}},{
+className:"tag",begin:/<>|<\/>/},{className:"tag",
+begin:n.concat(/</,n.lookahead(n.concat(t,n.either(/\/>/,/>/,/\s/)))),
+end:/\/?>/,contains:[{className:"name",begin:t,relevance:0,starts:l}]},{
+className:"tag",begin:n.concat(/<\//,n.lookahead(n.concat(t,/>/))),contains:[{
+className:"name",begin:t,relevance:0},{begin:/>/,relevance:0,endsParent:!0}]}]}
+},grmr_yaml:e=>{
+const n="true false yes no null",t="[\\w#;/?:@&=+$,.~*'()[\\]]+",a={
+className:"string",relevance:0,variants:[{begin:/'/,end:/'/},{begin:/"/,end:/"/
+},{begin:/\S+/}],contains:[e.BACKSLASH_ESCAPE,{className:"template-variable",
+variants:[{begin:/\{\{/,end:/\}\}/},{begin:/%\{/,end:/\}/}]}]},i=e.inherit(a,{
+variants:[{begin:/'/,end:/'/},{begin:/"/,end:/"/},{begin:/[^\s,{}[\]]+/}]}),r={
+end:",",endsWithParent:!0,excludeEnd:!0,keywords:n,relevance:0},s={begin:/\{/,
+end:/\}/,contains:[r],illegal:"\\n",relevance:0},o={begin:"\\[",end:"\\]",
+contains:[r],illegal:"\\n",relevance:0},l=[{className:"attr",variants:[{
+begin:"\\w[\\w :\\/.-]*:(?=[ \t]|$)"},{begin:'"\\w[\\w :\\/.-]*":(?=[ \t]|$)'},{
+begin:"'\\w[\\w :\\/.-]*':(?=[ \t]|$)"}]},{className:"meta",begin:"^---\\s*$",
+relevance:10},{className:"string",
+begin:"[\\|>]([1-9]?[+-])?[ ]*\\n( +)[^ ][^\\n]*\\n(\\2[^\\n]+\\n?)*"},{
+begin:"<%[%=-]?",end:"[%-]?%>",subLanguage:"ruby",excludeBegin:!0,excludeEnd:!0,
+relevance:0},{className:"type",begin:"!\\w+!"+t},{className:"type",
+begin:"!<"+t+">"},{className:"type",begin:"!"+t},{className:"type",begin:"!!"+t
+},{className:"meta",begin:"&"+e.UNDERSCORE_IDENT_RE+"$"},{className:"meta",
+begin:"\\*"+e.UNDERSCORE_IDENT_RE+"$"},{className:"bullet",begin:"-(?=[ ]|$)",
+relevance:0},e.HASH_COMMENT_MODE,{beginKeywords:n,keywords:{literal:n}},{
+className:"number",
+begin:"\\b[0-9]{4}(-[0-9][0-9]){0,2}([Tt \\t][0-9][0-9]?(:[0-9][0-9]){2})?(\\.[0-9]*)?([ \\t])*(Z|[-+][0-9][0-9]?(:[0-9][0-9])?)?\\b"
+},{className:"number",begin:e.C_NUMBER_RE+"\\b",relevance:0},s,o,a],c=[...l]
+;return c.pop(),c.push(i),r.contains=c,{name:"YAML",case_insensitive:!0,
+aliases:["yml"],contains:l}}});const He=ae;for(const e of Object.keys(Ke)){
+const n=e.replace("grmr_","").replace("_","-");He.registerLanguage(n,Ke[e])}
+return He}()
+;"object"==typeof exports&&"undefined"!=typeof module&&(module.exports=hljs);</script>
+
+  <!-- Main application code -->
+  <script>
+    (function() {
+      'use strict';
+
+      // ============================================================
+      // DATA LOADING
+      // ============================================================
+
+      const base64 = document.getElementById('session-data').textContent;
+      const binary = atob(base64);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+      }
+      const data = JSON.parse(new TextDecoder('utf-8').decode(bytes));
+      const { header, entries, leafId: defaultLeafId, systemPrompt, tools, renderedTools } = data;
+
+      // ============================================================
+      // URL PARAMETER HANDLING
+      // ============================================================
+
+      // Parse URL parameters for deep linking: leafId and targetId
+      // Check for injected params (when loaded in iframe via srcdoc) or use window.location
+      const injectedParams = document.querySelector('meta[name="pi-url-params"]');
+      const searchString = injectedParams ? injectedParams.content : window.location.search.substring(1);
+      const urlParams = new URLSearchParams(searchString);
+      const urlLeafId = urlParams.get('leafId');
+      const urlTargetId = urlParams.get('targetId');
+      // Use URL leafId if provided, otherwise fall back to session default
+      const leafId = urlLeafId || defaultLeafId;
+
+      // ============================================================
+      // DATA STRUCTURES
+      // ============================================================
+
+      // Entry lookup by ID
+      const byId = new Map();
+      for (const entry of entries) {
+        byId.set(entry.id, entry);
+      }
+
+      // Tool call lookup (toolCallId -> {name, arguments})
+      const toolCallMap = new Map();
+      for (const entry of entries) {
+        if (entry.type === 'message' && entry.message.role === 'assistant') {
+          const content = entry.message.content;
+          if (Array.isArray(content)) {
+            for (const block of content) {
+              if (block.type === 'toolCall') {
+                toolCallMap.set(block.id, { name: block.name, arguments: block.arguments });
+              }
+            }
+          }
+        }
+      }
+
+      // Label lookup (entryId -> label string)
+      // Labels are stored in 'label' entries that reference their target via targetId
+      const labelMap = new Map();
+      for (const entry of entries) {
+        if (entry.type === 'label' && entry.targetId && entry.label) {
+          labelMap.set(entry.targetId, entry.label);
+        }
+      }
+
+      // ============================================================
+      // TREE DATA PREPARATION (no DOM, pure data)
+      // ============================================================
+
+      /**
+       * Build tree structure from flat entries.
+       * Returns array of root nodes, each with { entry, children, label }.
+       */
+      function buildTree() {
+        const nodeMap = new Map();
+        const roots = [];
+
+        // Create nodes
+        for (const entry of entries) {
+          nodeMap.set(entry.id, { 
+            entry, 
+            children: [],
+            label: labelMap.get(entry.id)
+          });
+        }
+
+        // Build parent-child relationships
+        for (const entry of entries) {
+          const node = nodeMap.get(entry.id);
+          if (entry.parentId === null || entry.parentId === undefined || entry.parentId === entry.id) {
+            roots.push(node);
+          } else {
+            const parent = nodeMap.get(entry.parentId);
+            if (parent) {
+              parent.children.push(node);
+            } else {
+              roots.push(node);
+            }
+          }
+        }
+
+        // Sort children by timestamp
+        function sortChildren(node) {
+          node.children.sort((a, b) =>
+            new Date(a.entry.timestamp).getTime() - new Date(b.entry.timestamp).getTime()
+          );
+          node.children.forEach(sortChildren);
+        }
+        roots.forEach(sortChildren);
+
+        return roots;
+      }
+
+      /**
+       * Build set of entry IDs on path from root to target.
+       */
+      function buildActivePathIds(targetId) {
+        const ids = new Set();
+        let current = byId.get(targetId);
+        while (current) {
+          ids.add(current.id);
+          // Stop if no parent or self-referencing (root)
+          if (!current.parentId || current.parentId === current.id) {
+            break;
+          }
+          current = byId.get(current.parentId);
+        }
+        return ids;
+      }
+
+      /**
+       * Get array of entries from root to target (the conversation path).
+       */
+      function getPath(targetId) {
+        const path = [];
+        let current = byId.get(targetId);
+        while (current) {
+          path.unshift(current);
+          // Stop if no parent or self-referencing (root)
+          if (!current.parentId || current.parentId === current.id) {
+            break;
+          }
+          current = byId.get(current.parentId);
+        }
+        return path;
+      }
+
+      // Tree node lookup for finding leaves
+      let treeNodeMap = null;
+
+      /**
+       * Find the newest leaf node reachable from a given node.
+       * This allows clicking any node in a branch to show the full branch.
+       * Children are sorted by timestamp, so the newest is always last.
+       */
+      function findNewestLeaf(nodeId) {
+        // Build tree node map lazily
+        if (!treeNodeMap) {
+          treeNodeMap = new Map();
+          const tree = buildTree();
+          function mapNodes(node) {
+            treeNodeMap.set(node.entry.id, node);
+            node.children.forEach(mapNodes);
+          }
+          tree.forEach(mapNodes);
+        }
+
+        const node = treeNodeMap.get(nodeId);
+        if (!node) return nodeId;
+
+        // Follow the newest (last) child at each level
+        let current = node;
+        while (current.children.length > 0) {
+          current = current.children[current.children.length - 1];
+        }
+        return current.entry.id;
+      }
+
+      /**
+       * Flatten tree into list with indentation and connector info.
+       * Returns array of { node, indent, showConnector, isLast, gutters, isVirtualRootChild, multipleRoots }.
+       * Matches tree-selector.ts logic exactly.
+       */
+      function flattenTree(roots, activePathIds) {
+        const result = [];
+        const multipleRoots = roots.length > 1;
+
+        // Mark which subtrees contain the active leaf
+        const containsActive = new Map();
+        function markActive(node) {
+          let has = activePathIds.has(node.entry.id);
+          for (const child of node.children) {
+            if (markActive(child)) has = true;
+          }
+          containsActive.set(node, has);
+          return has;
+        }
+        roots.forEach(markActive);
+
+        // Stack: [node, indent, justBranched, showConnector, isLast, gutters, isVirtualRootChild]
+        const stack = [];
+
+        // Add roots (prioritize branch containing active leaf)
+        const orderedRoots = [...roots].sort((a, b) => 
+          Number(containsActive.get(b)) - Number(containsActive.get(a))
+        );
+        for (let i = orderedRoots.length - 1; i >= 0; i--) {
+          const isLast = i === orderedRoots.length - 1;
+          stack.push([orderedRoots[i], multipleRoots ? 1 : 0, multipleRoots, multipleRoots, isLast, [], multipleRoots]);
+        }
+
+        while (stack.length > 0) {
+          const [node, indent, justBranched, showConnector, isLast, gutters, isVirtualRootChild] = stack.pop();
+
+          result.push({ node, indent, showConnector, isLast, gutters, isVirtualRootChild, multipleRoots });
+
+          const children = node.children;
+          const multipleChildren = children.length > 1;
+
+          // Order children (active branch first)
+          const orderedChildren = [...children].sort((a, b) => 
+            Number(containsActive.get(b)) - Number(containsActive.get(a))
+          );
+
+          // Calculate child indent (matches tree-selector.ts)
+          let childIndent;
+          if (multipleChildren) {
+            // Parent branches: children get +1
+            childIndent = indent + 1;
+          } else if (justBranched && indent > 0) {
+            // First generation after a branch: +1 for visual grouping
+            childIndent = indent + 1;
+          } else {
+            // Single-child chain: stay flat
+            childIndent = indent;
+          }
+
+          // Build gutters for children
+          const connectorDisplayed = showConnector && !isVirtualRootChild;
+          const currentDisplayIndent = multipleRoots ? Math.max(0, indent - 1) : indent;
+          const connectorPosition = Math.max(0, currentDisplayIndent - 1);
+          const childGutters = connectorDisplayed
+            ? [...gutters, { position: connectorPosition, show: !isLast }]
+            : gutters;
+
+          // Add children in reverse order for stack
+          for (let i = orderedChildren.length - 1; i >= 0; i--) {
+            const childIsLast = i === orderedChildren.length - 1;
+            stack.push([orderedChildren[i], childIndent, multipleChildren, multipleChildren, childIsLast, childGutters, false]);
+          }
+        }
+
+        return result;
+      }
+
+      /**
+       * Build ASCII prefix string for tree node.
+       */
+      function buildTreePrefix(flatNode) {
+        const { indent, showConnector, isLast, gutters, isVirtualRootChild, multipleRoots } = flatNode;
+        const displayIndent = multipleRoots ? Math.max(0, indent - 1) : indent;
+        const connector = showConnector && !isVirtualRootChild ? (isLast ? '└─ ' : '├─ ') : '';
+        const connectorPosition = connector ? displayIndent - 1 : -1;
+
+        const totalChars = displayIndent * 3;
+        const prefixChars = [];
+        for (let i = 0; i < totalChars; i++) {
+          const level = Math.floor(i / 3);
+          const posInLevel = i % 3;
+
+          const gutter = gutters.find(g => g.position === level);
+          if (gutter) {
+            prefixChars.push(posInLevel === 0 ? (gutter.show ? '│' : ' ') : ' ');
+          } else if (connector && level === connectorPosition) {
+            if (posInLevel === 0) {
+              prefixChars.push(isLast ? '└' : '├');
+            } else if (posInLevel === 1) {
+              prefixChars.push('─');
+            } else {
+              prefixChars.push(' ');
+            }
+          } else {
+            prefixChars.push(' ');
+          }
+        }
+        return prefixChars.join('');
+      }
+
+      // ============================================================
+      // FILTERING (pure data)
+      // ============================================================
+
+      let filterMode = 'default';
+      let searchQuery = '';
+
+      function hasTextContent(content) {
+        if (typeof content === 'string') return content.trim().length > 0;
+        if (Array.isArray(content)) {
+          for (const c of content) {
+            if (c.type === 'text' && c.text && c.text.trim().length > 0) return true;
+          }
+        }
+        return false;
+      }
+
+      function extractContent(content) {
+        if (typeof content === 'string') return content;
+        if (Array.isArray(content)) {
+          return content
+            .filter(c => c.type === 'text' && c.text)
+            .map(c => c.text)
+            .join('');
+        }
+        return '';
+      }
+
+      function getSearchableText(entry, label) {
+        const parts = [];
+        if (label) parts.push(label);
+
+        switch (entry.type) {
+          case 'message': {
+            const msg = entry.message;
+            parts.push(msg.role);
+            if (msg.content) parts.push(extractContent(msg.content));
+            if (msg.role === 'bashExecution' && msg.command) parts.push(msg.command);
+            break;
+          }
+          case 'custom_message':
+            parts.push(entry.customType);
+            parts.push(typeof entry.content === 'string' ? entry.content : extractContent(entry.content));
+            break;
+          case 'compaction':
+            parts.push('compaction');
+            break;
+          case 'branch_summary':
+            parts.push('branch summary', entry.summary);
+            break;
+          case 'model_change':
+            parts.push('model', entry.modelId);
+            break;
+          case 'thinking_level_change':
+            parts.push('thinking', entry.thinkingLevel);
+            break;
+        }
+
+        return parts.join(' ').toLowerCase();
+      }
+
+      /**
+       * Filter flat nodes based on current filterMode and searchQuery.
+       */
+      function filterNodes(flatNodes, currentLeafId) {
+        const searchTokens = searchQuery.toLowerCase().split(/\s+/).filter(Boolean);
+
+        const filtered = flatNodes.filter(flatNode => {
+          const entry = flatNode.node.entry;
+          const label = flatNode.node.label;
+          const isCurrentLeaf = entry.id === currentLeafId;
+
+          // Always show current leaf
+          if (isCurrentLeaf) return true;
+
+          // Hide assistant messages with only tool calls (no text) unless error/aborted
+          if (entry.type === 'message' && entry.message.role === 'assistant') {
+            const msg = entry.message;
+            const hasText = hasTextContent(msg.content);
+            const isErrorOrAborted = msg.stopReason && msg.stopReason !== 'stop' && msg.stopReason !== 'toolUse';
+            if (!hasText && !isErrorOrAborted) return false;
+          }
+
+          // Apply filter mode
+          const isSettingsEntry = ['label', 'custom', 'model_change', 'thinking_level_change'].includes(entry.type);
+          let passesFilter = true;
+
+          switch (filterMode) {
+            case 'user-only':
+              passesFilter = entry.type === 'message' && entry.message.role === 'user';
+              break;
+            case 'no-tools':
+              passesFilter = !isSettingsEntry && !(entry.type === 'message' && entry.message.role === 'toolResult');
+              break;
+            case 'labeled-only':
+              passesFilter = label !== undefined;
+              break;
+            case 'all':
+              passesFilter = true;
+              break;
+            default: // 'default'
+              passesFilter = !isSettingsEntry;
+              break;
+          }
+
+          if (!passesFilter) return false;
+
+          // Apply search filter
+          if (searchTokens.length > 0) {
+            const nodeText = getSearchableText(entry, label);
+            if (!searchTokens.every(t => nodeText.includes(t))) return false;
+          }
+
+          return true;
+        });
+
+        // Recalculate visual structure based on visible tree
+        recalculateVisualStructure(filtered, flatNodes);
+
+        return filtered;
+      }
+
+      /**
+       * Recompute indentation/connectors for the filtered view
+       *
+       * Filtering can hide intermediate entries; descendants attach to the nearest visible ancestor.
+       * Keep indentation semantics aligned with flattenTree() so single-child chains don't drift right.
+       */
+      function recalculateVisualStructure(filteredNodes, allFlatNodes) {
+        if (filteredNodes.length === 0) return;
+
+        const visibleIds = new Set(filteredNodes.map(n => n.node.entry.id));
+
+        // Build entry map for parent lookup (using full tree)
+        const entryMap = new Map();
+        for (const flatNode of allFlatNodes) {
+          entryMap.set(flatNode.node.entry.id, flatNode);
+        }
+
+        // Find nearest visible ancestor for a node
+        function findVisibleAncestor(nodeId) {
+          let currentId = entryMap.get(nodeId)?.node.entry.parentId;
+          while (currentId != null) {
+            if (visibleIds.has(currentId)) {
+              return currentId;
+            }
+            currentId = entryMap.get(currentId)?.node.entry.parentId;
+          }
+          return null;
+        }
+
+        // Build visible tree structure
+        const visibleParent = new Map();
+        const visibleChildren = new Map();
+        visibleChildren.set(null, []); // root-level nodes
+
+        for (const flatNode of filteredNodes) {
+          const nodeId = flatNode.node.entry.id;
+          const ancestorId = findVisibleAncestor(nodeId);
+          visibleParent.set(nodeId, ancestorId);
+
+          if (!visibleChildren.has(ancestorId)) {
+            visibleChildren.set(ancestorId, []);
+          }
+          visibleChildren.get(ancestorId).push(nodeId);
+        }
+
+        // Update multipleRoots based on visible roots
+        const visibleRootIds = visibleChildren.get(null);
+        const multipleRoots = visibleRootIds.length > 1;
+
+        // Build a map for quick lookup: nodeId → FlatNode
+        const filteredNodeMap = new Map();
+        for (const flatNode of filteredNodes) {
+          filteredNodeMap.set(flatNode.node.entry.id, flatNode);
+        }
+
+        // DFS traversal of visible tree, applying same indentation rules as flattenTree()
+        // Stack items: [nodeId, indent, justBranched, showConnector, isLast, gutters, isVirtualRootChild]
+        const stack = [];
+
+        // Add visible roots in reverse order (to process in forward order via stack)
+        for (let i = visibleRootIds.length - 1; i >= 0; i--) {
+          const isLast = i === visibleRootIds.length - 1;
+          stack.push([
+            visibleRootIds[i],
+            multipleRoots ? 1 : 0,
+            multipleRoots,
+            multipleRoots,
+            isLast,
+            [],
+            multipleRoots
+          ]);
+        }
+
+        while (stack.length > 0) {
+          const [nodeId, indent, justBranched, showConnector, isLast, gutters, isVirtualRootChild] = stack.pop();
+
+          const flatNode = filteredNodeMap.get(nodeId);
+          if (!flatNode) continue;
+
+          // Update this node's visual properties
+          flatNode.indent = indent;
+          flatNode.showConnector = showConnector;
+          flatNode.isLast = isLast;
+          flatNode.gutters = gutters;
+          flatNode.isVirtualRootChild = isVirtualRootChild;
+          flatNode.multipleRoots = multipleRoots;
+
+          // Get visible children of this node
+          const children = visibleChildren.get(nodeId) || [];
+          const multipleChildren = children.length > 1;
+
+          // Calculate child indent using same rules as flattenTree():
+          // - Parent branches (multiple children): children get +1
+          // - Just branched and indent > 0: children get +1 for visual grouping
+          // - Single-child chain: stay flat
+          let childIndent;
+          if (multipleChildren) {
+            childIndent = indent + 1;
+          } else if (justBranched && indent > 0) {
+            childIndent = indent + 1;
+          } else {
+            childIndent = indent;
+          }
+
+          // Build gutters for children (same logic as flattenTree)
+          const connectorDisplayed = showConnector && !isVirtualRootChild;
+          const currentDisplayIndent = multipleRoots ? Math.max(0, indent - 1) : indent;
+          const connectorPosition = Math.max(0, currentDisplayIndent - 1);
+          const childGutters = connectorDisplayed
+            ? [...gutters, { position: connectorPosition, show: !isLast }]
+            : gutters;
+
+          // Add children in reverse order (to process in forward order via stack)
+          for (let i = children.length - 1; i >= 0; i--) {
+            const childIsLast = i === children.length - 1;
+            stack.push([
+              children[i],
+              childIndent,
+              multipleChildren,
+              multipleChildren,
+              childIsLast,
+              childGutters,
+              false
+            ]);
+          }
+        }
+      }
+
+      // ============================================================
+      // TREE DISPLAY TEXT (pure data -> string)
+      // ============================================================
+
+      function shortenPath(p) {
+        if (typeof p !== 'string') return '';
+        if (p.startsWith('/Users/')) {
+          const parts = p.split('/');
+          if (parts.length > 2) return '~' + p.slice(('/Users/' + parts[2]).length);
+        }
+        if (p.startsWith('/home/')) {
+          const parts = p.split('/');
+          if (parts.length > 2) return '~' + p.slice(('/home/' + parts[2]).length);
+        }
+        return p;
+      }
+
+      function formatToolCall(name, args) {
+        switch (name) {
+          case 'read': {
+            const path = shortenPath(String(args.path || args.file_path || ''));
+            const offset = args.offset;
+            const limit = args.limit;
+            let display = path;
+            if (offset !== undefined || limit !== undefined) {
+              const start = offset ?? 1;
+              const end = limit !== undefined ? start + limit - 1 : '';
+              display += `:${start}${end ? `-${end}` : ''}`;
+            }
+            return `[read: ${display}]`;
+          }
+          case 'write':
+            return `[write: ${shortenPath(String(args.path || args.file_path || ''))}]`;
+          case 'edit':
+            return `[edit: ${shortenPath(String(args.path || args.file_path || ''))}]`;
+          case 'bash': {
+            const rawCmd = String(args.command || '');
+            const cmd = rawCmd.replace(/[\n\t]/g, ' ').trim().slice(0, 50);
+            return `[bash: ${cmd}${rawCmd.length > 50 ? '...' : ''}]`;
+          }
+          case 'grep':
+            return `[grep: /${args.pattern || ''}/ in ${shortenPath(String(args.path || '.'))}]`;
+          case 'find':
+            return `[find: ${args.pattern || ''} in ${shortenPath(String(args.path || '.'))}]`;
+          case 'ls':
+            return `[ls: ${shortenPath(String(args.path || '.'))}]`;
+          default: {
+            const argsStr = JSON.stringify(args).slice(0, 40);
+            return `[${name}: ${argsStr}${JSON.stringify(args).length > 40 ? '...' : ''}]`;
+          }
+        }
+      }
+
+      function escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+      }
+
+      /**
+       * Truncate string to maxLen chars, append "..." if truncated.
+       */
+      function truncate(s, maxLen = 100) {
+        if (s.length <= maxLen) return s;
+        return s.slice(0, maxLen) + '...';
+      }
+
+      /**
+       * Get display text for tree node (returns HTML string).
+       */
+      function getTreeNodeDisplayHtml(entry, label) {
+        const normalize = s => s.replace(/[\n\t]/g, ' ').trim();
+        const labelHtml = label ? `<span class="tree-label">[${escapeHtml(label)}]</span> ` : '';
+
+        switch (entry.type) {
+          case 'message': {
+            const msg = entry.message;
+            if (msg.role === 'user') {
+              const content = truncate(normalize(extractContent(msg.content)));
+              return labelHtml + `<span class="tree-role-user">user:</span> ${escapeHtml(content)}`;
+            }
+            if (msg.role === 'assistant') {
+              const textContent = truncate(normalize(extractContent(msg.content)));
+              if (textContent) {
+                return labelHtml + `<span class="tree-role-assistant">assistant:</span> ${escapeHtml(textContent)}`;
+              }
+              if (msg.stopReason === 'aborted') {
+                return labelHtml + `<span class="tree-role-assistant">assistant:</span> <span class="tree-muted">(aborted)</span>`;
+              }
+              if (msg.errorMessage) {
+                return labelHtml + `<span class="tree-role-assistant">assistant:</span> <span class="tree-error">${escapeHtml(truncate(msg.errorMessage))}</span>`;
+              }
+              return labelHtml + `<span class="tree-role-assistant">assistant:</span> <span class="tree-muted">(no text)</span>`;
+            }
+            if (msg.role === 'toolResult') {
+              const toolCall = msg.toolCallId ? toolCallMap.get(msg.toolCallId) : null;
+              if (toolCall) {
+                return labelHtml + `<span class="tree-role-tool">${escapeHtml(formatToolCall(toolCall.name, toolCall.arguments))}</span>`;
+              }
+              return labelHtml + `<span class="tree-role-tool">[${msg.toolName || 'tool'}]</span>`;
+            }
+            if (msg.role === 'bashExecution') {
+              const cmd = truncate(normalize(msg.command || ''));
+              return labelHtml + `<span class="tree-role-tool">[bash]:</span> ${escapeHtml(cmd)}`;
+            }
+            return labelHtml + `<span class="tree-muted">[${msg.role}]</span>`;
+          }
+          case 'compaction':
+            return labelHtml + `<span class="tree-compaction">[compaction: ${Math.round(entry.tokensBefore/1000)}k tokens]</span>`;
+          case 'branch_summary': {
+            const summary = truncate(normalize(entry.summary || ''));
+            return labelHtml + `<span class="tree-branch-summary">[branch summary]:</span> ${escapeHtml(summary)}`;
+          }
+          case 'custom_message': {
+            const content = typeof entry.content === 'string' ? entry.content : extractContent(entry.content);
+            return labelHtml + `<span class="tree-custom">[${escapeHtml(entry.customType)}]:</span> ${escapeHtml(truncate(normalize(content)))}`;
+          }
+          case 'model_change':
+            return labelHtml + `<span class="tree-muted">[model: ${entry.modelId}]</span>`;
+          case 'thinking_level_change':
+            return labelHtml + `<span class="tree-muted">[thinking: ${entry.thinkingLevel}]</span>`;
+          default:
+            return labelHtml + `<span class="tree-muted">[${entry.type}]</span>`;
+        }
+      }
+
+      // ============================================================
+      // TREE RENDERING (DOM manipulation)
+      // ============================================================
+
+      let currentLeafId = leafId;
+      let currentTargetId = urlTargetId || leafId;
+      let treeRendered = false;
+
+      function renderTree() {
+        const tree = buildTree();
+        const activePathIds = buildActivePathIds(currentLeafId);
+        const flatNodes = flattenTree(tree, activePathIds);
+        const filtered = filterNodes(flatNodes, currentLeafId);
+        const container = document.getElementById('tree-container');
+
+        // Full render only on first call or when filter/search changes
+        if (!treeRendered) {
+          container.innerHTML = '';
+
+          for (const flatNode of filtered) {
+            const entry = flatNode.node.entry;
+            const isOnPath = activePathIds.has(entry.id);
+            const isTarget = entry.id === currentTargetId;
+
+            const div = document.createElement('div');
+            div.className = 'tree-node';
+            if (isOnPath) div.classList.add('in-path');
+            if (isTarget) div.classList.add('active');
+            div.dataset.id = entry.id;
+
+            const prefix = buildTreePrefix(flatNode);
+            const prefixSpan = document.createElement('span');
+            prefixSpan.className = 'tree-prefix';
+            prefixSpan.textContent = prefix;
+
+            const marker = document.createElement('span');
+            marker.className = 'tree-marker';
+            marker.textContent = isOnPath ? '•' : ' ';
+
+            const content = document.createElement('span');
+            content.className = 'tree-content';
+            content.innerHTML = getTreeNodeDisplayHtml(entry, flatNode.node.label);
+
+            div.appendChild(prefixSpan);
+            div.appendChild(marker);
+            div.appendChild(content);
+            // Navigate to the newest leaf through this node, but scroll to the clicked node
+            div.addEventListener('click', () => {
+              const leafId = findNewestLeaf(entry.id);
+              navigateTo(leafId, 'target', entry.id);
+            });
+
+            container.appendChild(div);
+          }
+
+          treeRendered = true;
+        } else {
+          // Just update markers and classes
+          const nodes = container.querySelectorAll('.tree-node');
+          for (const node of nodes) {
+            const id = node.dataset.id;
+            const isOnPath = activePathIds.has(id);
+            const isTarget = id === currentTargetId;
+
+            node.classList.toggle('in-path', isOnPath);
+            node.classList.toggle('active', isTarget);
+
+            const marker = node.querySelector('.tree-marker');
+            if (marker) {
+              marker.textContent = isOnPath ? '•' : ' ';
+            }
+          }
+        }
+
+        document.getElementById('tree-status').textContent = `${filtered.length} / ${flatNodes.length} entries`;
+
+        // Scroll active node into view after layout
+        setTimeout(() => {
+          const activeNode = container.querySelector('.tree-node.active');
+          if (activeNode) {
+            activeNode.scrollIntoView({ block: 'nearest' });
+          }
+        }, 0);
+      }
+
+      function forceTreeRerender() {
+        treeRendered = false;
+        renderTree();
+      }
+
+      // ============================================================
+      // MESSAGE RENDERING
+      // ============================================================
+
+      function formatTokens(count) {
+        if (count < 1000) return count.toString();
+        if (count < 10000) return (count / 1000).toFixed(1) + 'k';
+        if (count < 1000000) return Math.round(count / 1000) + 'k';
+        return (count / 1000000).toFixed(1) + 'M';
+      }
+
+      function formatTimestamp(ts) {
+        if (!ts) return '';
+        const date = new Date(ts);
+        return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+      }
+
+      function replaceTabs(text) {
+        return text.replace(/\t/g, '   ');
+      }
+
+      /** Safely coerce value to string for display. Returns null if invalid type. */
+      function str(value) {
+        if (typeof value === 'string') return value;
+        if (value == null) return '';
+        return null;
+      }
+
+      function getLanguageFromPath(filePath) {
+        const ext = filePath.split('.').pop()?.toLowerCase();
+        const extToLang = {
+          ts: 'typescript', tsx: 'typescript', js: 'javascript', jsx: 'javascript',
+          py: 'python', rb: 'ruby', rs: 'rust', go: 'go', java: 'java',
+          c: 'c', cpp: 'cpp', h: 'c', hpp: 'cpp', cs: 'csharp',
+          php: 'php', sh: 'bash', bash: 'bash', zsh: 'bash',
+          sql: 'sql', html: 'html', css: 'css', scss: 'scss',
+          json: 'json', yaml: 'yaml', yml: 'yaml', xml: 'xml',
+          md: 'markdown', dockerfile: 'dockerfile'
+        };
+        return extToLang[ext];
+      }
+
+      function findToolResult(toolCallId) {
+        for (const entry of entries) {
+          if (entry.type === 'message' && entry.message.role === 'toolResult') {
+            if (entry.message.toolCallId === toolCallId) {
+              return entry.message;
+            }
+          }
+        }
+        return null;
+      }
+
+      function formatExpandableOutput(text, maxLines, lang) {
+        text = replaceTabs(text);
+        const lines = text.split('\n');
+        const displayLines = lines.slice(0, maxLines);
+        const remaining = lines.length - maxLines;
+
+        if (lang) {
+          let highlighted;
+          try {
+            highlighted = hljs.highlight(text, { language: lang }).value;
+          } catch {
+            highlighted = escapeHtml(text);
+          }
+
+          if (remaining > 0) {
+            const previewCode = displayLines.join('\n');
+            let previewHighlighted;
+            try {
+              previewHighlighted = hljs.highlight(previewCode, { language: lang }).value;
+            } catch {
+              previewHighlighted = escapeHtml(previewCode);
+            }
+
+            return `<div class="tool-output expandable" onclick="this.classList.toggle('expanded')">
+              <div class="output-preview"><pre><code class="hljs">${previewHighlighted}</code></pre>
+              <div class="expand-hint">... (${remaining} more lines)</div></div>
+              <div class="output-full"><pre><code class="hljs">${highlighted}</code></pre></div></div>`;
+          }
+
+          return `<div class="tool-output"><pre><code class="hljs">${highlighted}</code></pre></div>`;
+        }
+
+        // Plain text output
+        if (remaining > 0) {
+          let out = '<div class="tool-output expandable" onclick="this.classList.toggle(\'expanded\')">';
+          out += '<div class="output-preview">';
+          for (const line of displayLines) {
+            out += `<div>${escapeHtml(replaceTabs(line))}</div>`;
+          }
+          out += `<div class="expand-hint">... (${remaining} more lines)</div></div>`;
+          out += '<div class="output-full">';
+          for (const line of lines) {
+            out += `<div>${escapeHtml(replaceTabs(line))}</div>`;
+          }
+          out += '</div></div>';
+          return out;
+        }
+
+        let out = '<div class="tool-output">';
+        for (const line of displayLines) {
+          out += `<div>${escapeHtml(replaceTabs(line))}</div>`;
+        }
+        out += '</div>';
+        return out;
+      }
+
+      function renderToolCall(call) {
+        const result = findToolResult(call.id);
+        const isError = result?.isError || false;
+        const statusClass = result ? (isError ? 'error' : 'success') : 'pending';
+
+        const getResultText = () => {
+          if (!result) return '';
+          const textBlocks = result.content.filter(c => c.type === 'text');
+          return textBlocks.map(c => c.text).join('\n');
+        };
+
+        const getResultImages = () => {
+          if (!result) return [];
+          return result.content.filter(c => c.type === 'image');
+        };
+
+        const renderResultImages = () => {
+          const images = getResultImages();
+          if (images.length === 0) return '';
+          return '<div class="tool-images">' + 
+            images.map(img => `<img src="data:${img.mimeType};base64,${img.data}" class="tool-image" />`).join('') + 
+            '</div>';
+        };
+
+        let html = `<div class="tool-execution ${statusClass}">`;
+        const args = call.arguments || {};
+        const name = call.name;
+
+        const invalidArg = '<span class="tool-error">[invalid arg]</span>';
+
+        switch (name) {
+          case 'bash': {
+            const command = str(args.command);
+            const cmdDisplay = command === null ? invalidArg : escapeHtml(command || '...');
+            html += `<div class="tool-command">$ ${cmdDisplay}</div>`;
+            if (result) {
+              const output = getResultText().trim();
+              if (output) html += formatExpandableOutput(output, 5);
+            }
+            break;
+          }
+          case 'read': {
+            const filePath = str(args.file_path ?? args.path);
+            const offset = args.offset;
+            const limit = args.limit;
+
+            let pathHtml = filePath === null ? invalidArg : escapeHtml(shortenPath(filePath || ''));
+            if (filePath !== null && (offset !== undefined || limit !== undefined)) {
+              const startLine = offset ?? 1;
+              const endLine = limit !== undefined ? startLine + limit - 1 : '';
+              pathHtml += `<span class="line-numbers">:${startLine}${endLine ? '-' + endLine : ''}</span>`;
+            }
+
+            html += `<div class="tool-header"><span class="tool-name">read</span> <span class="tool-path">${pathHtml}</span></div>`;
+            if (result) {
+              html += renderResultImages();
+              const output = getResultText();
+              const lang = filePath ? getLanguageFromPath(filePath) : null;
+              if (output) html += formatExpandableOutput(output, 10, lang);
+            }
+            break;
+          }
+          case 'write': {
+            const filePath = str(args.file_path ?? args.path);
+            const content = str(args.content);
+
+            html += `<div class="tool-header"><span class="tool-name">write</span> <span class="tool-path">${filePath === null ? invalidArg : escapeHtml(shortenPath(filePath || ''))}</span>`;
+            if (content !== null && content) {
+              const lines = content.split('\n');
+              if (lines.length > 10) html += ` <span class="line-count">(${lines.length} lines)</span>`;
+            }
+            html += '</div>';
+
+            if (content === null) {
+              html += `<div class="tool-error">[invalid content arg - expected string]</div>`;
+            } else if (content) {
+              const lang = filePath ? getLanguageFromPath(filePath) : null;
+              html += formatExpandableOutput(content, 10, lang);
+            }
+            if (result) {
+              const output = getResultText().trim();
+              if (output) html += `<div class="tool-output"><div>${escapeHtml(output)}</div></div>`;
+            }
+            break;
+          }
+          case 'edit': {
+            const filePath = str(args.file_path ?? args.path);
+            html += `<div class="tool-header"><span class="tool-name">edit</span> <span class="tool-path">${filePath === null ? invalidArg : escapeHtml(shortenPath(filePath || ''))}</span></div>`;
+
+            if (result?.details?.diff) {
+              const diffLines = result.details.diff.split('\n');
+              html += '<div class="tool-diff">';
+              for (const line of diffLines) {
+                const cls = line.match(/^\+/) ? 'diff-added' : line.match(/^-/) ? 'diff-removed' : 'diff-context';
+                html += `<div class="${cls}">${escapeHtml(replaceTabs(line))}</div>`;
+              }
+              html += '</div>';
+            } else if (result) {
+              const output = getResultText().trim();
+              if (output) html += `<div class="tool-output"><pre>${escapeHtml(output)}</pre></div>`;
+            }
+            break;
+          }
+          default: {
+            // Check for pre-rendered custom tool HTML
+            const rendered = renderedTools?.[call.id];
+            if (rendered?.callHtml || rendered?.resultHtmlCollapsed || rendered?.resultHtmlExpanded) {
+              // Custom tool with pre-rendered HTML from TUI renderer
+              if (rendered.callHtml) {
+                html += `<div class="tool-header ansi-rendered">${rendered.callHtml}</div>`;
+              } else {
+                html += `<div class="tool-header"><span class="tool-name">${escapeHtml(name)}</span></div>`;
+              }
+              
+              if (rendered.resultHtmlCollapsed && rendered.resultHtmlExpanded && rendered.resultHtmlCollapsed !== rendered.resultHtmlExpanded) {
+                // Both collapsed and expanded differ - render expandable section
+                html += `<div class="tool-output expandable ansi-rendered" onclick="this.classList.toggle('expanded')">
+                  <div class="output-preview">${rendered.resultHtmlCollapsed}</div>
+                  <div class="output-full">${rendered.resultHtmlExpanded}</div>
+                </div>`;
+              } else if (rendered.resultHtmlExpanded) {
+                // Only expanded exists (or collapsed is identical) - show directly
+                html += `<div class="tool-output ansi-rendered">${rendered.resultHtmlExpanded}</div>`;
+              } else if (result) {
+                // No pre-rendered result HTML - fallback to JSON
+                const output = getResultText();
+                if (output) html += formatExpandableOutput(output, 10);
+              }
+            } else {
+              // Fallback to JSON display (existing behavior)
+              html += `<div class="tool-header"><span class="tool-name">${escapeHtml(name)}</span></div>`;
+              html += `<div class="tool-output"><pre>${escapeHtml(JSON.stringify(args, null, 2))}</pre></div>`;
+              if (result) {
+                const output = getResultText();
+                if (output) html += formatExpandableOutput(output, 10);
+              }
+            }
+          }
+        }
+
+        html += '</div>';
+        return html;
+      }
+
+      /**
+       * Download the session data as a JSONL file.
+       * Reconstructs the original format: header line + entry lines.
+       */
+      window.downloadSessionJson = function() {
+        // Build JSONL content: header first, then all entries
+        const lines = [];
+        if (header) {
+          lines.push(JSON.stringify({ type: 'header', ...header }));
+        }
+        for (const entry of entries) {
+          lines.push(JSON.stringify(entry));
+        }
+        const jsonlContent = lines.join('\n');
+
+        // Create download
+        const blob = new Blob([jsonlContent], { type: 'application/x-ndjson' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `${header?.id || 'session'}.jsonl`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }
+
+      /**
+       * Build a shareable URL for a specific message.
+       * URL format: base?gistId&leafId=<leafId>&targetId=<entryId>
+       */
+      function buildShareUrl(entryId) {
+        // Check for injected base URL (used when loaded in iframe via srcdoc)
+        const baseUrlMeta = document.querySelector('meta[name="pi-share-base-url"]');
+        const baseUrl = baseUrlMeta ? baseUrlMeta.content : window.location.href.split('?')[0];
+        
+        const url = new URL(window.location.href);
+        // Find the gist ID (first query param without value, e.g., ?abc123)
+        const gistId = Array.from(url.searchParams.keys()).find(k => !url.searchParams.get(k));
+        
+        // Build the share URL
+        const params = new URLSearchParams();
+        params.set('leafId', currentLeafId);
+        params.set('targetId', entryId);
+        
+        // If we have an injected base URL (iframe context), use it directly
+        if (baseUrlMeta) {
+          return `${baseUrl}&${params.toString()}`;
+        }
+        
+        // Otherwise build from current location (direct file access)
+        url.search = gistId ? `?${gistId}&${params.toString()}` : `?${params.toString()}`;
+        return url.toString();
+      }
+
+      /**
+       * Copy text to clipboard with visual feedback.
+       * Uses navigator.clipboard with fallback to execCommand for HTTP contexts.
+       */
+      async function copyToClipboard(text, button) {
+        let success = false;
+        try {
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            await navigator.clipboard.writeText(text);
+            success = true;
+          }
+        } catch (err) {
+          // Clipboard API failed, try fallback
+        }
+        
+        // Fallback for HTTP or when Clipboard API is unavailable
+        if (!success) {
+          try {
+            const textarea = document.createElement('textarea');
+            textarea.value = text;
+            textarea.style.position = 'fixed';
+            textarea.style.opacity = '0';
+            document.body.appendChild(textarea);
+            textarea.select();
+            success = document.execCommand('copy');
+            document.body.removeChild(textarea);
+          } catch (err) {
+            console.error('Failed to copy:', err);
+          }
+        }
+        
+        if (success && button) {
+          const originalHtml = button.innerHTML;
+          button.innerHTML = '✓';
+          button.classList.add('copied');
+          setTimeout(() => {
+            button.innerHTML = originalHtml;
+            button.classList.remove('copied');
+          }, 1500);
+        }
+      }
+
+      /**
+       * Render the copy-link button HTML for a message.
+       */
+      function renderCopyLinkButton(entryId) {
+        return `<button class="copy-link-btn" data-entry-id="${entryId}" title="Copy link to this message">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
+            <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
+          </svg>
+        </button>`;
+      }
+
+      function renderEntry(entry) {
+        const ts = formatTimestamp(entry.timestamp);
+        const tsHtml = ts ? `<div class="message-timestamp">${ts}</div>` : '';
+        const entryId = `entry-${entry.id}`;
+        const copyBtnHtml = renderCopyLinkButton(entry.id);
+
+        if (entry.type === 'message') {
+          const msg = entry.message;
+
+          if (msg.role === 'user') {
+            let html = `<div class="user-message" id="${entryId}">${copyBtnHtml}${tsHtml}`;
+            const content = msg.content;
+
+            if (Array.isArray(content)) {
+              const images = content.filter(c => c.type === 'image');
+              if (images.length > 0) {
+                html += '<div class="message-images">';
+                for (const img of images) {
+                  html += `<img src="data:${img.mimeType};base64,${img.data}" class="message-image" />`;
+                }
+                html += '</div>';
+              }
+            }
+
+            const text = typeof content === 'string' ? content : 
+              content.filter(c => c.type === 'text').map(c => c.text).join('\n');
+            if (text.trim()) {
+              html += `<div class="markdown-content">${safeMarkedParse(text)}</div>`;
+            }
+            html += '</div>';
+            return html;
+          }
+
+          if (msg.role === 'assistant') {
+            let html = `<div class="assistant-message" id="${entryId}">${copyBtnHtml}${tsHtml}`;
+
+            for (const block of msg.content) {
+              if (block.type === 'text' && block.text.trim()) {
+                html += `<div class="assistant-text markdown-content">${safeMarkedParse(block.text)}</div>`;
+              } else if (block.type === 'thinking' && block.thinking.trim()) {
+                html += `<div class="thinking-block">
+                  <div class="thinking-text">${escapeHtml(block.thinking)}</div>
+                  <div class="thinking-collapsed">Thinking ...</div>
+                </div>`;
+              }
+            }
+
+            for (const block of msg.content) {
+              if (block.type === 'toolCall') {
+                html += renderToolCall(block);
+              }
+            }
+
+            if (msg.stopReason === 'aborted') {
+              html += '<div class="error-text">Aborted</div>';
+            } else if (msg.stopReason === 'error') {
+              html += `<div class="error-text">Error: ${escapeHtml(msg.errorMessage || 'Unknown error')}</div>`;
+            }
+
+            html += '</div>';
+            return html;
+          }
+
+          if (msg.role === 'bashExecution') {
+            const isError = msg.cancelled || (msg.exitCode !== 0 && msg.exitCode !== null);
+            let html = `<div class="tool-execution ${isError ? 'error' : 'success'}" id="${entryId}">${tsHtml}`;
+            html += `<div class="tool-command">$ ${escapeHtml(msg.command)}</div>`;
+            if (msg.output) html += formatExpandableOutput(msg.output, 10);
+            if (msg.cancelled) {
+              html += '<div style="color: var(--warning)">(cancelled)</div>';
+            } else if (msg.exitCode !== 0 && msg.exitCode !== null) {
+              html += `<div style="color: var(--error)">(exit ${msg.exitCode})</div>`;
+            }
+            html += '</div>';
+            return html;
+          }
+
+          if (msg.role === 'toolResult') return '';
+        }
+
+        if (entry.type === 'model_change') {
+          return `<div class="model-change" id="${entryId}">${tsHtml}Switched to model: <span class="model-name">${escapeHtml(entry.provider)}/${escapeHtml(entry.modelId)}</span></div>`;
+        }
+
+        if (entry.type === 'compaction') {
+          return `<div class="compaction" id="${entryId}" onclick="this.classList.toggle('expanded')">
+            <div class="compaction-label">[compaction]</div>
+            <div class="compaction-collapsed">Compacted from ${entry.tokensBefore.toLocaleString()} tokens</div>
+            <div class="compaction-content"><strong>Compacted from ${entry.tokensBefore.toLocaleString()} tokens</strong>\n\n${escapeHtml(entry.summary)}</div>
+          </div>`;
+        }
+
+        if (entry.type === 'branch_summary') {
+          return `<div class="branch-summary" id="${entryId}">${tsHtml}
+            <div class="branch-summary-header">Branch Summary</div>
+            <div class="markdown-content">${safeMarkedParse(entry.summary)}</div>
+          </div>`;
+        }
+
+        if (entry.type === 'custom_message' && entry.display) {
+          return `<div class="hook-message" id="${entryId}">${tsHtml}
+            <div class="hook-type">[${escapeHtml(entry.customType)}]</div>
+            <div class="markdown-content">${safeMarkedParse(typeof entry.content === 'string' ? entry.content : JSON.stringify(entry.content))}</div>
+          </div>`;
+        }
+
+        return '';
+      }
+
+      // ============================================================
+      // HEADER / STATS
+      // ============================================================
+
+      function computeStats(entryList) {
+        let userMessages = 0, assistantMessages = 0, toolResults = 0;
+        let customMessages = 0, compactions = 0, branchSummaries = 0, toolCalls = 0;
+        const tokens = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+        const cost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+        const models = new Set();
+
+        for (const entry of entryList) {
+          if (entry.type === 'message') {
+            const msg = entry.message;
+            if (msg.role === 'user') userMessages++;
+            if (msg.role === 'assistant') {
+              assistantMessages++;
+              if (msg.model) models.add(msg.provider ? `${msg.provider}/${msg.model}` : msg.model);
+              if (msg.usage) {
+                tokens.input += msg.usage.input || 0;
+                tokens.output += msg.usage.output || 0;
+                tokens.cacheRead += msg.usage.cacheRead || 0;
+                tokens.cacheWrite += msg.usage.cacheWrite || 0;
+                if (msg.usage.cost) {
+                  cost.input += msg.usage.cost.input || 0;
+                  cost.output += msg.usage.cost.output || 0;
+                  cost.cacheRead += msg.usage.cost.cacheRead || 0;
+                  cost.cacheWrite += msg.usage.cost.cacheWrite || 0;
+                }
+              }
+              toolCalls += msg.content.filter(c => c.type === 'toolCall').length;
+            }
+            if (msg.role === 'toolResult') toolResults++;
+          } else if (entry.type === 'compaction') {
+            compactions++;
+          } else if (entry.type === 'branch_summary') {
+            branchSummaries++;
+          } else if (entry.type === 'custom_message') {
+            customMessages++;
+          }
+        }
+
+        return { userMessages, assistantMessages, toolResults, customMessages, compactions, branchSummaries, toolCalls, tokens, cost, models: Array.from(models) };
+      }
+
+      const globalStats = computeStats(entries);
+
+      function renderHeader() {
+        const totalCost = globalStats.cost.input + globalStats.cost.output + globalStats.cost.cacheRead + globalStats.cost.cacheWrite;
+
+        const tokenParts = [];
+        if (globalStats.tokens.input) tokenParts.push(`↑${formatTokens(globalStats.tokens.input)}`);
+        if (globalStats.tokens.output) tokenParts.push(`↓${formatTokens(globalStats.tokens.output)}`);
+        if (globalStats.tokens.cacheRead) tokenParts.push(`R${formatTokens(globalStats.tokens.cacheRead)}`);
+        if (globalStats.tokens.cacheWrite) tokenParts.push(`W${formatTokens(globalStats.tokens.cacheWrite)}`);
+
+        const msgParts = [];
+        if (globalStats.userMessages) msgParts.push(`${globalStats.userMessages} user`);
+        if (globalStats.assistantMessages) msgParts.push(`${globalStats.assistantMessages} assistant`);
+        if (globalStats.toolResults) msgParts.push(`${globalStats.toolResults} tool results`);
+        if (globalStats.customMessages) msgParts.push(`${globalStats.customMessages} custom`);
+        if (globalStats.compactions) msgParts.push(`${globalStats.compactions} compactions`);
+        if (globalStats.branchSummaries) msgParts.push(`${globalStats.branchSummaries} branch summaries`);
+
+        let html = `
+          <div class="header">
+            <h1>Session: ${escapeHtml(header?.id || 'unknown')}</h1>
+            <div class="help-bar">
+              <span>Ctrl+T toggle thinking · Ctrl+O toggle tools</span>
+              <button class="download-json-btn" onclick="downloadSessionJson()" title="Download session as JSONL">↓ JSONL</button>
+            </div>
+            <div class="header-info">
+              <div class="info-item"><span class="info-label">Date:</span><span class="info-value">${header?.timestamp ? new Date(header.timestamp).toLocaleString() : 'unknown'}</span></div>
+              <div class="info-item"><span class="info-label">Models:</span><span class="info-value">${globalStats.models.join(', ') || 'unknown'}</span></div>
+              <div class="info-item"><span class="info-label">Messages:</span><span class="info-value">${msgParts.join(', ') || '0'}</span></div>
+              <div class="info-item"><span class="info-label">Tool Calls:</span><span class="info-value">${globalStats.toolCalls}</span></div>
+              <div class="info-item"><span class="info-label">Tokens:</span><span class="info-value">${tokenParts.join(' ') || '0'}</span></div>
+              <div class="info-item"><span class="info-label">Cost:</span><span class="info-value">${totalCost.toFixed(3)}</span></div>
+            </div>
+          </div>`;
+
+        // Render system prompt (user's base prompt, applies to all providers)
+        if (systemPrompt) {
+          const lines = systemPrompt.split('\n');
+          const previewLines = 10;
+          if (lines.length > previewLines) {
+            const preview = lines.slice(0, previewLines).join('\n');
+            const remaining = lines.length - previewLines;
+            html += `<div class="system-prompt expandable" onclick="this.classList.toggle('expanded')">
+              <div class="system-prompt-header">System Prompt</div>
+              <div class="system-prompt-preview">${escapeHtml(preview)}</div>
+              <div class="system-prompt-expand-hint">... (${remaining} more lines, click to expand)</div>
+              <div class="system-prompt-full">${escapeHtml(systemPrompt)}</div>
+            </div>`;
+          } else {
+            html += `<div class="system-prompt">
+              <div class="system-prompt-header">System Prompt</div>
+              <div class="system-prompt-full" style="display: block">${escapeHtml(systemPrompt)}</div>
+            </div>`;
+          }
+        }
+
+        if (tools && tools.length > 0) {
+          html += `<div class="tools-list">
+            <div class="tools-header">Available Tools</div>
+            <div class="tools-content">
+              ${tools.map(t => {
+                const hasParams = t.parameters && typeof t.parameters === 'object' && t.parameters.properties && Object.keys(t.parameters.properties).length > 0;
+                if (!hasParams) {
+                  return `<div class="tool-item"><span class="tool-item-name">${escapeHtml(t.name)}</span> - <span class="tool-item-desc">${escapeHtml(t.description)}</span></div>`;
+                }
+                const params = t.parameters;
+                const properties = params.properties;
+                const required = params.required || [];
+                let paramsHtml = '';
+                for (const [name, prop] of Object.entries(properties)) {
+                  const isRequired = required.includes(name);
+                  const typeStr = prop.type || 'any';
+                  const reqLabel = isRequired ? '<span class="tool-param-required">required</span>' : '<span class="tool-param-optional">optional</span>';
+                  paramsHtml += `<div class="tool-param"><span class="tool-param-name">${escapeHtml(name)}</span> <span class="tool-param-type">${escapeHtml(typeStr)}</span> ${reqLabel}`;
+                  if (prop.description) {
+                    paramsHtml += `<div class="tool-param-desc">${escapeHtml(prop.description)}</div>`;
+                  }
+                  paramsHtml += `</div>`;
+                }
+                return `<div class="tool-item" onclick="this.classList.toggle('params-expanded')"><span class="tool-item-name">${escapeHtml(t.name)}</span> - <span class="tool-item-desc">${escapeHtml(t.description)}</span> <span class="tool-params-hint"></span><div class="tool-params-content">${paramsHtml}</div></div>`;
+              }).join('')}
+            </div>
+          </div>`;
+        }
+
+        return html;
+      }
+
+      // ============================================================
+      // NAVIGATION
+      // ============================================================
+
+      // Cache for rendered entry DOM nodes
+      const entryCache = new Map();
+
+      function renderEntryToNode(entry) {
+        // Check cache first
+        if (entryCache.has(entry.id)) {
+          return entryCache.get(entry.id).cloneNode(true);
+        }
+
+        // Render to HTML string, then parse to node
+        const html = renderEntry(entry);
+        if (!html) return null;
+
+        const template = document.createElement('template');
+        template.innerHTML = html;
+        const node = template.content.firstElementChild;
+
+        // Cache the node
+        if (node) {
+          entryCache.set(entry.id, node.cloneNode(true));
+        }
+        return node;
+      }
+
+      function navigateTo(targetId, scrollMode = 'target', scrollToEntryId = null) {
+        currentLeafId = targetId;
+        currentTargetId = scrollToEntryId || targetId;
+        const path = getPath(targetId);
+
+        renderTree();
+
+        document.getElementById('header-container').innerHTML = renderHeader();
+
+        // Build messages using cached DOM nodes
+        const messagesEl = document.getElementById('messages');
+        const fragment = document.createDocumentFragment();
+
+        for (const entry of path) {
+          const node = renderEntryToNode(entry);
+          if (node) {
+            fragment.appendChild(node);
+          }
+        }
+
+        messagesEl.innerHTML = '';
+        messagesEl.appendChild(fragment);
+
+        // Attach click handlers for copy-link buttons
+        messagesEl.querySelectorAll('.copy-link-btn').forEach(btn => {
+          btn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const entryId = btn.dataset.entryId;
+            const shareUrl = buildShareUrl(entryId);
+            copyToClipboard(shareUrl, btn);
+          });
+        });
+
+        // Use setTimeout(0) to ensure DOM is fully laid out before scrolling
+        setTimeout(() => {
+          const content = document.getElementById('content');
+          if (scrollMode === 'bottom') {
+            content.scrollTop = content.scrollHeight;
+          } else if (scrollMode === 'target') {
+            // If scrollToEntryId is provided, scroll to that specific entry
+            const scrollTargetId = scrollToEntryId || targetId;
+            const targetEl = document.getElementById(`entry-${scrollTargetId}`);
+            if (targetEl) {
+              targetEl.scrollIntoView({ block: 'center' });
+              // Briefly highlight the target message
+              if (scrollToEntryId) {
+                targetEl.classList.add('highlight');
+                setTimeout(() => targetEl.classList.remove('highlight'), 2000);
+              }
+            }
+          }
+        }, 0);
+      }
+
+      // ============================================================
+      // INITIALIZATION
+      // ============================================================
+
+      // Escape HTML tags in text (but not code blocks)
+      function escapeHtmlTags(text) {
+        return text.replace(/<(?=[a-zA-Z\/])/g, '&lt;');
+      }
+
+      // Configure marked with syntax highlighting and HTML escaping for text
+      marked.use({
+        breaks: true,
+        gfm: true,
+        renderer: {
+          // Code blocks: syntax highlight, no HTML escaping
+          code(token) {
+            const code = token.text;
+            const lang = token.lang;
+            let highlighted;
+            if (lang && hljs.getLanguage(lang)) {
+              try {
+                highlighted = hljs.highlight(code, { language: lang }).value;
+              } catch {
+                highlighted = escapeHtml(code);
+              }
+            } else {
+              // Auto-detect language if not specified
+              try {
+                highlighted = hljs.highlightAuto(code).value;
+              } catch {
+                highlighted = escapeHtml(code);
+              }
+            }
+            return `<pre><code class="hljs">${highlighted}</code></pre>`;
+          },
+          // Text content: escape HTML tags
+          text(token) {
+            return escapeHtmlTags(escapeHtml(token.text));
+          },
+          // Inline code: escape HTML
+          codespan(token) {
+            return `<code>${escapeHtml(token.text)}</code>`;
+          }
+        }
+      });
+
+      // Simple marked parse (escaping handled in renderers)
+      function safeMarkedParse(text) {
+        return marked.parse(text);
+      }
+
+      // Search input
+      const searchInput = document.getElementById('tree-search');
+      searchInput.addEventListener('input', (e) => {
+        searchQuery = e.target.value;
+        forceTreeRerender();
+      });
+
+      // Filter buttons
+      document.querySelectorAll('.filter-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+          document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
+          btn.classList.add('active');
+          filterMode = btn.dataset.filter;
+          forceTreeRerender();
+        });
+      });
+
+      // Sidebar toggle
+      const sidebar = document.getElementById('sidebar');
+      const overlay = document.getElementById('sidebar-overlay');
+      const hamburger = document.getElementById('hamburger');
+      const sidebarResizer = document.getElementById('sidebar-resizer');
+      const SIDEBAR_WIDTH_STORAGE_KEY = 'pi-share:v1:sidebar-width';
+      const MIN_CONTENT_WIDTH = 320;
+
+      function isMobileLayout() {
+        return window.matchMedia('(max-width: 900px)').matches;
+      }
+
+      function getSidebarBounds() {
+        const rootStyles = getComputedStyle(document.documentElement);
+        const minWidth = parseFloat(rootStyles.getPropertyValue('--sidebar-min-width')) || 240;
+        const maxWidth = parseFloat(rootStyles.getPropertyValue('--sidebar-max-width')) || 720;
+        const viewportMaxWidth = window.innerWidth - MIN_CONTENT_WIDTH;
+        return {
+          minWidth,
+          maxWidth: Math.max(minWidth, Math.min(maxWidth, viewportMaxWidth))
+        };
+      }
+
+      function clampSidebarWidth(width) {
+        const { minWidth, maxWidth } = getSidebarBounds();
+        return Math.max(minWidth, Math.min(maxWidth, width));
+      }
+
+      function applySidebarWidth(width) {
+        document.documentElement.style.setProperty('--sidebar-width', `${Math.round(clampSidebarWidth(width))}px`);
+      }
+
+      function loadSidebarWidth() {
+        try {
+          const raw = localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
+          if (raw === null) return null;
+          const width = Number(raw);
+          return Number.isFinite(width) ? width : null;
+        } catch {
+          return null;
+        }
+      }
+
+      function saveSidebarWidth(width) {
+        try {
+          localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(Math.round(clampSidebarWidth(width))));
+        } catch {
+          // Ignore storage failures (e.g. private browsing restrictions)
+        }
+      }
+
+      function setupSidebarResize() {
+        const savedWidth = loadSidebarWidth();
+        if (savedWidth !== null) {
+          applySidebarWidth(savedWidth);
+        }
+
+        if (!sidebarResizer) return;
+
+        let cleanupDrag = null;
+
+        const stopDrag = (pointerId) => {
+          if (cleanupDrag) {
+            cleanupDrag(pointerId);
+            cleanupDrag = null;
+          }
+        };
+
+        sidebarResizer.addEventListener('pointerdown', (e) => {
+          if (isMobileLayout()) return;
+
+          e.preventDefault();
+          const startX = e.clientX;
+          const startWidth = sidebar.getBoundingClientRect().width;
+          document.body.classList.add('sidebar-resizing');
+          sidebarResizer.setPointerCapture?.(e.pointerId);
+
+          const onPointerMove = (event) => {
+            applySidebarWidth(startWidth + (event.clientX - startX));
+          };
+
+          cleanupDrag = (pointerIdToRelease) => {
+            document.body.classList.remove('sidebar-resizing');
+            sidebarResizer.releasePointerCapture?.(pointerIdToRelease);
+            window.removeEventListener('pointermove', onPointerMove);
+            window.removeEventListener('pointerup', onPointerUp);
+            window.removeEventListener('pointercancel', onPointerCancel);
+            saveSidebarWidth(sidebar.getBoundingClientRect().width);
+          };
+
+          const onPointerUp = (event) => stopDrag(event.pointerId);
+          const onPointerCancel = (event) => stopDrag(event.pointerId);
+
+          window.addEventListener('pointermove', onPointerMove);
+          window.addEventListener('pointerup', onPointerUp);
+          window.addEventListener('pointercancel', onPointerCancel);
+        });
+
+        sidebarResizer.addEventListener('dblclick', () => {
+          if (isMobileLayout()) return;
+          applySidebarWidth(400);
+          saveSidebarWidth(400);
+        });
+
+        window.addEventListener('resize', () => {
+          if (isMobileLayout()) return;
+          applySidebarWidth(sidebar.getBoundingClientRect().width);
+        });
+      }
+
+      setupSidebarResize();
+
+      hamburger.addEventListener('click', () => {
+        sidebar.classList.add('open');
+        overlay.classList.add('open');
+        hamburger.style.display = 'none';
+      });
+
+      const closeSidebar = () => {
+        sidebar.classList.remove('open');
+        overlay.classList.remove('open');
+        hamburger.style.display = '';
+      };
+
+      overlay.addEventListener('click', closeSidebar);
+      document.getElementById('sidebar-close').addEventListener('click', closeSidebar);
+
+      // Toggle states
+      let thinkingExpanded = true;
+      let toolOutputsExpanded = false;
+
+      const toggleThinking = () => {
+        thinkingExpanded = !thinkingExpanded;
+        document.querySelectorAll('.thinking-text').forEach(el => {
+          el.style.display = thinkingExpanded ? '' : 'none';
+        });
+        document.querySelectorAll('.thinking-collapsed').forEach(el => {
+          el.style.display = thinkingExpanded ? 'none' : 'block';
+        });
+      };
+
+      const toggleToolOutputs = () => {
+        toolOutputsExpanded = !toolOutputsExpanded;
+        document.querySelectorAll('.tool-output.expandable').forEach(el => {
+          el.classList.toggle('expanded', toolOutputsExpanded);
+        });
+        document.querySelectorAll('.compaction').forEach(el => {
+          el.classList.toggle('expanded', toolOutputsExpanded);
+        });
+      };
+
+      // Keyboard shortcuts
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') {
+          searchInput.value = '';
+          searchQuery = '';
+          navigateTo(leafId, 'bottom');
+        }
+        if (e.ctrlKey && e.key === 't') {
+          e.preventDefault();
+          toggleThinking();
+        }
+        if (e.ctrlKey && e.key === 'o') {
+          e.preventDefault();
+          toggleToolOutputs();
+        }
+      });
+
+      // Initial render
+      // If URL has targetId, scroll to that specific message; otherwise stay at top
+      if (leafId) {
+        if (urlTargetId && byId.has(urlTargetId)) {
+          // Deep link: navigate to leaf and scroll to target message
+          navigateTo(leafId, 'target', urlTargetId);
+        } else {
+          navigateTo(leafId, 'none');
+        }
+      } else if (entries.length > 0) {
+        // Fallback: use last entry if no leafId
+        navigateTo(entries[entries.length - 1].id, 'none');
+      }
+    })();
+
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Adds a proper man page for git-ls that will be installed by Homebrew.

## Changes

- Created `manpage/git-ls.1` in roff format with full documentation
  - Includes all command-line options
  - Examples section
  - Terminal support information
  - Proper cross-references to related git commands

- Updated `.goreleaser.yaml`:
  - Include man page in release archives
  - Install man page via Homebrew formula to `man1/` directory

- Updated `Makefile` to verify man page exists during build

- Added `manpage/README.md` with documentation on managing the man page

## Testing

Tested locally:
- `man ./manpage/git-ls.1` displays correctly
- `git ls --help` works when man page is installed to `~/.local/share/man/man1/`

## Result

When users install via Homebrew, `git ls --help` will now display the proper man page instead of showing "No manual entry for git-ls".

## Transcript

The AI session transcript for this PR is available at: [transcripts/42-add-man-page.html](transcripts/42-add-man-page.html)