### PR TITLE
fix: handle detached HEAD and rebase states

### DIFF
--- a/main.go
+++ b/main.go
@@ -171,7 +171,7 @@ func fetchGitData() *gitResults {
 	})
 
 	wg.Go(func() {
-		results.currentBranch = gitCurrentBranchSymbolic()
+		results.currentBranch = headDescription()
 	})
 
 	wg.Go(func() {
@@ -438,7 +438,7 @@ func main() {
 	if maxWidth == 0 {
 		maxWidth = 80 // default when not a TTY
 	}
-	fmt.Printf("On branch %s%s%s\n\n", RED, gitData.currentBranch, RESET)
+	fmt.Printf("%s%s%s\n\n", RED, gitData.currentBranch, RESET)
 	rctx := &RenderContext{
 		GithubURL: isGithub(gitData.remotes),
 		Dir:       must(filepath.Abs(".")),
@@ -648,15 +648,131 @@ func isGithub(out []byte) string {
 	return ""
 }
 
-// gitCurrentBranchSymbolic gets the current branch name using symbolic-ref.
-// This works in empty repos (no commits) where rev-parse would fail.
-func gitCurrentBranchSymbolic() string {
+// headDescription returns a string describing the current HEAD state,
+// matching git-status output: "On branch X", "HEAD detached at X",
+// "HEAD detached from X", or rebase-in-progress messages.
+// The returned string includes the prefix (e.g. "On branch ").
+func headDescription() string {
+	// Try symbolic-ref first — if it works, we're on a branch
 	cmd := exec.Command("git", "-c", "core.fsmonitor=false", "symbolic-ref", "--short", "HEAD")
 	out, err := cmd.Output()
+	if err == nil {
+		return "On branch " + strings.TrimSpace(string(out))
+	}
+
+	// We're in detached HEAD state. Check for rebase.
+	gitDir := gitCommonDir()
+	if desc := rebaseDescription(gitDir); desc != "" {
+		return desc
+	}
+
+	// Determine "detached at" vs "detached from" by comparing HEAD to the
+	// commit we originally detached at (found via reflog).
+	return detachedDescription()
+}
+
+// gitCommonDir returns the path to the git common dir (handles worktrees).
+func gitCommonDir() string {
+	cmd := exec.Command("git", "-c", "core.fsmonitor=false", "rev-parse", "--git-common-dir")
+	out, err := cmd.Output()
 	if err != nil {
-		log.Fatalf("Failed to get current branch: %v", err)
+		return ".git"
 	}
 	return strings.TrimSpace(string(out))
+}
+
+// rebaseDescription checks for an in-progress rebase and returns the
+// appropriate status string, or "" if no rebase is active.
+func rebaseDescription(gitDir string) string {
+	ontoBytes, err := os.ReadFile(filepath.Join(gitDir, "rebase-merge", "onto"))
+	if err == nil {
+		onto := strings.TrimSpace(string(ontoBytes))
+		onto = shortOid(onto)
+		if _, e := os.Stat(filepath.Join(gitDir, "rebase-merge", "interactive")); e == nil {
+			return "interactive rebase in progress; onto " + onto
+		}
+		return "rebase in progress; onto " + onto
+	}
+	ontoBytes, err = os.ReadFile(filepath.Join(gitDir, "rebase-apply", "onto"))
+	if err == nil {
+		onto := strings.TrimSpace(string(ontoBytes))
+		onto = shortOid(onto)
+		return "rebase in progress; onto " + onto
+	}
+	return ""
+}
+
+// shortOid abbreviates a full hex oid via rev-parse --short.
+func shortOid(oid string) string {
+	cmd := exec.Command("git", "-c", "core.fsmonitor=false", "rev-parse", "--short", oid)
+	out, err := cmd.Output()
+	if err != nil {
+		return oid
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// detachedDescription returns "HEAD detached at X" or "HEAD detached from X"
+// by inspecting the reflog, mirroring git-status behavior.
+func detachedDescription() string {
+	// Walk the reflog to find the checkout/switch entry where we detached.
+	// That entry's oid is the commit we originally landed on.
+	cmd := exec.Command("git", "-c", "core.fsmonitor=false",
+		"reflog", "--format=%H %gs", "HEAD")
+	reflogOut, err := cmd.Output()
+	if err != nil {
+		return "Not currently on any branch."
+	}
+
+	var detachedOid string
+	for line := range strings.SplitSeq(strings.TrimSpace(string(reflogOut)), "\n") {
+		if strings.Contains(line, "checkout: ") || strings.Contains(line, "switch: ") {
+			detachedOid, _, _ = strings.Cut(line, " ")
+			break
+		}
+	}
+	if detachedOid == "" {
+		return "Not currently on any branch."
+	}
+
+	// Get current HEAD oid
+	cmd = exec.Command("git", "-c", "core.fsmonitor=false", "rev-parse", "HEAD")
+	headOut, err := cmd.Output()
+	if err != nil {
+		return "Not currently on any branch."
+	}
+	headOid := strings.TrimSpace(string(headOut))
+
+	atOrFrom := "at"
+	if headOid != detachedOid {
+		atOrFrom = "from"
+	}
+
+	// Try to find a friendly name (tag or branch) that points at detachedOid
+	name := friendlyRefName(detachedOid)
+
+	return "HEAD detached " + atOrFrom + " " + name
+}
+
+// friendlyRefName tries to describe an oid with a tag or branch name.
+// Falls back to the short hash.
+func friendlyRefName(oid string) string {
+	// Try describe --tags --exact-match first for tags
+	cmd := exec.Command("git", "-c", "core.fsmonitor=false", "describe", "--tags", "--exact-match", oid)
+	out, err := cmd.Output()
+	if err == nil {
+		return strings.TrimSpace(string(out))
+	}
+	// Try branch name via name-rev
+	cmd = exec.Command("git", "-c", "core.fsmonitor=false", "name-rev", "--name-only", "--no-undefined", "--refs=refs/heads/*", oid)
+	out, err = cmd.Output()
+	if err == nil {
+		name := strings.TrimSpace(string(out))
+		if name != "" && !strings.Contains(name, "~") && !strings.Contains(name, "^") {
+			return name
+		}
+	}
+	return shortOid(oid)
 }
 
 // gitRoot returns the root directory of the git repository

--- a/main_test.go
+++ b/main_test.go
@@ -1143,3 +1143,128 @@ func TestRenamedFileGitInfo(t *testing.T) {
 		t.Errorf("Expected message 'initial commit', got %q", renamed.message)
 	}
 }
+
+func TestHeadDescription(t *testing.T) {
+	tmpDir := t.TempDir()
+	repoDir := tmpDir + "/repo"
+	if err := os.Mkdir(repoDir, 0o755); err != nil {
+		t.Fatalf("Failed to create repo dir: %v", err)
+	}
+
+	for _, args := range [][]string{
+		{"init", "-b", "main"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test User"},
+	} {
+		if err := runCmd(repoDir, "git", args...); err != nil {
+			t.Fatalf("git %v failed: %v", args, err)
+		}
+	}
+
+	// Create two commits so we can detach at the first one
+	if err := os.WriteFile(repoDir+"/a.txt", []byte("a"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, "git", "add", "."); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, "git", "commit", "-m", "first"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(repoDir+"/b.txt", []byte("b"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, "git", "add", "."); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, "git", "commit", "-m", "second"); err != nil {
+		t.Fatal(err)
+	}
+
+	oldDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldDir) }()
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// On a branch
+	t.Run("on branch", func(t *testing.T) {
+		desc := headDescription()
+		if desc != "On branch main" {
+			t.Fatalf("expected 'On branch main', got %q", desc)
+		}
+	})
+
+	// Detach HEAD at the first commit
+	if err := runCmd(repoDir, "git", "checkout", "--detach", "HEAD~1"); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("detached at", func(t *testing.T) {
+		desc := headDescription()
+		if !strings.HasPrefix(desc, "HEAD detached at ") {
+			t.Fatalf("expected 'HEAD detached at <hash>', got %q", desc)
+		}
+		hash := strings.TrimPrefix(desc, "HEAD detached at ")
+		if len(hash) < 7 {
+			t.Fatalf("expected at least 7-char short hash, got %q", hash)
+		}
+	})
+
+	// Make a commit while detached — now it should be "detached from"
+	if err := runCmd(repoDir, "git", "commit", "--allow-empty", "-m", "detached commit"); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("detached from", func(t *testing.T) {
+		desc := headDescription()
+		if !strings.HasPrefix(desc, "HEAD detached from ") {
+			t.Fatalf("expected 'HEAD detached from <hash>', got %q", desc)
+		}
+	})
+
+	// Go back to main for rebase test
+	if err := runCmd(repoDir, "git", "switch", "main"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a branch with a conflicting change for rebase
+	if err := runCmd(repoDir, "git", "checkout", "-b", "feature"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(repoDir+"/a.txt", []byte("feature change"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, "git", "add", "."); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, "git", "commit", "-m", "feature"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Start a rebase that will conflict
+	if err := runCmd(repoDir, "git", "switch", "main"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(repoDir+"/a.txt", []byte("main change"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, "git", "add", "."); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, "git", "commit", "-m", "main diverge"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, "git", "switch", "feature"); err != nil {
+		t.Fatal(err)
+	}
+	// This rebase will fail due to conflict — that's what we want
+	_ = runCmd(repoDir, "git", "rebase", "main")
+
+	t.Run("rebase in progress", func(t *testing.T) {
+		desc := headDescription()
+		if !strings.Contains(desc, "rebase in progress; onto ") {
+			t.Fatalf("expected rebase message, got %q", desc)
+		}
+	})
+}

--- a/transcripts/45-handle-detached-head/index.html
+++ b/transcripts/45-handle-detached-head/index.html
@@ -1,0 +1,566 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Claude Code transcript - Index</title>
+    <style>
+:root { --bg-color: #f5f5f5; --card-bg: #ffffff; --user-bg: #e3f2fd; --user-border: #1976d2; --assistant-bg: #f5f5f5; --assistant-border: #9e9e9e; --thinking-bg: #fff8e1; --thinking-border: #ffc107; --thinking-text: #666; --tool-bg: #f3e5f5; --tool-border: #9c27b0; --tool-result-bg: #e8f5e9; --tool-error-bg: #ffebee; --text-color: #212121; --text-muted: #757575; --code-bg: #263238; --code-text: #aed581; }
+* { box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg-color); color: var(--text-color); margin: 0; padding: 16px; line-height: 1.6; }
+.container { max-width: 800px; margin: 0 auto; }
+h1 { font-size: 1.5rem; margin-bottom: 24px; padding-bottom: 8px; border-bottom: 2px solid var(--user-border); }
+.header-row { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; border-bottom: 2px solid var(--user-border); padding-bottom: 8px; margin-bottom: 24px; }
+.header-row h1 { border-bottom: none; padding-bottom: 0; margin-bottom: 0; flex: 1; min-width: 200px; }
+.message { margin-bottom: 16px; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.message.user { background: var(--user-bg); border-left: 4px solid var(--user-border); }
+.message.assistant { background: var(--card-bg); border-left: 4px solid var(--assistant-border); }
+.message.tool-reply { background: #fff8e1; border-left: 4px solid #ff9800; }
+.tool-reply .role-label { color: #e65100; }
+.tool-reply .tool-result { background: transparent; padding: 0; margin: 0; }
+.tool-reply .tool-result .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff8e1); }
+.message-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 16px; background: rgba(0,0,0,0.03); font-size: 0.85rem; }
+.role-label { font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
+.user .role-label { color: var(--user-border); }
+time { color: var(--text-muted); font-size: 0.8rem; }
+.timestamp-link { color: inherit; text-decoration: none; }
+.timestamp-link:hover { text-decoration: underline; }
+.message:target { animation: highlight 2s ease-out; }
+@keyframes highlight { 0% { background-color: rgba(25, 118, 210, 0.2); } 100% { background-color: transparent; } }
+.message-content { padding: 16px; }
+.message-content p { margin: 0 0 12px 0; }
+.message-content p:last-child { margin-bottom: 0; }
+.thinking { background: var(--thinking-bg); border: 1px solid var(--thinking-border); border-radius: 8px; padding: 12px; margin: 12px 0; font-size: 0.9rem; color: var(--thinking-text); }
+.thinking-label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: #f57c00; margin-bottom: 8px; }
+.thinking p { margin: 8px 0; }
+.assistant-text { margin: 8px 0; }
+.tool-use { background: var(--tool-bg); border: 1px solid var(--tool-border); border-radius: 8px; padding: 12px; margin: 12px 0; }
+.tool-header { font-weight: 600; color: var(--tool-border); margin-bottom: 8px; display: flex; align-items: center; gap: 8px; }
+.tool-icon { font-size: 1.1rem; }
+.tool-description { font-size: 0.9rem; color: var(--text-muted); margin-bottom: 8px; font-style: italic; }
+.tool-result { background: var(--tool-result-bg); border-radius: 8px; padding: 12px; margin: 12px 0; }
+.tool-result.tool-error { background: var(--tool-error-bg); }
+.file-tool { border-radius: 8px; padding: 12px; margin: 12px 0; }
+.write-tool { background: linear-gradient(135deg, #e3f2fd 0%, #e8f5e9 100%); border: 1px solid #4caf50; }
+.edit-tool { background: linear-gradient(135deg, #fff3e0 0%, #fce4ec 100%); border: 1px solid #ff9800; }
+.file-tool-header { font-weight: 600; margin-bottom: 4px; display: flex; align-items: center; gap: 8px; font-size: 0.95rem; }
+.write-header { color: #2e7d32; }
+.edit-header { color: #e65100; }
+.file-tool-icon { font-size: 1rem; }
+.file-tool-path { font-family: monospace; background: rgba(0,0,0,0.08); padding: 2px 8px; border-radius: 4px; }
+.file-tool-fullpath { font-family: monospace; font-size: 0.8rem; color: var(--text-muted); margin-bottom: 8px; word-break: break-all; }
+.file-content { margin: 0; }
+.edit-section { display: flex; margin: 4px 0; border-radius: 4px; overflow: hidden; }
+.edit-label { padding: 8px 12px; font-weight: bold; font-family: monospace; display: flex; align-items: flex-start; }
+.edit-old { background: #fce4ec; }
+.edit-old .edit-label { color: #b71c1c; background: #f8bbd9; }
+.edit-old .edit-content { color: #880e4f; }
+.edit-new { background: #e8f5e9; }
+.edit-new .edit-label { color: #1b5e20; background: #a5d6a7; }
+.edit-new .edit-content { color: #1b5e20; }
+.edit-content { margin: 0; flex: 1; background: transparent; font-size: 0.85rem; }
+.edit-replace-all { font-size: 0.75rem; font-weight: normal; color: var(--text-muted); }
+.write-tool .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #e6f4ea); }
+.edit-tool .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff0e5); }
+.todo-list { background: linear-gradient(135deg, #e8f5e9 0%, #f1f8e9 100%); border: 1px solid #81c784; border-radius: 8px; padding: 12px; margin: 12px 0; }
+.todo-header { font-weight: 600; color: #2e7d32; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; font-size: 0.95rem; }
+.todo-items { list-style: none; margin: 0; padding: 0; }
+.todo-item { display: flex; align-items: flex-start; gap: 10px; padding: 6px 0; border-bottom: 1px solid rgba(0,0,0,0.06); font-size: 0.9rem; }
+.todo-item:last-child { border-bottom: none; }
+.todo-icon { flex-shrink: 0; width: 20px; height: 20px; display: flex; align-items: center; justify-content: center; font-weight: bold; border-radius: 50%; }
+.todo-completed .todo-icon { color: #2e7d32; background: rgba(46, 125, 50, 0.15); }
+.todo-completed .todo-content { color: #558b2f; text-decoration: line-through; }
+.todo-in-progress .todo-icon { color: #f57c00; background: rgba(245, 124, 0, 0.15); }
+.todo-in-progress .todo-content { color: #e65100; font-weight: 500; }
+.todo-pending .todo-icon { color: #757575; background: rgba(0,0,0,0.05); }
+.todo-pending .todo-content { color: #616161; }
+pre { background: var(--code-bg); color: var(--code-text); padding: 12px; border-radius: 6px; overflow-x: auto; font-size: 0.85rem; line-height: 1.5; margin: 8px 0; white-space: pre-wrap; word-wrap: break-word; }
+pre.json { color: #e0e0e0; }
+code { background: rgba(0,0,0,0.08); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+pre code { background: none; padding: 0; }
+.user-content { margin: 0; }
+.truncatable { position: relative; }
+.truncatable.truncated .truncatable-content { max-height: 200px; overflow: hidden; }
+.truncatable.truncated::after { content: ''; position: absolute; bottom: 32px; left: 0; right: 0; height: 60px; background: linear-gradient(to bottom, transparent, var(--card-bg)); pointer-events: none; }
+.message.user .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--user-bg)); }
+.message.tool-reply .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff8e1); }
+.tool-use .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--tool-bg)); }
+.tool-result .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--tool-result-bg)); }
+.expand-btn { display: none; width: 100%; padding: 8px 16px; margin-top: 4px; background: rgba(0,0,0,0.05); border: 1px solid rgba(0,0,0,0.1); border-radius: 6px; cursor: pointer; font-size: 0.85rem; color: var(--text-muted); }
+.expand-btn:hover { background: rgba(0,0,0,0.1); }
+.truncatable.truncated .expand-btn, .truncatable.expanded .expand-btn { display: block; }
+.pagination { display: flex; justify-content: center; gap: 8px; margin: 24px 0; flex-wrap: wrap; }
+.pagination a, .pagination span { padding: 5px 10px; border-radius: 6px; text-decoration: none; font-size: 0.85rem; }
+.pagination a { background: var(--card-bg); color: var(--user-border); border: 1px solid var(--user-border); }
+.pagination a:hover { background: var(--user-bg); }
+.pagination .current { background: var(--user-border); color: white; }
+.pagination .disabled { color: var(--text-muted); border: 1px solid #ddd; }
+.pagination .index-link { background: var(--user-border); color: white; }
+details.continuation { margin-bottom: 16px; }
+details.continuation summary { cursor: pointer; padding: 12px 16px; background: var(--user-bg); border-left: 4px solid var(--user-border); border-radius: 12px; font-weight: 500; color: var(--text-muted); }
+details.continuation summary:hover { background: rgba(25, 118, 210, 0.15); }
+details.continuation[open] summary { border-radius: 12px 12px 0 0; margin-bottom: 0; }
+.index-item { margin-bottom: 16px; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); background: var(--user-bg); border-left: 4px solid var(--user-border); }
+.index-item a { display: block; text-decoration: none; color: inherit; }
+.index-item a:hover { background: rgba(25, 118, 210, 0.1); }
+.index-item-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 16px; background: rgba(0,0,0,0.03); font-size: 0.85rem; }
+.index-item-number { font-weight: 600; color: var(--user-border); }
+.index-item-content { padding: 16px; }
+.index-item-stats { padding: 8px 16px 12px 32px; font-size: 0.85rem; color: var(--text-muted); border-top: 1px solid rgba(0,0,0,0.06); }
+.index-item-commit { margin-top: 6px; padding: 4px 8px; background: #fff3e0; border-radius: 4px; font-size: 0.85rem; color: #e65100; }
+.index-item-commit code { background: rgba(0,0,0,0.08); padding: 1px 4px; border-radius: 3px; font-size: 0.8rem; margin-right: 6px; }
+.commit-card { margin: 8px 0; padding: 10px 14px; background: #fff3e0; border-left: 4px solid #ff9800; border-radius: 6px; }
+.commit-card a { text-decoration: none; color: #5d4037; display: block; }
+.commit-card a:hover { color: #e65100; }
+.commit-card-hash { font-family: monospace; color: #e65100; font-weight: 600; margin-right: 8px; }
+.index-commit { margin-bottom: 12px; padding: 10px 16px; background: #fff3e0; border-left: 4px solid #ff9800; border-radius: 8px; box-shadow: 0 1px 2px rgba(0,0,0,0.05); }
+.index-commit a { display: block; text-decoration: none; color: inherit; }
+.index-commit a:hover { background: rgba(255, 152, 0, 0.1); margin: -10px -16px; padding: 10px 16px; border-radius: 8px; }
+.index-commit-header { display: flex; justify-content: space-between; align-items: center; font-size: 0.85rem; margin-bottom: 4px; }
+.index-commit-hash { font-family: monospace; color: #e65100; font-weight: 600; }
+.index-commit-msg { color: #5d4037; }
+.index-item-long-text { margin-top: 8px; padding: 12px; background: var(--card-bg); border-radius: 8px; border-left: 3px solid var(--assistant-border); }
+.index-item-long-text .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--card-bg)); }
+.index-item-long-text-content { color: var(--text-color); }
+#search-box { display: none; align-items: center; gap: 8px; }
+#search-box input { padding: 6px 12px; border: 1px solid var(--assistant-border); border-radius: 6px; font-size: 16px; width: 180px; }
+#search-box button, #modal-search-btn, #modal-close-btn { background: var(--user-border); color: white; border: none; border-radius: 6px; padding: 6px 10px; cursor: pointer; display: flex; align-items: center; justify-content: center; }
+#search-box button:hover, #modal-search-btn:hover { background: #1565c0; }
+#modal-close-btn { background: var(--text-muted); margin-left: 8px; }
+#modal-close-btn:hover { background: #616161; }
+#search-modal[open] { border: none; border-radius: 12px; box-shadow: 0 4px 24px rgba(0,0,0,0.2); padding: 0; width: 90vw; max-width: 900px; height: 80vh; max-height: 80vh; display: flex; flex-direction: column; }
+#search-modal::backdrop { background: rgba(0,0,0,0.5); }
+.search-modal-header { display: flex; align-items: center; gap: 8px; padding: 16px; border-bottom: 1px solid var(--assistant-border); background: var(--bg-color); border-radius: 12px 12px 0 0; }
+.search-modal-header input { flex: 1; padding: 8px 12px; border: 1px solid var(--assistant-border); border-radius: 6px; font-size: 16px; }
+#search-status { padding: 8px 16px; font-size: 0.85rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
+#search-results { flex: 1; overflow-y: auto; padding: 16px; }
+.search-result { margin-bottom: 16px; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.search-result a { display: block; text-decoration: none; color: inherit; }
+.search-result a:hover { background: rgba(25, 118, 210, 0.05); }
+.search-result-page { padding: 6px 12px; background: rgba(0,0,0,0.03); font-size: 0.8rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
+.search-result-content { padding: 12px; }
+.search-result mark { background: #fff59d; padding: 1px 2px; border-radius: 2px; }
+@media (max-width: 600px) { body { padding: 8px; } .message, .index-item { border-radius: 8px; } .message-content, .index-item-content { padding: 12px; } pre { font-size: 0.8rem; padding: 8px; } #search-box input { width: 120px; } #search-modal[open] { width: 95vw; height: 90vh; } }
+</style>
+</head>
+<body>
+    <div class="container">
+        <div class="header-row">
+            <h1>Claude Code transcript</h1>
+            <div id="search-box">
+                <input type="text" id="search-input" placeholder="Search..." aria-label="Search transcripts">
+                <button id="search-btn" type="button" aria-label="Search">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.35-4.35"></path></svg>
+                </button>
+            </div>
+        </div>
+        
+
+<div class="pagination">
+<span class="current">Index</span>
+<span class="disabled">&larr; Prev</span>
+<a href="page-001.html">1</a>
+<a href="page-002.html">2</a>
+<a href="page-001.html">Next &rarr;</a>
+</div>
+
+        <p style="color: var(--text-muted); margin-bottom: 24px;">8 prompts · 236 messages · 88 tool calls · 1 commits · 2 pages</p>
+        
+<div class="index-item"><a href="page-001.html#msg-2026-04-08T11-36-41-872Z"><div class="index-item-header"><span class="index-item-number">#1</span><time datetime="2026-04-08T11:36:41.872Z" data-timestamp="2026-04-08T11:36:41.872Z">2026-04-08T11:36:41.872Z</time></div><div class="index-item-content"><p>Can I configure claude code not to add itself as a git co-author</p></div></a><div class="index-item-stats"><span>1 agent</span>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>Yes. Add this to your settings file (<code>~/.claude/settings.json</code> for global, or <code>.claude/settings.json</code> for per-project):</p>
+<pre><code class="language-json">{
+  &quot;attribution&quot;: {
+    &quot;commit&quot;: &quot;&quot;
+  }
+}
+</code></pre>
+<p>Setting <code>commit</code> to an empty string removes the <code>Co-Authored-By</code> trailer entirely. You can also customize it to whatever text you'd like instead of removing it.</p></div></div><button class="expand-btn">Show more</button></div></div>
+</div></div>
+<div class="index-item"><a href="page-001.html#msg-2026-04-08T11-39-12-798Z"><div class="index-item-header"><span class="index-item-number">#2</span><time datetime="2026-04-08T11:39:12.798Z" data-timestamp="2026-04-08T11:39:12.798Z">2026-04-08T11:39:12.798Z</time></div><div class="index-item-content"><p>git-ls fails when you're not on a branch:
+$ git sw --detach HEAD~1
+HEAD is now at d84ca28 fix: unmodified tracked files show no commit info after --changed-only was added (#43)
+$ git ls
+2026/04/08 07:38:59 Failed to get current branch: exit status 128</p></div></a><div class="index-item-stats"><span>4 grep · 3 read · 1 edit</span>
+</div></div>
+<div class="index-item"><a href="page-001.html#msg-2026-04-08T11-40-36-142Z"><div class="index-item-header"><span class="index-item-number">#3</span><time datetime="2026-04-08T11:40:36.142Z" data-timestamp="2026-04-08T11:40:36.142Z">2026-04-08T11:40:36.142Z</time></div><div class="index-item-content"><p>but I'd like us to do something better than print an empty string. git status says "HEAD detached at d84ca28", which seems at least a better alternative</p></div></a><div class="index-item-stats"><span>2 edit · 2 bash · 1 read</span>
+</div></div>
+<div class="index-item"><a href="page-001.html#msg-2026-04-09T12-07-15-744Z"><div class="index-item-header"><span class="index-item-number">#4</span><time datetime="2026-04-09T12:07:15.744Z" data-timestamp="2026-04-09T12:07:15.744Z">2026-04-09T12:07:15.744Z</time></div><div class="index-item-content"><p>add a test. Are there any other states besides detached HEAD that we ought to check for, or does "branch" and "detached HEAD" cover all cases?</p></div></a><div class="index-item-stats"><span>6 read · 3 grep · 1 glob · 1 edit · 1 bash</span>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>Now regarding other states — I think "on a branch" and "detached HEAD" covers all cases. During a rebase or bisect, HEAD is detached, so it falls into the same bucket. An orphan branch (no commits yet) still has a symbolic ref so <code>symbolic-ref</code> works. The empty repo case is already handled separately via <code>isEmptyRepo()</code>.</p>
+<p>The two cases cover everything. Let me add the test.</p></div></div><button class="expand-btn">Show more</button></div></div>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>Test passes. To answer your question: "branch" and "detached HEAD" covers all cases. During a rebase, bisect, or cherry-pick, git is in detached HEAD state, so the same codepath applies. An orphan branch (e.g. <code>git checkout --orphan foo</code>) still has a symbolic ref, so <code>symbolic-ref</code> succeeds and returns the branch name. The empty repo case is already handled separately via <code>isEmptyRepo()</code>.</p></div></div><button class="expand-btn">Show more</button></div></div>
+</div></div>
+<div class="index-item"><a href="page-001.html#msg-2026-04-09T12-09-42-251Z"><div class="index-item-header"><span class="index-item-number">#5</span><time datetime="2026-04-09T12:09:42.251Z" data-timestamp="2026-04-09T12:09:42.251Z">2026-04-09T12:09:42.251Z</time></div><div class="index-item-content"><p>I cloned git into the 'git' dir. Figure out where it determines what text to print in git status, I want to read it</p></div></a></div>
+<div class="index-item"><a href="page-002.html#msg-2026-04-09T12-10-30-961Z"><div class="index-item-header"><span class="index-item-number">#6</span><time datetime="2026-04-09T12:10:30.961Z" data-timestamp="2026-04-09T12:10:30.961Z">2026-04-09T12:10:30.961Z</time></div><div class="index-item-content"><p>I cloned git into the 'git' dir. Figure out where it determines what text to print in git status, I want to read it. What I mean is the bit where it decides to say "On branch handle-non-branch" or "HEAD detached at d84ca28"</p></div></a><div class="index-item-stats"><span>1 agent</span>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>The logic is in <code>git/wt-status.c</code>, function <code>wt_longstatus_print</code> starting at line 1890. Here are the key lines:</p>
+<ul>
+<li><strong>Line 1897:</strong> Default is <code>"On branch "</code></li>
+<li><strong>Lines 1899-1916:</strong> If <code>branch_name</code> is <code>"HEAD"</code>:</li>
+<li>During rebase: <code>"rebase in progress; onto "</code> or <code>"interactive rebase in progress; onto "</code></li>
+<li>Detached: <code>"HEAD detached at "</code> vs <code>"HEAD detached from "</code> (depending on <code>detached_at</code> flag)</li>
+<li>Fallback: <code>"Not currently on any branch."</code></li>
+<li><strong>Lines 1921-1922:</strong> Prints the chosen message with the branch/ref name</li>
+</ul>
+<p>Want to read it?</p></div></div><button class="expand-btn">Show more</button></div></div>
+</div></div>
+<div class="index-item"><a href="page-002.html#msg-2026-04-09T12-11-29-051Z"><div class="index-item-header"><span class="index-item-number">#7</span><time datetime="2026-04-09T12:11:29.051Z" data-timestamp="2026-04-09T12:11:29.051Z">2026-04-09T12:11:29.051Z</time></div><div class="index-item-content"><p>perfect! I'd like to have the same text in git-ls, it will be familiar to users</p></div></a><div class="index-item-stats"><span>21 bash · 11 read · 6 edit · 5 grep</span>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>OK, the simplest reliable approach: <code>git status -b</code> already computes exactly the right text. But that's a full status run and we already run porcelain status separately. The cleanest option is to replicate git's logic using the reflog approach. Let me now read the current state of the function and the display code to implement this properly.</p></div></div><button class="expand-btn">Show more</button></div></div>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>Good. Now I have the full picture. Let me implement this. The key states are:</p>
+<ol>
+<li><strong>On branch X</strong> — <code>symbolic-ref</code> succeeds</li>
+<li><strong>HEAD detached at X</strong> — detached, HEAD hasn't moved from where we detached</li>
+<li><strong>HEAD detached from X</strong> — detached, HEAD has moved (e.g. made commits)</li>
+<li><strong>rebase in progress; onto X</strong> — <code>.git/rebase-apply</code> exists (non-interactive)</li>
+<li><strong>interactive rebase in progress; onto X</strong> — <code>.git/rebase-merge</code> exists</li>
+<li><strong>Not currently on any branch.</strong> — fallback</li>
+</ol>
+<p>For "at" vs "from", git checks the reflog to find what ref/commit we detached at, then compares current HEAD to that oid. For the ref name, it tries to resolve the reflog entry to a tag or remote branch name, falling back to a short hash.</p></div></div><button class="expand-btn">Show more</button></div></div>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>I see — the reflog approach needs to find the checkout entry specifically. Let me look at how git does it more carefully. The <code>grab_1st_switch</code> callback in git walks the reflog backwards looking for the first checkout entry, and uses its "old" oid as the detach point.</p>
+<p>The simpler approach: I should find the reflog entry where we switched/checked out, and use <em>that</em> entry's oid to compare against current HEAD.</p></div></div><button class="expand-btn">Show more</button></div></div>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>All tests pass. Here's a summary of what changed:</p>
+<p><strong>States now handled</strong> (matching <code>git status</code> output exactly):
+- <strong>"On branch X"</strong> — normal branch
+- <strong>"HEAD detached at X"</strong> — detached, HEAD still at the detach point
+- <strong>"HEAD detached from X"</strong> — detached but HEAD has moved (e.g. made commits)
+- <strong>"rebase in progress; onto X"</strong> / <strong>"interactive rebase in progress; onto X"</strong> — mid-rebase
+- <strong>"Not currently on any branch."</strong> — fallback (e.g. no reflog)</p>
+<p>The ref name resolution also tries tag names and branch names before falling back to a short hash, matching git's behavior.</p></div></div><button class="expand-btn">Show more</button></div></div>
+</div></div>
+<div class="index-item"><a href="page-002.html#msg-2026-04-09T16-59-17-817Z"><div class="index-item-header"><span class="index-item-number">#8</span><time datetime="2026-04-09T16:59:17.817Z" data-timestamp="2026-04-09T16:59:17.817Z">2026-04-09T16:59:17.817Z</time></div><div class="index-item-content"><p>commit and file a PR, and create a transcript of this conversation in transcripts/ using https://github.com/simonw/claude-code-transcripts which is named <pr number>-slug.html</p></div></a><div class="index-item-stats"><span>18 bash</span>
+</div></div><div class="index-commit"><a href="https://github.com/llimllib/git-ls/commit/0453722"><div class="index-commit-header"><span class="index-commit-hash">0453722</span><time datetime="2026-04-09T16:59:30.655Z" data-timestamp="2026-04-09T16:59:30.655Z">2026-04-09T16:59:30.655Z</time></div><div class="index-commit-msg">fix: handle detached HEAD and rebase states gracefully</div></a></div>
+        
+
+<div class="pagination">
+<span class="current">Index</span>
+<span class="disabled">&larr; Prev</span>
+<a href="page-001.html">1</a>
+<a href="page-002.html">2</a>
+<a href="page-001.html">Next &rarr;</a>
+</div>
+
+
+        <dialog id="search-modal">
+            <div class="search-modal-header">
+                <input type="text" id="modal-search-input" placeholder="Search..." aria-label="Search transcripts">
+                <button id="modal-search-btn" type="button" aria-label="Search">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.35-4.35"></path></svg>
+                </button>
+                <button id="modal-close-btn" type="button" aria-label="Close">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg>
+                </button>
+            </div>
+            <div id="search-status"></div>
+            <div id="search-results"></div>
+        </dialog>
+        <script>
+(function() {
+    var totalPages = 2;
+    var searchBox = document.getElementById('search-box');
+    var searchInput = document.getElementById('search-input');
+    var searchBtn = document.getElementById('search-btn');
+    var modal = document.getElementById('search-modal');
+    var modalInput = document.getElementById('modal-search-input');
+    var modalSearchBtn = document.getElementById('modal-search-btn');
+    var modalCloseBtn = document.getElementById('modal-close-btn');
+    var searchStatus = document.getElementById('search-status');
+    var searchResults = document.getElementById('search-results');
+
+    if (!searchBox || !modal) return;
+
+    // Hide search on file:// protocol (doesn't work due to CORS restrictions)
+    if (window.location.protocol === 'file:') return;
+
+    // Show search box (progressive enhancement)
+    searchBox.style.display = 'flex';
+
+    // Gist preview support - detect if we're on gisthost.github.io or gistpreview.github.io
+    var hostname = window.location.hostname;
+    var isGistPreview = hostname === 'gisthost.github.io' || hostname === 'gistpreview.github.io';
+    var gistId = null;
+    var gistOwner = null;
+    var gistInfoLoaded = false;
+
+    if (isGistPreview) {
+        // Extract gist ID from URL query string like ?78a436a8a9e7a2e603738b8193b95410/index.html
+        var queryMatch = window.location.search.match(/^\?([a-f0-9]+)/i);
+        if (queryMatch) {
+            gistId = queryMatch[1];
+        }
+    }
+
+    async function loadGistInfo() {
+        if (!isGistPreview || !gistId || gistInfoLoaded) return;
+        try {
+            var response = await fetch('https://api.github.com/gists/' + gistId);
+            if (response.ok) {
+                var info = await response.json();
+                gistOwner = info.owner.login;
+                gistInfoLoaded = true;
+            }
+        } catch (e) {
+            console.error('Failed to load gist info:', e);
+        }
+    }
+
+    function getPageFetchUrl(pageFile) {
+        if (isGistPreview && gistOwner && gistId) {
+            // Use raw gist URL for fetching content
+            return 'https://gist.githubusercontent.com/' + gistOwner + '/' + gistId + '/raw/' + pageFile;
+        }
+        return pageFile;
+    }
+
+    function getPageLinkUrl(pageFile) {
+        if (isGistPreview && gistId) {
+            // Use gistpreview URL format for navigation links
+            return '?' + gistId + '/' + pageFile;
+        }
+        return pageFile;
+    }
+
+    function escapeHtml(text) {
+        var div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    function escapeRegex(string) {
+        return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+
+    function openModal(query) {
+        modalInput.value = query || '';
+        searchResults.innerHTML = '';
+        searchStatus.textContent = '';
+        modal.showModal();
+        modalInput.focus();
+        if (query) {
+            performSearch(query);
+        }
+    }
+
+    function closeModal() {
+        modal.close();
+        // Update URL to remove search fragment, preserving path and query string
+        if (window.location.hash.startsWith('#search=')) {
+            history.replaceState(null, '', window.location.pathname + window.location.search);
+        }
+    }
+
+    function updateUrlHash(query) {
+        if (query) {
+            // Preserve path and query string when adding hash
+            history.replaceState(null, '', window.location.pathname + window.location.search + '#search=' + encodeURIComponent(query));
+        }
+    }
+
+    function highlightTextNodes(element, searchTerm) {
+        var walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT, null, false);
+        var nodesToReplace = [];
+
+        while (walker.nextNode()) {
+            var node = walker.currentNode;
+            if (node.nodeValue.toLowerCase().indexOf(searchTerm.toLowerCase()) !== -1) {
+                nodesToReplace.push(node);
+            }
+        }
+
+        nodesToReplace.forEach(function(node) {
+            var text = node.nodeValue;
+            var regex = new RegExp('(' + escapeRegex(searchTerm) + ')', 'gi');
+            var parts = text.split(regex);
+            if (parts.length > 1) {
+                var span = document.createElement('span');
+                parts.forEach(function(part) {
+                    if (part.toLowerCase() === searchTerm.toLowerCase()) {
+                        var mark = document.createElement('mark');
+                        mark.textContent = part;
+                        span.appendChild(mark);
+                    } else {
+                        span.appendChild(document.createTextNode(part));
+                    }
+                });
+                node.parentNode.replaceChild(span, node);
+            }
+        });
+    }
+
+    function fixInternalLinks(element, pageFile) {
+        // Update all internal anchor links to include the page file
+        var links = element.querySelectorAll('a[href^="#"]');
+        links.forEach(function(link) {
+            var href = link.getAttribute('href');
+            link.setAttribute('href', pageFile + href);
+        });
+    }
+
+    function processPage(pageFile, html, query) {
+        var parser = new DOMParser();
+        var doc = parser.parseFromString(html, 'text/html');
+        var resultsFromPage = 0;
+
+        // Find all message blocks
+        var messages = doc.querySelectorAll('.message');
+        messages.forEach(function(msg) {
+            var text = msg.textContent || '';
+            if (text.toLowerCase().indexOf(query.toLowerCase()) !== -1) {
+                resultsFromPage++;
+
+                // Get the message ID for linking
+                var msgId = msg.id || '';
+                var pageLinkUrl = getPageLinkUrl(pageFile);
+                var link = pageLinkUrl + (msgId ? '#' + msgId : '');
+
+                // Clone the message HTML and highlight matches
+                var clone = msg.cloneNode(true);
+                // Fix internal links to include the page file
+                fixInternalLinks(clone, pageLinkUrl);
+                highlightTextNodes(clone, query);
+
+                var resultDiv = document.createElement('div');
+                resultDiv.className = 'search-result';
+                resultDiv.innerHTML = '<a href="' + link + '">' +
+                    '<div class="search-result-page">' + escapeHtml(pageFile) + '</div>' +
+                    '<div class="search-result-content">' + clone.innerHTML + '</div>' +
+                    '</a>';
+                searchResults.appendChild(resultDiv);
+            }
+        });
+
+        return resultsFromPage;
+    }
+
+    async function performSearch(query) {
+        if (!query.trim()) {
+            searchStatus.textContent = 'Enter a search term';
+            return;
+        }
+
+        updateUrlHash(query);
+        searchResults.innerHTML = '';
+        searchStatus.textContent = 'Searching...';
+
+        // Load gist info if on gistpreview (needed for constructing URLs)
+        if (isGistPreview && !gistInfoLoaded) {
+            searchStatus.textContent = 'Loading gist info...';
+            await loadGistInfo();
+            if (!gistOwner) {
+                searchStatus.textContent = 'Failed to load gist info. Search unavailable.';
+                return;
+            }
+        }
+
+        var resultsFound = 0;
+        var pagesSearched = 0;
+
+        // Build list of pages to fetch
+        var pagesToFetch = [];
+        for (var i = 1; i <= totalPages; i++) {
+            pagesToFetch.push('page-' + String(i).padStart(3, '0') + '.html');
+        }
+
+        searchStatus.textContent = 'Searching...';
+
+        // Process pages in batches of 3, but show results immediately as each completes
+        var batchSize = 3;
+        for (var i = 0; i < pagesToFetch.length; i += batchSize) {
+            var batch = pagesToFetch.slice(i, i + batchSize);
+
+            // Create promises that process results immediately when each fetch completes
+            var promises = batch.map(function(pageFile) {
+                return fetch(getPageFetchUrl(pageFile))
+                    .then(function(response) {
+                        if (!response.ok) throw new Error('Failed to fetch');
+                        return response.text();
+                    })
+                    .then(function(html) {
+                        // Process and display results immediately
+                        var count = processPage(pageFile, html, query);
+                        resultsFound += count;
+                        pagesSearched++;
+                        searchStatus.textContent = 'Found ' + resultsFound + ' result(s) in ' + pagesSearched + '/' + totalPages + ' pages...';
+                    })
+                    .catch(function() {
+                        pagesSearched++;
+                        searchStatus.textContent = 'Found ' + resultsFound + ' result(s) in ' + pagesSearched + '/' + totalPages + ' pages...';
+                    });
+            });
+
+            // Wait for this batch to complete before starting the next
+            await Promise.all(promises);
+        }
+
+        searchStatus.textContent = 'Found ' + resultsFound + ' result(s) in ' + totalPages + ' pages';
+    }
+
+    // Event listeners
+    searchBtn.addEventListener('click', function() {
+        openModal(searchInput.value);
+    });
+
+    searchInput.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter') {
+            openModal(searchInput.value);
+        }
+    });
+
+    modalSearchBtn.addEventListener('click', function() {
+        performSearch(modalInput.value);
+    });
+
+    modalInput.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter') {
+            performSearch(modalInput.value);
+        }
+    });
+
+    modalCloseBtn.addEventListener('click', closeModal);
+
+    modal.addEventListener('click', function(e) {
+        if (e.target === modal) {
+            closeModal();
+        }
+    });
+
+    // Check for #search= in URL on page load
+    if (window.location.hash.startsWith('#search=')) {
+        var query = decodeURIComponent(window.location.hash.substring(8));
+        if (query) {
+            searchInput.value = query;
+            openModal(query);
+        }
+    }
+})();
+        </script>
+    </div>
+    <script>
+document.querySelectorAll('time[data-timestamp]').forEach(function(el) {
+    const timestamp = el.getAttribute('data-timestamp');
+    const date = new Date(timestamp);
+    const now = new Date();
+    const isToday = date.toDateString() === now.toDateString();
+    const timeStr = date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+    if (isToday) { el.textContent = timeStr; }
+    else { el.textContent = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' ' + timeStr; }
+});
+document.querySelectorAll('pre.json').forEach(function(el) {
+    let text = el.textContent;
+    text = text.replace(/"([^"]+)":/g, '<span style="color: #ce93d8">"$1"</span>:');
+    text = text.replace(/: "([^"]*)"/g, ': <span style="color: #81d4fa">"$1"</span>');
+    text = text.replace(/: (\d+)/g, ': <span style="color: #ffcc80">$1</span>');
+    text = text.replace(/: (true|false|null)/g, ': <span style="color: #f48fb1">$1</span>');
+    el.innerHTML = text;
+});
+document.querySelectorAll('.truncatable').forEach(function(wrapper) {
+    const content = wrapper.querySelector('.truncatable-content');
+    const btn = wrapper.querySelector('.expand-btn');
+    if (content.scrollHeight > 250) {
+        wrapper.classList.add('truncated');
+        btn.addEventListener('click', function() {
+            if (wrapper.classList.contains('truncated')) { wrapper.classList.remove('truncated'); wrapper.classList.add('expanded'); btn.textContent = 'Show less'; }
+            else { wrapper.classList.remove('expanded'); wrapper.classList.add('truncated'); btn.textContent = 'Show more'; }
+        });
+    }
+});
+</script>
+</body>
+</html>

--- a/transcripts/45-handle-detached-head/page-001.html
+++ b/transcripts/45-handle-detached-head/page-001.html
@@ -1,0 +1,898 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Claude Code transcript - page 1</title>
+    <style>
+:root { --bg-color: #f5f5f5; --card-bg: #ffffff; --user-bg: #e3f2fd; --user-border: #1976d2; --assistant-bg: #f5f5f5; --assistant-border: #9e9e9e; --thinking-bg: #fff8e1; --thinking-border: #ffc107; --thinking-text: #666; --tool-bg: #f3e5f5; --tool-border: #9c27b0; --tool-result-bg: #e8f5e9; --tool-error-bg: #ffebee; --text-color: #212121; --text-muted: #757575; --code-bg: #263238; --code-text: #aed581; }
+* { box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg-color); color: var(--text-color); margin: 0; padding: 16px; line-height: 1.6; }
+.container { max-width: 800px; margin: 0 auto; }
+h1 { font-size: 1.5rem; margin-bottom: 24px; padding-bottom: 8px; border-bottom: 2px solid var(--user-border); }
+.header-row { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; border-bottom: 2px solid var(--user-border); padding-bottom: 8px; margin-bottom: 24px; }
+.header-row h1 { border-bottom: none; padding-bottom: 0; margin-bottom: 0; flex: 1; min-width: 200px; }
+.message { margin-bottom: 16px; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.message.user { background: var(--user-bg); border-left: 4px solid var(--user-border); }
+.message.assistant { background: var(--card-bg); border-left: 4px solid var(--assistant-border); }
+.message.tool-reply { background: #fff8e1; border-left: 4px solid #ff9800; }
+.tool-reply .role-label { color: #e65100; }
+.tool-reply .tool-result { background: transparent; padding: 0; margin: 0; }
+.tool-reply .tool-result .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff8e1); }
+.message-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 16px; background: rgba(0,0,0,0.03); font-size: 0.85rem; }
+.role-label { font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
+.user .role-label { color: var(--user-border); }
+time { color: var(--text-muted); font-size: 0.8rem; }
+.timestamp-link { color: inherit; text-decoration: none; }
+.timestamp-link:hover { text-decoration: underline; }
+.message:target { animation: highlight 2s ease-out; }
+@keyframes highlight { 0% { background-color: rgba(25, 118, 210, 0.2); } 100% { background-color: transparent; } }
+.message-content { padding: 16px; }
+.message-content p { margin: 0 0 12px 0; }
+.message-content p:last-child { margin-bottom: 0; }
+.thinking { background: var(--thinking-bg); border: 1px solid var(--thinking-border); border-radius: 8px; padding: 12px; margin: 12px 0; font-size: 0.9rem; color: var(--thinking-text); }
+.thinking-label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: #f57c00; margin-bottom: 8px; }
+.thinking p { margin: 8px 0; }
+.assistant-text { margin: 8px 0; }
+.tool-use { background: var(--tool-bg); border: 1px solid var(--tool-border); border-radius: 8px; padding: 12px; margin: 12px 0; }
+.tool-header { font-weight: 600; color: var(--tool-border); margin-bottom: 8px; display: flex; align-items: center; gap: 8px; }
+.tool-icon { font-size: 1.1rem; }
+.tool-description { font-size: 0.9rem; color: var(--text-muted); margin-bottom: 8px; font-style: italic; }
+.tool-result { background: var(--tool-result-bg); border-radius: 8px; padding: 12px; margin: 12px 0; }
+.tool-result.tool-error { background: var(--tool-error-bg); }
+.file-tool { border-radius: 8px; padding: 12px; margin: 12px 0; }
+.write-tool { background: linear-gradient(135deg, #e3f2fd 0%, #e8f5e9 100%); border: 1px solid #4caf50; }
+.edit-tool { background: linear-gradient(135deg, #fff3e0 0%, #fce4ec 100%); border: 1px solid #ff9800; }
+.file-tool-header { font-weight: 600; margin-bottom: 4px; display: flex; align-items: center; gap: 8px; font-size: 0.95rem; }
+.write-header { color: #2e7d32; }
+.edit-header { color: #e65100; }
+.file-tool-icon { font-size: 1rem; }
+.file-tool-path { font-family: monospace; background: rgba(0,0,0,0.08); padding: 2px 8px; border-radius: 4px; }
+.file-tool-fullpath { font-family: monospace; font-size: 0.8rem; color: var(--text-muted); margin-bottom: 8px; word-break: break-all; }
+.file-content { margin: 0; }
+.edit-section { display: flex; margin: 4px 0; border-radius: 4px; overflow: hidden; }
+.edit-label { padding: 8px 12px; font-weight: bold; font-family: monospace; display: flex; align-items: flex-start; }
+.edit-old { background: #fce4ec; }
+.edit-old .edit-label { color: #b71c1c; background: #f8bbd9; }
+.edit-old .edit-content { color: #880e4f; }
+.edit-new { background: #e8f5e9; }
+.edit-new .edit-label { color: #1b5e20; background: #a5d6a7; }
+.edit-new .edit-content { color: #1b5e20; }
+.edit-content { margin: 0; flex: 1; background: transparent; font-size: 0.85rem; }
+.edit-replace-all { font-size: 0.75rem; font-weight: normal; color: var(--text-muted); }
+.write-tool .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #e6f4ea); }
+.edit-tool .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff0e5); }
+.todo-list { background: linear-gradient(135deg, #e8f5e9 0%, #f1f8e9 100%); border: 1px solid #81c784; border-radius: 8px; padding: 12px; margin: 12px 0; }
+.todo-header { font-weight: 600; color: #2e7d32; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; font-size: 0.95rem; }
+.todo-items { list-style: none; margin: 0; padding: 0; }
+.todo-item { display: flex; align-items: flex-start; gap: 10px; padding: 6px 0; border-bottom: 1px solid rgba(0,0,0,0.06); font-size: 0.9rem; }
+.todo-item:last-child { border-bottom: none; }
+.todo-icon { flex-shrink: 0; width: 20px; height: 20px; display: flex; align-items: center; justify-content: center; font-weight: bold; border-radius: 50%; }
+.todo-completed .todo-icon { color: #2e7d32; background: rgba(46, 125, 50, 0.15); }
+.todo-completed .todo-content { color: #558b2f; text-decoration: line-through; }
+.todo-in-progress .todo-icon { color: #f57c00; background: rgba(245, 124, 0, 0.15); }
+.todo-in-progress .todo-content { color: #e65100; font-weight: 500; }
+.todo-pending .todo-icon { color: #757575; background: rgba(0,0,0,0.05); }
+.todo-pending .todo-content { color: #616161; }
+pre { background: var(--code-bg); color: var(--code-text); padding: 12px; border-radius: 6px; overflow-x: auto; font-size: 0.85rem; line-height: 1.5; margin: 8px 0; white-space: pre-wrap; word-wrap: break-word; }
+pre.json { color: #e0e0e0; }
+code { background: rgba(0,0,0,0.08); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+pre code { background: none; padding: 0; }
+.user-content { margin: 0; }
+.truncatable { position: relative; }
+.truncatable.truncated .truncatable-content { max-height: 200px; overflow: hidden; }
+.truncatable.truncated::after { content: ''; position: absolute; bottom: 32px; left: 0; right: 0; height: 60px; background: linear-gradient(to bottom, transparent, var(--card-bg)); pointer-events: none; }
+.message.user .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--user-bg)); }
+.message.tool-reply .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff8e1); }
+.tool-use .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--tool-bg)); }
+.tool-result .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--tool-result-bg)); }
+.expand-btn { display: none; width: 100%; padding: 8px 16px; margin-top: 4px; background: rgba(0,0,0,0.05); border: 1px solid rgba(0,0,0,0.1); border-radius: 6px; cursor: pointer; font-size: 0.85rem; color: var(--text-muted); }
+.expand-btn:hover { background: rgba(0,0,0,0.1); }
+.truncatable.truncated .expand-btn, .truncatable.expanded .expand-btn { display: block; }
+.pagination { display: flex; justify-content: center; gap: 8px; margin: 24px 0; flex-wrap: wrap; }
+.pagination a, .pagination span { padding: 5px 10px; border-radius: 6px; text-decoration: none; font-size: 0.85rem; }
+.pagination a { background: var(--card-bg); color: var(--user-border); border: 1px solid var(--user-border); }
+.pagination a:hover { background: var(--user-bg); }
+.pagination .current { background: var(--user-border); color: white; }
+.pagination .disabled { color: var(--text-muted); border: 1px solid #ddd; }
+.pagination .index-link { background: var(--user-border); color: white; }
+details.continuation { margin-bottom: 16px; }
+details.continuation summary { cursor: pointer; padding: 12px 16px; background: var(--user-bg); border-left: 4px solid var(--user-border); border-radius: 12px; font-weight: 500; color: var(--text-muted); }
+details.continuation summary:hover { background: rgba(25, 118, 210, 0.15); }
+details.continuation[open] summary { border-radius: 12px 12px 0 0; margin-bottom: 0; }
+.index-item { margin-bottom: 16px; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); background: var(--user-bg); border-left: 4px solid var(--user-border); }
+.index-item a { display: block; text-decoration: none; color: inherit; }
+.index-item a:hover { background: rgba(25, 118, 210, 0.1); }
+.index-item-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 16px; background: rgba(0,0,0,0.03); font-size: 0.85rem; }
+.index-item-number { font-weight: 600; color: var(--user-border); }
+.index-item-content { padding: 16px; }
+.index-item-stats { padding: 8px 16px 12px 32px; font-size: 0.85rem; color: var(--text-muted); border-top: 1px solid rgba(0,0,0,0.06); }
+.index-item-commit { margin-top: 6px; padding: 4px 8px; background: #fff3e0; border-radius: 4px; font-size: 0.85rem; color: #e65100; }
+.index-item-commit code { background: rgba(0,0,0,0.08); padding: 1px 4px; border-radius: 3px; font-size: 0.8rem; margin-right: 6px; }
+.commit-card { margin: 8px 0; padding: 10px 14px; background: #fff3e0; border-left: 4px solid #ff9800; border-radius: 6px; }
+.commit-card a { text-decoration: none; color: #5d4037; display: block; }
+.commit-card a:hover { color: #e65100; }
+.commit-card-hash { font-family: monospace; color: #e65100; font-weight: 600; margin-right: 8px; }
+.index-commit { margin-bottom: 12px; padding: 10px 16px; background: #fff3e0; border-left: 4px solid #ff9800; border-radius: 8px; box-shadow: 0 1px 2px rgba(0,0,0,0.05); }
+.index-commit a { display: block; text-decoration: none; color: inherit; }
+.index-commit a:hover { background: rgba(255, 152, 0, 0.1); margin: -10px -16px; padding: 10px 16px; border-radius: 8px; }
+.index-commit-header { display: flex; justify-content: space-between; align-items: center; font-size: 0.85rem; margin-bottom: 4px; }
+.index-commit-hash { font-family: monospace; color: #e65100; font-weight: 600; }
+.index-commit-msg { color: #5d4037; }
+.index-item-long-text { margin-top: 8px; padding: 12px; background: var(--card-bg); border-radius: 8px; border-left: 3px solid var(--assistant-border); }
+.index-item-long-text .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--card-bg)); }
+.index-item-long-text-content { color: var(--text-color); }
+#search-box { display: none; align-items: center; gap: 8px; }
+#search-box input { padding: 6px 12px; border: 1px solid var(--assistant-border); border-radius: 6px; font-size: 16px; width: 180px; }
+#search-box button, #modal-search-btn, #modal-close-btn { background: var(--user-border); color: white; border: none; border-radius: 6px; padding: 6px 10px; cursor: pointer; display: flex; align-items: center; justify-content: center; }
+#search-box button:hover, #modal-search-btn:hover { background: #1565c0; }
+#modal-close-btn { background: var(--text-muted); margin-left: 8px; }
+#modal-close-btn:hover { background: #616161; }
+#search-modal[open] { border: none; border-radius: 12px; box-shadow: 0 4px 24px rgba(0,0,0,0.2); padding: 0; width: 90vw; max-width: 900px; height: 80vh; max-height: 80vh; display: flex; flex-direction: column; }
+#search-modal::backdrop { background: rgba(0,0,0,0.5); }
+.search-modal-header { display: flex; align-items: center; gap: 8px; padding: 16px; border-bottom: 1px solid var(--assistant-border); background: var(--bg-color); border-radius: 12px 12px 0 0; }
+.search-modal-header input { flex: 1; padding: 8px 12px; border: 1px solid var(--assistant-border); border-radius: 6px; font-size: 16px; }
+#search-status { padding: 8px 16px; font-size: 0.85rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
+#search-results { flex: 1; overflow-y: auto; padding: 16px; }
+.search-result { margin-bottom: 16px; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.search-result a { display: block; text-decoration: none; color: inherit; }
+.search-result a:hover { background: rgba(25, 118, 210, 0.05); }
+.search-result-page { padding: 6px 12px; background: rgba(0,0,0,0.03); font-size: 0.8rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
+.search-result-content { padding: 12px; }
+.search-result mark { background: #fff59d; padding: 1px 2px; border-radius: 2px; }
+@media (max-width: 600px) { body { padding: 8px; } .message, .index-item { border-radius: 8px; } .message-content, .index-item-content { padding: 12px; } pre { font-size: 0.8rem; padding: 8px; } #search-box input { width: 120px; } #search-modal[open] { width: 95vw; height: 90vh; } }
+</style>
+</head>
+<body>
+    <div class="container">
+        <h1><a href="index.html" style="color: inherit; text-decoration: none;">Claude Code transcript</a> - page 1/2</h1>
+        
+
+<div class="pagination">
+<a href="index.html" class="index-link">Index</a>
+<span class="disabled">&larr; Prev</span>
+<span class="current">1</span>
+<a href="page-002.html">2</a>
+<a href="page-002.html">Next &rarr;</a>
+</div>
+
+        
+<div class="message user" id="msg-2026-04-08T11-36-41-872Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-08T11-36-41-872Z" class="timestamp-link"><time datetime="2026-04-08T11:36:41.872Z" data-timestamp="2026-04-08T11:36:41.872Z">2026-04-08T11:36:41.872Z</time></a></div><div class="message-content">
+<div class="user-content"><p>Can I configure claude code not to add itself as a git co-author</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-08T11-36-45-239Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-08T11-36-45-239Z" class="timestamp-link"><time datetime="2026-04-08T11:36:45.239Z" data-timestamp="2026-04-08T11:36:45.239Z">2026-04-08T11:36:45.239Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_015b1WfyvLxwM9ZvNntbcxAC"><div class="tool-header"><span class="tool-icon">⚙</span> Agent</div><div class="tool-description">Co-author git config</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;subagent_type&#34;: &#34;claude-code-guide&#34;,
+  &#34;prompt&#34;: &#34;Can the user configure Claude Code to not add the \&#34;Co-Authored-By: Claude\&#34; trailer to git commit messages? What setting controls this behavior?&#34;
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-08T11-37-36-759Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-08T11-37-36-759Z" class="timestamp-link"><time datetime="2026-04-08T11:37:36.759Z" data-timestamp="2026-04-08T11:37:36.759Z">2026-04-08T11:37:36.759Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Perfect! I found the information. Let me provide a comprehensive answer to the user.
+
+Yes, users can configure Claude Code to disable the &quot;Co-Authored-By: Claude&quot; trailer in git commit messages using the **`attribution`** setting.
+
+## How to Configure It
+
+The `attribution` setting controls both commit and pull request attribution. To disable or customize the co-author trailer, add this to your settings file:
+
+**To hide all commit attribution:**
+```json
+{
+  &quot;attribution&quot;: {
+    &quot;commit&quot;: &quot;&quot;
+  }
+}
+```
+
+**To customize the trailer:**
+```json
+{
+  &quot;attribution&quot;: {
+    &quot;commit&quot;: &quot;Generated with AI\n\nCo-Authored-By: AI &lt;ai@example.com&gt;&quot;,
+    &quot;pr&quot;: &quot;&quot;
+  }
+}
+```
+
+## Default Behavior
+
+By default, Claude Code adds:
+```
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+   Co-Authored-By: Claude Sonnet 4.6 &lt;noreply@anthropic.com&gt;
+```
+
+## Key Details
+
+- The `attribution.commit` setting controls git trailers (like the Co-Authored-By trailer)
+- Setting `commit` to an empty string hides all commit attribution
+- The `attribution` setting takes precedence over the deprecated `includeCoAuthoredBy` setting
+- This can be configured at any scope: **User** (`~/.claude/settings.json`), **Project** (`.claude/settings.json`), or **Local** (`.claude/settings.local.json`)
+
+To apply these changes, add or modify your `.claude/settings.json` file (for project-level settings shared with your team) or `~/.claude/settings.json` (for personal global settings).</pre><pre>agentId: a122525c7724f9681 (use SendMessage with to: &#x27;a122525c7724f9681&#x27; to continue this agent)
+&lt;usage&gt;total_tokens: 25745
+tool_uses: 11
+duration_ms: 51515&lt;/usage&gt;</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-08T11-37-40-183Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-08T11-37-40-183Z" class="timestamp-link"><time datetime="2026-04-08T11:37:40.183Z" data-timestamp="2026-04-08T11:37:40.183Z">2026-04-08T11:37:40.183Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Yes. Add this to your settings file (<code>~/.claude/settings.json</code> for global, or <code>.claude/settings.json</code> for per-project):</p>
+<pre><code class="language-json">{
+  &quot;attribution&quot;: {
+    &quot;commit&quot;: &quot;&quot;
+  }
+}
+</code></pre>
+<p>Setting <code>commit</code> to an empty string removes the <code>Co-Authored-By</code> trailer entirely. You can also customize it to whatever text you'd like instead of removing it.</p></div></div></div>
+<div class="message user" id="msg-2026-04-08T11-39-12-798Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-08T11-39-12-798Z" class="timestamp-link"><time datetime="2026-04-08T11:39:12.798Z" data-timestamp="2026-04-08T11:39:12.798Z">2026-04-08T11:39:12.798Z</time></a></div><div class="message-content">
+<div class="user-content"><p>git-ls fails when you're not on a branch:
+$ git sw --detach HEAD~1
+HEAD is now at d84ca28 fix: unmodified tracked files show no commit info after --changed-only was added (#43)
+$ git ls
+2026/04/08 07:38:59 Failed to get current branch: exit status 128</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-08T11-39-19-986Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-08T11-39-19-986Z" class="timestamp-link"><time datetime="2026-04-08T11:39:19.986Z" data-timestamp="2026-04-08T11:39:19.986Z">2026-04-08T11:39:19.986Z</time></a></div><div class="message-content">
+<div class="thinking"><div class="thinking-label">Thinking</div></div></div></div>
+<div class="message assistant" id="msg-2026-04-08T11-39-19-987Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-08T11-39-19-987Z" class="timestamp-link"><time datetime="2026-04-08T11:39:19.987Z" data-timestamp="2026-04-08T11:39:19.987Z">2026-04-08T11:39:19.987Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01Kr4fSZkaNfFeh6mVh86dyR"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;Failed to get current branch&#34;
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-08T11-39-20-014Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-08T11-39-20-014Z" class="timestamp-link"><time datetime="2026-04-08T11:39:20.014Z" data-timestamp="2026-04-08T11:39:20.014Z">2026-04-08T11:39:20.014Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Found 1 file
+main.go</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-08T11-39-20-661Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-08T11-39-20-661Z" class="timestamp-link"><time datetime="2026-04-08T11:39:20.661Z" data-timestamp="2026-04-08T11:39:20.661Z">2026-04-08T11:39:20.661Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01XXzwGck8RygwjDfnTHtZ4A"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;current branch&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-08T11-39-20-680Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-08T11-39-20-680Z" class="timestamp-link"><time datetime="2026-04-08T11:39:20.680Z" data-timestamp="2026-04-08T11:39:20.680Z">2026-04-08T11:39:20.680Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>main.go:651:// gitCurrentBranchSymbolic gets the current branch name using symbolic-ref.
+main.go:657:		log.Fatalf(&quot;Failed to get current branch: %v&quot;, err)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-08T11-39-23-981Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-08T11-39-23-981Z" class="timestamp-link"><time datetime="2026-04-08T11:39:23.981Z" data-timestamp="2026-04-08T11:39:23.981Z">2026-04-08T11:39:23.981Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01UzVezYLduZXqoWSQRBEqUD"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main.go&#34;,
+  &#34;offset&#34;: 645,
+  &#34;limit&#34;: 30
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-08T11-39-23-988Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-08T11-39-23-988Z" class="timestamp-link"><time datetime="2026-04-08T11:39:23.988Z" data-timestamp="2026-04-08T11:39:23.988Z">2026-04-08T11:39:23.988Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>645		if len(matches) == 3 {
+646			return fmt.Sprintf(&quot;https://github.com/%s/%s&quot;, matches[1], matches[2])
+647		}
+648		return &quot;&quot;
+649	}
+650	
+651	// gitCurrentBranchSymbolic gets the current branch name using symbolic-ref.
+652	// This works in empty repos (no commits) where rev-parse would fail.
+653	func gitCurrentBranchSymbolic() string {
+654		cmd := exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;symbolic-ref&quot;, &quot;--short&quot;, &quot;HEAD&quot;)
+655		out, err := cmd.Output()
+656		if err != nil {
+657			log.Fatalf(&quot;Failed to get current branch: %v&quot;, err)
+658		}
+659		return strings.TrimSpace(string(out))
+660	}
+661	
+662	// gitRoot returns the root directory of the git repository
+663	func gitRoot() string {
+664		cmd := exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;rev-parse&quot;, &quot;--show-toplevel&quot;)
+665		out, err := cmd.Output()
+666		if err != nil {
+667			log.Fatalf(&quot;Failed to get git status: %v&quot;, err)
+668		}
+669		return strings.TrimSpace(string(out))
+670	}
+671	
+672	// gitStatus accepts a dir and a slice of files, and adds the git status to
+673	// each file in place
+674	func gitStatus() []byte {
+[result-id: r1]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-08T11-39-24-270Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-08T11-39-24-270Z" class="timestamp-link"><time datetime="2026-04-08T11:39:24.270Z" data-timestamp="2026-04-08T11:39:24.270Z">2026-04-08T11:39:24.270Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01HZoKbeyfzpt3aSCNGYDM2b"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;gitCurrentBranch&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main.go&#34;
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-08T11-39-24-293Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-08T11-39-24-293Z" class="timestamp-link"><time datetime="2026-04-08T11:39:24.293Z" data-timestamp="2026-04-08T11:39:24.293Z">2026-04-08T11:39:24.293Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>174:		results.currentBranch = gitCurrentBranchSymbolic()
+651:// gitCurrentBranchSymbolic gets the current branch name using symbolic-ref.
+653:func gitCurrentBranchSymbolic() string {</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-08T11-39-26-742Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-08T11-39-26-742Z" class="timestamp-link"><time datetime="2026-04-08T11:39:26.742Z" data-timestamp="2026-04-08T11:39:26.742Z">2026-04-08T11:39:26.742Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01K8KRwe5jPqLTiXYtCi3faF"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main.go&#34;,
+  &#34;offset&#34;: 168,
+  &#34;limit&#34;: 20
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-08T11-39-26-749Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-08T11-39-26-749Z" class="timestamp-link"><time datetime="2026-04-08T11:39:26.749Z" data-timestamp="2026-04-08T11:39:26.749Z">2026-04-08T11:39:26.749Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>168	
+169		wg.Go(func() {
+170			results.status = gitStatus()
+171		})
+172	
+173		wg.Go(func() {
+174			results.currentBranch = gitCurrentBranchSymbolic()
+175		})
+176	
+177		wg.Go(func() {
+178			results.remotes = gitRemotes()
+179		})
+180	
+181		// No diff stats in empty repo
+182		if isEmptyRepo() {
+183			results.isEmpty = true
+184			results.diffStat = []byte{}
+185		} else {
+186			wg.Go(func() {
+187				results.diffStat = gitDiffStat()
+[result-id: r2]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-08T11-39-27-266Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-08T11-39-27-266Z" class="timestamp-link"><time datetime="2026-04-08T11:39:27.266Z" data-timestamp="2026-04-08T11:39:27.266Z">2026-04-08T11:39:27.266Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01UV9sLxkFkD8VWtLraDEECX"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;currentBranch&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main.go&#34;
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-08T11-39-27-281Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-08T11-39-27-281Z" class="timestamp-link"><time datetime="2026-04-08T11:39:27.281Z" data-timestamp="2026-04-08T11:39:27.281Z">2026-04-08T11:39:27.281Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>133:	currentBranch string
+174:		results.currentBranch = gitCurrentBranchSymbolic()
+441:	fmt.Printf(&quot;On branch %s%s%s\n\n&quot;, RED, gitData.currentBranch, RESET)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-08T11-39-29-594Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-08T11-39-29-594Z" class="timestamp-link"><time datetime="2026-04-08T11:39:29.594Z" data-timestamp="2026-04-08T11:39:29.594Z">2026-04-08T11:39:29.594Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_017ABq1v8KR4mY5ErfGDa3rA"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main.go&#34;,
+  &#34;offset&#34;: 435,
+  &#34;limit&#34;: 15
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-08T11-39-29-598Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-08T11-39-29-598Z" class="timestamp-link"><time datetime="2026-04-08T11:39:29.598Z" data-timestamp="2026-04-08T11:39:29.598Z">2026-04-08T11:39:29.598Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>435		}
+436	
+437		maxWidth := columns(os.Stdout.Fd())
+438		if maxWidth == 0 {
+439			maxWidth = 80 // default when not a TTY
+440		}
+441		fmt.Printf(&quot;On branch %s%s%s\n\n&quot;, RED, gitData.currentBranch, RESET)
+442		rctx := &amp;RenderContext{
+443			GithubURL: isGithub(gitData.remotes),
+444			Dir:       must(filepath.Abs(&quot;.&quot;)),
+445			MonoHash:  monoHash,
+446			NerdFont:  nerdFont,
+447		}
+448		showColumns(os.Stdout, maxWidth, files, rctx, formatColumns)
+449	}
+[result-id: r3]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-08T11-39-32-881Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-08T11-39-32-881Z" class="timestamp-link"><time datetime="2026-04-08T11:39:32.881Z" data-timestamp="2026-04-08T11:39:32.881Z">2026-04-08T11:39:32.881Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>The fix is straightforward: <code>git symbolic-ref</code> fails in detached HEAD state. We should handle that gracefully — return an empty string and adjust the display.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-08T11-39-37-046Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-08T11-39-37-046Z" class="timestamp-link"><time datetime="2026-04-08T11:39:37.046Z" data-timestamp="2026-04-08T11:39:37.046Z">2026-04-08T11:39:37.046Z</time></a></div><div class="message-content"><div class="file-tool edit-tool" data-tool-id="toolu_01MCEspa4FXepY3iBrgAttXr">
+<div class="file-tool-header edit-header"><span class="file-tool-icon">✏️</span> Edit <span class="file-tool-path">main.go</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/handle-non-branch/main.go</div>
+<div class="truncatable"><div class="truncatable-content">
+<div class="edit-section edit-old"><div class="edit-label">−</div><pre class="edit-content">// gitCurrentBranchSymbolic gets the current branch name using symbolic-ref.
+// This works in empty repos (no commits) where rev-parse would fail.
+func gitCurrentBranchSymbolic() string {
+	cmd := exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;, &#34;symbolic-ref&#34;, &#34;--short&#34;, &#34;HEAD&#34;)
+	out, err := cmd.Output()
+	if err != nil {
+		log.Fatalf(&#34;Failed to get current branch: %v&#34;, err)
+	}
+	return strings.TrimSpace(string(out))
+}</pre></div>
+<div class="edit-section edit-new"><div class="edit-label">+</div><pre class="edit-content">// gitCurrentBranchSymbolic gets the current branch name using symbolic-ref.
+// This works in empty repos (no commits) where rev-parse would fail.
+// Returns empty string in detached HEAD state.
+func gitCurrentBranchSymbolic() string {
+	cmd := exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;, &#34;symbolic-ref&#34;, &#34;--short&#34;, &#34;HEAD&#34;)
+	out, err := cmd.Output()
+	if err != nil {
+		// detached HEAD — symbolic-ref exits 128
+		return &#34;&#34;
+	}
+	return strings.TrimSpace(string(out))
+}</pre></div>
+</div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message user" id="msg-2026-04-08T11-40-36-142Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-08T11-40-36-142Z" class="timestamp-link"><time datetime="2026-04-08T11:40:36.142Z" data-timestamp="2026-04-08T11:40:36.142Z">2026-04-08T11:40:36.142Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/handle-non-branch/main.go has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div>
+<div class="assistant-text"><p>but I'd like us to do something better than print an empty string. git status says "HEAD detached at d84ca28", which seems at least a better alternative</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-08T11-40-39-359Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-08T11-40-39-359Z" class="timestamp-link"><time datetime="2026-04-08T11:40:39.359Z" data-timestamp="2026-04-08T11:40:39.359Z">2026-04-08T11:40:39.359Z</time></a></div><div class="message-content">
+<div class="thinking"><div class="thinking-label">Thinking</div></div></div></div>
+<div class="message assistant" id="msg-2026-04-08T11-40-43-258Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-08T11-40-43-258Z" class="timestamp-link"><time datetime="2026-04-08T11:40:43.258Z" data-timestamp="2026-04-08T11:40:43.258Z">2026-04-08T11:40:43.258Z</time></a></div><div class="message-content"><div class="file-tool edit-tool" data-tool-id="toolu_01P5bCYfxrtk8C1M8t8UjrKT">
+<div class="file-tool-header edit-header"><span class="file-tool-icon">✏️</span> Edit <span class="file-tool-path">main.go</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/handle-non-branch/main.go</div>
+<div class="truncatable"><div class="truncatable-content">
+<div class="edit-section edit-old"><div class="edit-label">−</div><pre class="edit-content">// gitCurrentBranchSymbolic gets the current branch name using symbolic-ref.
+// This works in empty repos (no commits) where rev-parse would fail.
+// Returns empty string in detached HEAD state.
+func gitCurrentBranchSymbolic() string {
+	cmd := exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;, &#34;symbolic-ref&#34;, &#34;--short&#34;, &#34;HEAD&#34;)
+	out, err := cmd.Output()
+	if err != nil {
+		// detached HEAD — symbolic-ref exits 128
+		return &#34;&#34;
+	}
+	return strings.TrimSpace(string(out))
+}</pre></div>
+<div class="edit-section edit-new"><div class="edit-label">+</div><pre class="edit-content">// gitCurrentBranchSymbolic gets the current branch name using symbolic-ref.
+// This works in empty repos (no commits) where rev-parse would fail.
+// In detached HEAD state, falls back to &#34;HEAD detached at &lt;short-hash&gt;&#34;.
+func gitCurrentBranchSymbolic() string {
+	cmd := exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;, &#34;symbolic-ref&#34;, &#34;--short&#34;, &#34;HEAD&#34;)
+	out, err := cmd.Output()
+	if err != nil {
+		// detached HEAD — fall back to short commit hash
+		cmd = exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;, &#34;rev-parse&#34;, &#34;--short&#34;, &#34;HEAD&#34;)
+		out, err = cmd.Output()
+		if err != nil {
+			return &#34;unknown&#34;
+		}
+		return &#34;HEAD detached at &#34; + strings.TrimSpace(string(out))
+	}
+	return strings.TrimSpace(string(out))
+}</pre></div>
+</div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-08T11-41-07-086Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-08T11-41-07-086Z" class="timestamp-link"><time datetime="2026-04-08T11:41:07.086Z" data-timestamp="2026-04-08T11:41:07.086Z">2026-04-08T11:41:07.086Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/handle-non-branch/main.go has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-08T11-41-10-681Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-08T11-41-10-681Z" class="timestamp-link"><time datetime="2026-04-08T11:41:10.681Z" data-timestamp="2026-04-08T11:41:10.681Z">2026-04-08T11:41:10.681Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now the header line will read <code>On branch HEAD detached at d84ca28</code> — but "On branch" doesn't make sense for detached HEAD. Let me fix the display too.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-08T11-41-12-197Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-08T11-41-12-197Z" class="timestamp-link"><time datetime="2026-04-08T11:41:12.197Z" data-timestamp="2026-04-08T11:41:12.197Z">2026-04-08T11:41:12.197Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01DrGabbFTictyXwHwSdzyPf"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main.go&#34;,
+  &#34;offset&#34;: 439,
+  &#34;limit&#34;: 5
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-08T11-41-12-204Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-08T11-41-12-204Z" class="timestamp-link"><time datetime="2026-04-08T11:41:12.204Z" data-timestamp="2026-04-08T11:41:12.204Z">2026-04-08T11:41:12.204Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>439			maxWidth = 80 // default when not a TTY
+440		}
+441		fmt.Printf(&quot;On branch %s%s%s\n\n&quot;, RED, gitData.currentBranch, RESET)
+442		rctx := &amp;RenderContext{
+443			GithubURL: isGithub(gitData.remotes),</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-08T11-41-16-293Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-08T11-41-16-293Z" class="timestamp-link"><time datetime="2026-04-08T11:41:16.293Z" data-timestamp="2026-04-08T11:41:16.293Z">2026-04-08T11:41:16.293Z</time></a></div><div class="message-content"><div class="file-tool edit-tool" data-tool-id="toolu_01MFfqJcXgKsunBLH33amzEh">
+<div class="file-tool-header edit-header"><span class="file-tool-icon">✏️</span> Edit <span class="file-tool-path">main.go</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/handle-non-branch/main.go</div>
+<div class="truncatable"><div class="truncatable-content">
+<div class="edit-section edit-old"><div class="edit-label">−</div><pre class="edit-content">	fmt.Printf(&#34;On branch %s%s%s\n\n&#34;, RED, gitData.currentBranch, RESET)</pre></div>
+<div class="edit-section edit-new"><div class="edit-label">+</div><pre class="edit-content">	if strings.HasPrefix(gitData.currentBranch, &#34;HEAD detached&#34;) {
+		fmt.Printf(&#34;%s%s%s\n\n&#34;, RED, gitData.currentBranch, RESET)
+	} else {
+		fmt.Printf(&#34;On branch %s%s%s\n\n&#34;, RED, gitData.currentBranch, RESET)
+	}</pre></div>
+</div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-08T11-42-37-081Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-08T11-42-37-081Z" class="timestamp-link"><time datetime="2026-04-08T11:42:37.081Z" data-timestamp="2026-04-08T11:42:37.081Z">2026-04-08T11:42:37.081Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/handle-non-branch/main.go has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-08T11-42-42-331Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-08T11-42-42-331Z" class="timestamp-link"><time datetime="2026-04-08T11:42:42.331Z" data-timestamp="2026-04-08T11:42:42.331Z">2026-04-08T11:42:42.331Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Let me verify it builds and works.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-08T11-42-42-951Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-08T11-42-42-951Z" class="timestamp-link"><time datetime="2026-04-08T11:42:42.951Z" data-timestamp="2026-04-08T11:42:42.951Z">2026-04-08T11:42:42.951Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_016k9BN34b7DWAcp9b8uxrXr">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go build -o /tmp/git-ls-test . 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-08T11-42-48-842Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-08T11-42-48-842Z" class="timestamp-link"><time datetime="2026-04-08T11:42:48.842Z" data-timestamp="2026-04-08T11:42:48.842Z">2026-04-08T11:42:48.842Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>[rerun: b1]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-08T11-42-51-954Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-08T11-42-51-954Z" class="timestamp-link"><time datetime="2026-04-08T11:42:51.954Z" data-timestamp="2026-04-08T11:42:51.954Z">2026-04-08T11:42:51.954Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01RMM9DHpw9gXmEXHodqJXEs">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git stash &amp;&amp; git switch --detach HEAD~1 &amp;&amp; /tmp/git-ls-test 2&gt;&amp;1 | head -3; git switch - &amp;&amp; git stash pop</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-08T11-42-56-869Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-08T11-42-56-869Z" class="timestamp-link"><time datetime="2026-04-08T11:42:56.869Z" data-timestamp="2026-04-08T11:42:56.869Z">2026-04-08T11:42:56.869Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Saved working directory and index state WIP on handle-non-branch: 84a45fb chore: bump version to 5.8.0
+HEAD is now at d84ca28 fix: unmodified tracked files show no commit info after --changed-only was added (#43)
+[31mHEAD detached at d84ca28[0m
+
+??  [34m]8;;file://adama/Users/llimllib/code/git-ls/handle-non-branch/.claude\.claude]8;;\         [0m [36m[0m                   [33m]8;;https://github.com/llimllib/git-ls/commits?author=\]8;;\[0m          ]8;;https://github.com/llimllib/git-ls/commit/\]8;;\                              
+Previous HEAD position was d84ca28 fix: unmodified tracked files show no commit info after --changed-only was added (#43)
+Switched to branch &#x27;handle-non-branch&#x27;
+On branch handle-non-branch
+Changes not staged for commit:
+  (use &quot;git add &lt;file&gt;...&quot; to update what will be committed)
+  (use &quot;git restore &lt;file&gt;...&quot; to discard changes in working directory)
+	modified:   main.go
+
+Untracked files:
+  (use &quot;git add &lt;file&gt;...&quot; to include in what will be committed)
+	.claude/
+
+no changes added to commit (use &quot;git add&quot; and/or &quot;git commit -a&quot;)
+Dropped refs/stash@{0} (3ecc24f155ff6b5eee76300a46a471640eab5a66)
+[result-id: r4]
+[rerun: b2]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-08T11-42-59-328Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-08T11-42-59-328Z" class="timestamp-link"><time datetime="2026-04-08T11:42:59.328Z" data-timestamp="2026-04-08T11:42:59.328Z">2026-04-08T11:42:59.328Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Works. In detached HEAD state it now shows <code>HEAD detached at d84ca28</code> (in red) instead of crashing.</p></div></div></div>
+<div class="message user" id="msg-2026-04-09T12-07-15-744Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-09T12-07-15-744Z" class="timestamp-link"><time datetime="2026-04-09T12:07:15.744Z" data-timestamp="2026-04-09T12:07:15.744Z">2026-04-09T12:07:15.744Z</time></a></div><div class="message-content">
+<div class="user-content"><p>add a test. Are there any other states besides detached HEAD that we ought to check for, or does "branch" and "detached HEAD" cover all cases?</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-07-23-674Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-07-23-674Z" class="timestamp-link"><time datetime="2026-04-09T12:07:23.674Z" data-timestamp="2026-04-09T12:07:23.674Z">2026-04-09T12:07:23.674Z</time></a></div><div class="message-content">
+<div class="thinking"><div class="thinking-label">Thinking</div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-07-24-955Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-07-24-955Z" class="timestamp-link"><time datetime="2026-04-09T12:07:24.955Z" data-timestamp="2026-04-09T12:07:24.955Z">2026-04-09T12:07:24.955Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01FBATBTfoVwiTZgkayJHZTU"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;gitCurrentBranch|symbolic-ref&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;glob&#34;: &#34;*_test.go&#34;
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-07-24-974Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-07-24-974Z" class="timestamp-link"><time datetime="2026-04-09T12:07:24.974Z" data-timestamp="2026-04-09T12:07:24.974Z">2026-04-09T12:07:24.974Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01V6YGEemDGRP26E5LCXNXtf"><div class="tool-header"><span class="tool-icon">⚙</span> Glob</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;*_test.go&#34;
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-07-24-992Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-07-24-992Z" class="timestamp-link"><time datetime="2026-04-09T12:07:24.992Z" data-timestamp="2026-04-09T12:07:24.992Z">2026-04-09T12:07:24.992Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>No matches found</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-07-24-993Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-07-24-993Z" class="timestamp-link"><time datetime="2026-04-09T12:07:24.993Z" data-timestamp="2026-04-09T12:07:24.993Z">2026-04-09T12:07:24.993Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>columns_test.go
+main_test.go</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-07-27-391Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-07-27-391Z" class="timestamp-link"><time datetime="2026-04-09T12:07:27.391Z" data-timestamp="2026-04-09T12:07:27.391Z">2026-04-09T12:07:27.391Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01CDsXFrAcVWAh2CgCJh3mVn"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main_test.go&#34;
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-07-27-625Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-07-27-625Z" class="timestamp-link"><time datetime="2026-04-09T12:07:27.625Z" data-timestamp="2026-04-09T12:07:27.625Z">2026-04-09T12:07:27.625Z</time></a></div><div class="message-content"><div class="tool-result tool-error"><div class="truncatable"><div class="truncatable-content"><pre>File content (11852 tokens) exceeds maximum allowed tokens (10000). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file.</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-07-31-859Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-07-31-859Z" class="timestamp-link"><time datetime="2026-04-09T12:07:31.859Z" data-timestamp="2026-04-09T12:07:31.859Z">2026-04-09T12:07:31.859Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01P2Q3YPPXAUTkvVJt24k2qC"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main_test.go&#34;,
+  &#34;limit&#34;: 60
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-07-31-870Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-07-31-870Z" class="timestamp-link"><time datetime="2026-04-09T12:07:31.870Z" data-timestamp="2026-04-09T12:07:31.870Z">2026-04-09T12:07:31.870Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>1	package main
+2	
+3	import (
+4		&quot;fmt&quot;
+5		&quot;os&quot;
+6		&quot;os/exec&quot;
+7		&quot;path/filepath&quot;
+8		&quot;strings&quot;
+9		&quot;testing&quot;
+10		&quot;time&quot;
+11	)
+12	
+13	func TestMakeDiffGraph(t *testing.T) {
+14		tests := []struct {
+15			name     string
+16			file     *File
+17			width    int
+18			expected string
+19		}{
+20			{
+21				name:     &quot;nil diffSum&quot;,
+22				file:     &amp;File{},
+23				width:    4,
+24				expected: &quot;&quot;,
+25			},
+26			{
+27				name:     &quot;only additions&quot;,
+28				file:     &amp;File{diffSum: &amp;Diff{plus: 3, minus: 0}},
+29				width:    4,
+30				expected: GREEN + &quot;+++&quot; + RED + &quot;&quot; + RESET,
+31			},
+32			{
+33				name:     &quot;only deletions&quot;,
+34				file:     &amp;File{diffSum: &amp;Diff{plus: 0, minus: 2}},
+35				width:    4,
+36				expected: GREEN + &quot;&quot; + RED + &quot;--&quot; + RESET,
+37			},
+38			{
+39				name:     &quot;additions and deletions within width&quot;,
+40				file:     &amp;File{diffSum: &amp;Diff{plus: 2, minus: 2}},
+41				width:    4,
+42				expected: GREEN + &quot;++&quot; + RED + &quot;--&quot; + RESET,
+43			},
+44			{
+45				name:     &quot;additions and deletions exceeding width are scaled&quot;,
+46				file:     &amp;File{diffSum: &amp;Diff{plus: 10, minus: 10}},
+47				width:    4,
+48				expected: GREEN + &quot;++&quot; + RED + &quot;--&quot; + RESET,
+49			},
+50			{
+51				name:     &quot;new file with 4 additions fits in width 4&quot;,
+52				file:     &amp;File{diffSum: &amp;Diff{plus: 4, minus: 0}},
+53				width:    4,
+54				expected: GREEN + &quot;++++&quot; + RED + &quot;&quot; + RESET,
+55			},
+56		}
+57	
+58		for _, tt := range tests {
+59			t.Run(tt.name, func(t *testing.T) {
+60				result := makeDiffGraph(tt.file, tt.width)
+[result-id: r5]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-07-35-618Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-07-35-618Z" class="timestamp-link"><time datetime="2026-04-09T12:07:35.618Z" data-timestamp="2026-04-09T12:07:35.618Z">2026-04-09T12:07:35.618Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_013Vffijrjm1mBnD5QBVoYZv"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;func Test|func init|func setup|func create.*repo|tmpDir|TempDir&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main_test.go&#34;
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-07-35-645Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-07-35-645Z" class="timestamp-link"><time datetime="2026-04-09T12:07:35.645Z" data-timestamp="2026-04-09T12:07:35.645Z">2026-04-09T12:07:35.645Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>13:func TestMakeDiffGraph(t *testing.T) {
+68:func TestIsGithub(t *testing.T) {
+126:func TestFileStatus(t *testing.T) {
+262:func TestParseArgs(t *testing.T) {
+305:func TestDirectoryArgDoesNotHang(t *testing.T) {
+328:func TestShowFileHyperlinks(t *testing.T) {
+387:func TestHashToColor(t *testing.T) {
+441:func TestLinkify(t *testing.T) {
+481:func TestWorktreeWithSymlink(t *testing.T) {
+483:	tmpDir := t.TempDir()
+486:	repoDir := tmpDir + &quot;/repo&quot;
+516:	wtDir := tmpDir + &quot;/worktree&quot;
+527:	linkDir := tmpDir + &quot;/link-to-wt&quot;
+653:func TestSubdirectoryGitInfo(t *testing.T) {
+655:	tmpDir := t.TempDir()
+658:	repoDir := tmpDir + &quot;/repo&quot;
+764:func TestEmptyRepository(t *testing.T) {
+766:	tmpDir := t.TempDir()
+769:	repoDir := tmpDir + &quot;/empty-repo&quot;
+821:func TestChangedOnly(t *testing.T) {
+872:func TestUnmodifiedFileGetsGitInfo(t *testing.T) {
+873:	tmpDir := t.TempDir()
+875:	repoDir := tmpDir + &quot;/repo&quot;
+978:func TestSkipGitLogForIgnoredFiles(t *testing.T) {
+1038:func TestRenamedFileGitInfo(t *testing.T) {
+1039:	tmpDir := t.TempDir()
+1041:	repoDir := tmpDir + &quot;/repo&quot;
+[result-id: r6]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-07-37-839Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-07-37-839Z" class="timestamp-link"><time datetime="2026-04-09T12:07:37.839Z" data-timestamp="2026-04-09T12:07:37.839Z">2026-04-09T12:07:37.839Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Let me look at a representative integration test to understand the pattern used.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-07-38-355Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-07-38-355Z" class="timestamp-link"><time datetime="2026-04-09T12:07:38.355Z" data-timestamp="2026-04-09T12:07:38.355Z">2026-04-09T12:07:38.355Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_011nx2guFsQPqJbJM6aQ5wdw"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main_test.go&#34;,
+  &#34;offset&#34;: 764,
+  &#34;limit&#34;: 60
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-07-38-368Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-07-38-368Z" class="timestamp-link"><time datetime="2026-04-09T12:07:38.368Z" data-timestamp="2026-04-09T12:07:38.368Z">2026-04-09T12:07:38.368Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>764	func TestEmptyRepository(t *testing.T) {
+765		// Create a temporary directory for our test
+766		tmpDir := t.TempDir()
+767	
+768		// Create an empty git repo (no commits)
+769		repoDir := tmpDir + &quot;/empty-repo&quot;
+770		if err := os.Mkdir(repoDir, 0o755); err != nil {
+771			t.Fatalf(&quot;Failed to create repo dir: %v&quot;, err)
+772		}
+773	
+774		// Initialize git repo
+775		if err := runCmd(repoDir, &quot;git&quot;, &quot;init&quot;, &quot;-b&quot;, &quot;main&quot;); err != nil {
+776			t.Fatalf(&quot;Failed to init repo: %v&quot;, err)
+777		}
+778	
+779		// Configure git user for this test repo
+780		if err := runCmd(repoDir, &quot;git&quot;, &quot;config&quot;, &quot;user.email&quot;, &quot;test@example.com&quot;); err != nil {
+781			t.Fatalf(&quot;Failed to set git email: %v&quot;, err)
+782		}
+783		if err := runCmd(repoDir, &quot;git&quot;, &quot;config&quot;, &quot;user.name&quot;, &quot;Test User&quot;); err != nil {
+784			t.Fatalf(&quot;Failed to set git name: %v&quot;, err)
+785		}
+786	
+787		// Create a file but don&#x27;t commit it
+788		if err := os.WriteFile(repoDir+&quot;/test.txt&quot;, []byte(&quot;hello&quot;), 0o644); err != nil {
+789			t.Fatalf(&quot;Failed to write file: %v&quot;, err)
+790		}
+791	
+792		// Change to the empty repo directory
+793		oldDir, _ := os.Getwd()
+794		defer func() {
+795			if err := os.Chdir(oldDir); err != nil {
+796				t.Logf(&quot;Failed to restore directory: %v&quot;, err)
+797			}
+798		}()
+799	
+800		if err := os.Chdir(repoDir); err != nil {
+801			t.Fatalf(&quot;Failed to chdir to empty repo: %v&quot;, err)
+802		}
+803	
+804		// This should not crash with &quot;fatal: ambiguous argument &#x27;HEAD&#x27;&quot;
+805		// Before the fix, gitDiffStat() would call log.Fatalf() here
+806		diffStat := gitDiffStat()
+807	
+808		// In an empty repo with no commits, there should be no diff stats
+809		// (because there&#x27;s no HEAD to compare against)
+810		if len(diffStat) != 0 {
+811			t.Logf(&quot;Expected empty diffStat in empty repo, got: %s&quot;, string(diffStat))
+812			// Note: This is logged but not a failure - the important thing is
+813			// that gitDiffStat() didn&#x27;t crash
+814		}
+815	
+816		t.Log(&quot;Successfully ran gitDiffStat() in empty repository without crashing&quot;)
+817	}
+818	
+819	// TestChangedOnly verifies that the --changed-only flag filters files
+820	// to only show those with git status.
+821	func TestChangedOnly(t *testing.T) {
+822		// Create test files with different statuses
+823		files := []*File{
+[result-id: r7]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-07-44-198Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-07-44-198Z" class="timestamp-link"><time datetime="2026-04-09T12:07:44.198Z" data-timestamp="2026-04-09T12:07:44.198Z">2026-04-09T12:07:44.198Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now let me also check <code>runCmd</code>:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-07-45-261Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-07-45-261Z" class="timestamp-link"><time datetime="2026-04-09T12:07:45.261Z" data-timestamp="2026-04-09T12:07:45.261Z">2026-04-09T12:07:45.261Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01GRLPtK9xwi4DoJ367QuKFd"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;func runCmd&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main_test.go&#34;,
+  &#34;-A&#34;: 8
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-07-45-276Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-07-45-276Z" class="timestamp-link"><time datetime="2026-04-09T12:07:45.276Z" data-timestamp="2026-04-09T12:07:45.276Z">2026-04-09T12:07:45.276Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>639:func runCmd(dir string, name string, args ...string) error {
+640-	cmd := exec.Command(name, args...)
+641-	cmd.Dir = dir
+642-	out, err := cmd.CombinedOutput()
+643-	if err != nil {
+644-		return fmt.Errorf(&quot;%w: %s&quot;, err, string(out))
+645-	}
+646-	return nil
+647-}
+[result-id: r8]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-07-51-280Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-07-51-280Z" class="timestamp-link"><time datetime="2026-04-09T12:07:51.280Z" data-timestamp="2026-04-09T12:07:51.280Z">2026-04-09T12:07:51.280Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now regarding other states — I think "on a branch" and "detached HEAD" covers all cases. During a rebase or bisect, HEAD is detached, so it falls into the same bucket. An orphan branch (no commits yet) still has a symbolic ref so <code>symbolic-ref</code> works. The empty repo case is already handled separately via <code>isEmptyRepo()</code>.</p>
+<p>The two cases cover everything. Let me add the test.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-07-51-988Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-07-51-988Z" class="timestamp-link"><time datetime="2026-04-09T12:07:51.988Z" data-timestamp="2026-04-09T12:07:51.988Z">2026-04-09T12:07:51.988Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01H9XRWv1sABYhYCJt5bT5nc"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main_test.go&#34;,
+  &#34;offset&#34;: 1085,
+  &#34;limit&#34;: 30
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-07-52-000Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-07-52-000Z" class="timestamp-link"><time datetime="2026-04-09T12:07:52.000Z" data-timestamp="2026-04-09T12:07:52.000Z">2026-04-09T12:07:52.000Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>1085		if err != nil {
+1086			t.Fatalf(&quot;Failed to read directory: %v&quot;, err)
+1087		}
+1088	
+1089		var files []*File
+1090		for _, file := range osfiles {
+1091			stat, _ := os.Stat(file.Name())
+1092			files = append(files, &amp;File{
+1093				entry: file,
+1094				isDir: file.IsDir(),
+1095				isExe: !file.IsDir() &amp;&amp; stat.Mode()&amp;0o111 != 0,
+1096			})
+1097		}
+1098	
+1099		gitData := fetchGitData()
+1100		resolved := must(filepath.EvalSymlinks(must(filepath.Abs(&quot;.&quot;))))
+1101		curdir := must(filepath.Rel(gitData.root, resolved))
+1102		fileStatus(gitData.status, files, curdir)
+1103	
+1104		// Run the streaming log — should find renamed files via their old name
+1105		if err := parseGitLog(files); err != nil {
+1106			t.Fatalf(&quot;parseGitLog failed: %v&quot;, err)
+1107		}
+1108	
+1109		// Find new-name.txt
+1110		var renamed *File
+1111		for _, f := range files {
+1112			if f.Name() == &quot;new-name.txt&quot; {
+1113				renamed = f
+1114				break
+[result-id: r9]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-07-55-491Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-07-55-491Z" class="timestamp-link"><time datetime="2026-04-09T12:07:55.491Z" data-timestamp="2026-04-09T12:07:55.491Z">2026-04-09T12:07:55.491Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01FDY23jwPZ6WTgDMrXzYDLi"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main_test.go&#34;,
+  &#34;offset&#34;: 1120,
+  &#34;limit&#34;: 20
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-07-55-499Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-07-55-499Z" class="timestamp-link"><time datetime="2026-04-09T12:07:55.499Z" data-timestamp="2026-04-09T12:07:55.499Z">2026-04-09T12:07:55.499Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>1120		}
+1121	
+1122		// Verify status
+1123		if renamed.status == &quot;&quot; {
+1124			t.Error(&quot;Expected new-name.txt to have a rename status, but it was empty&quot;)
+1125		}
+1126		if renamed.status[0] != &#x27;R&#x27; {
+1127			t.Errorf(&quot;Expected rename status starting with &#x27;R&#x27;, got %q&quot;, renamed.status)
+1128		}
+1129	
+1130		// Verify oldName was recorded
+1131		if renamed.oldName != &quot;old-name.txt&quot; {
+1132			t.Errorf(&quot;Expected oldName &#x27;old-name.txt&#x27;, got %q&quot;, renamed.oldName)
+1133		}
+1134	
+1135		// Verify commit info was found via the old name
+1136		if renamed.hash == &quot;&quot; {
+1137			t.Error(&quot;Expected new-name.txt to have a commit hash from its old name, but it was empty&quot;)
+1138		}
+1139		if renamed.author != &quot;Test User&quot; {
+[result-id: r10]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-07-57-597Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-07-57-597Z" class="timestamp-link"><time datetime="2026-04-09T12:07:57.597Z" data-timestamp="2026-04-09T12:07:57.597Z">2026-04-09T12:07:57.597Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_011MiVejkMmpAB45cQ26L5DJ"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main_test.go&#34;,
+  &#34;offset&#34;: 1140,
+  &#34;limit&#34;: 15
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-07-57-607Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-07-57-607Z" class="timestamp-link"><time datetime="2026-04-09T12:07:57.607Z" data-timestamp="2026-04-09T12:07:57.607Z">2026-04-09T12:07:57.607Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>1140			t.Errorf(&quot;Expected author &#x27;Test User&#x27;, got %q&quot;, renamed.author)
+1141		}
+1142		if renamed.message != &quot;initial commit&quot; {
+1143			t.Errorf(&quot;Expected message &#x27;initial commit&#x27;, got %q&quot;, renamed.message)
+1144		}
+1145	}
+1146	</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-08-00-523Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-08-00-523Z" class="timestamp-link"><time datetime="2026-04-09T12:08:00.523Z" data-timestamp="2026-04-09T12:08:00.523Z">2026-04-09T12:08:00.523Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now I'll add the test at the end of the file:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-08-10-910Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-08-10-910Z" class="timestamp-link"><time datetime="2026-04-09T12:08:10.910Z" data-timestamp="2026-04-09T12:08:10.910Z">2026-04-09T12:08:10.910Z</time></a></div><div class="message-content"><div class="file-tool edit-tool" data-tool-id="toolu_01KFbSrQkaCwT1TtbU97o4S9">
+<div class="file-tool-header edit-header"><span class="file-tool-icon">✏️</span> Edit <span class="file-tool-path">main_test.go</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/handle-non-branch/main_test.go</div>
+<div class="truncatable"><div class="truncatable-content">
+<div class="edit-section edit-old"><div class="edit-label">−</div><pre class="edit-content">	if renamed.message != &#34;initial commit&#34; {
+		t.Errorf(&#34;Expected message &#39;initial commit&#39;, got %q&#34;, renamed.message)
+	}
+}</pre></div>
+<div class="edit-section edit-new"><div class="edit-label">+</div><pre class="edit-content">	if renamed.message != &#34;initial commit&#34; {
+		t.Errorf(&#34;Expected message &#39;initial commit&#39;, got %q&#34;, renamed.message)
+	}
+}
+
+func TestDetachedHead(t *testing.T) {
+	tmpDir := t.TempDir()
+	repoDir := tmpDir + &#34;/repo&#34;
+	if err := os.Mkdir(repoDir, 0o755); err != nil {
+		t.Fatalf(&#34;Failed to create repo dir: %v&#34;, err)
+	}
+
+	for _, args := range [][]string{
+		{&#34;init&#34;, &#34;-b&#34;, &#34;main&#34;},
+		{&#34;config&#34;, &#34;user.email&#34;, &#34;test@example.com&#34;},
+		{&#34;config&#34;, &#34;user.name&#34;, &#34;Test User&#34;},
+	} {
+		if err := runCmd(repoDir, &#34;git&#34;, args...); err != nil {
+			t.Fatalf(&#34;git %v failed: %v&#34;, args, err)
+		}
+	}
+
+	// Create two commits so we can detach at the first one
+	if err := os.WriteFile(repoDir+&#34;/a.txt&#34;, []byte(&#34;a&#34;), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;add&#34;, &#34;.&#34;); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;commit&#34;, &#34;-m&#34;, &#34;first&#34;); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(repoDir+&#34;/b.txt&#34;, []byte(&#34;b&#34;), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;add&#34;, &#34;.&#34;); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;commit&#34;, &#34;-m&#34;, &#34;second&#34;); err != nil {
+		t.Fatal(err)
+	}
+
+	// Detach HEAD at the first commit
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;checkout&#34;, &#34;--detach&#34;, &#34;HEAD~1&#34;); err != nil {
+		t.Fatal(err)
+	}
+
+	oldDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldDir) }()
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatal(err)
+	}
+
+	branch := gitCurrentBranchSymbolic()
+	if !strings.HasPrefix(branch, &#34;HEAD detached at &#34;) {
+		t.Fatalf(&#34;expected &#39;HEAD detached at &lt;hash&gt;&#39;, got %q&#34;, branch)
+	}
+	hash := strings.TrimPrefix(branch, &#34;HEAD detached at &#34;)
+	if len(hash) &lt; 7 {
+		t.Fatalf(&#34;expected at least 7-char short hash, got %q&#34;, hash)
+	}
+}</pre></div>
+</div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-08-16-702Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-08-16-702Z" class="timestamp-link"><time datetime="2026-04-09T12:08:16.702Z" data-timestamp="2026-04-09T12:08:16.702Z">2026-04-09T12:08:16.702Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/handle-non-branch/main_test.go has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-08-19-356Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-08-19-356Z" class="timestamp-link"><time datetime="2026-04-09T12:08:19.356Z" data-timestamp="2026-04-09T12:08:19.356Z">2026-04-09T12:08:19.356Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_0179NbRUWp4Zqu9yL23FmKMY">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go test -run TestDetachedHead -v 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-08-24-518Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-08-24-518Z" class="timestamp-link"><time datetime="2026-04-09T12:08:24.518Z" data-timestamp="2026-04-09T12:08:24.518Z">2026-04-09T12:08:24.518Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>=== RUN   TestDetachedHead
+--- PASS: TestDetachedHead (0.12s)
+PASS
+ok  	github.com/llimllib/git-ls	0.497s
+[rerun: b3]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-08-29-464Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-08-29-464Z" class="timestamp-link"><time datetime="2026-04-09T12:08:29.464Z" data-timestamp="2026-04-09T12:08:29.464Z">2026-04-09T12:08:29.464Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Test passes. To answer your question: "branch" and "detached HEAD" covers all cases. During a rebase, bisect, or cherry-pick, git is in detached HEAD state, so the same codepath applies. An orphan branch (e.g. <code>git checkout --orphan foo</code>) still has a symbolic ref, so <code>symbolic-ref</code> succeeds and returns the branch name. The empty repo case is already handled separately via <code>isEmptyRepo()</code>.</p></div></div></div>
+<div class="message user" id="msg-2026-04-09T12-09-42-251Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-09T12-09-42-251Z" class="timestamp-link"><time datetime="2026-04-09T12:09:42.251Z" data-timestamp="2026-04-09T12:09:42.251Z">2026-04-09T12:09:42.251Z</time></a></div><div class="message-content">
+<div class="user-content"><p>I cloned git into the 'git' dir. Figure out where it determines what text to print in git status, I want to read it</p></div></div></div>
+        
+
+<div class="pagination">
+<a href="index.html" class="index-link">Index</a>
+<span class="disabled">&larr; Prev</span>
+<span class="current">1</span>
+<a href="page-002.html">2</a>
+<a href="page-002.html">Next &rarr;</a>
+</div>
+
+    </div>
+    <script>
+document.querySelectorAll('time[data-timestamp]').forEach(function(el) {
+    const timestamp = el.getAttribute('data-timestamp');
+    const date = new Date(timestamp);
+    const now = new Date();
+    const isToday = date.toDateString() === now.toDateString();
+    const timeStr = date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+    if (isToday) { el.textContent = timeStr; }
+    else { el.textContent = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' ' + timeStr; }
+});
+document.querySelectorAll('pre.json').forEach(function(el) {
+    let text = el.textContent;
+    text = text.replace(/"([^"]+)":/g, '<span style="color: #ce93d8">"$1"</span>:');
+    text = text.replace(/: "([^"]*)"/g, ': <span style="color: #81d4fa">"$1"</span>');
+    text = text.replace(/: (\d+)/g, ': <span style="color: #ffcc80">$1</span>');
+    text = text.replace(/: (true|false|null)/g, ': <span style="color: #f48fb1">$1</span>');
+    el.innerHTML = text;
+});
+document.querySelectorAll('.truncatable').forEach(function(wrapper) {
+    const content = wrapper.querySelector('.truncatable-content');
+    const btn = wrapper.querySelector('.expand-btn');
+    if (content.scrollHeight > 250) {
+        wrapper.classList.add('truncated');
+        btn.addEventListener('click', function() {
+            if (wrapper.classList.contains('truncated')) { wrapper.classList.remove('truncated'); wrapper.classList.add('expanded'); btn.textContent = 'Show less'; }
+            else { wrapper.classList.remove('expanded'); wrapper.classList.add('truncated'); btn.textContent = 'Show more'; }
+        });
+    }
+});
+</script>
+</body>
+</html>

--- a/transcripts/45-handle-detached-head/page-002.html
+++ b/transcripts/45-handle-detached-head/page-002.html
@@ -1,0 +1,2013 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Claude Code transcript - page 2</title>
+    <style>
+:root { --bg-color: #f5f5f5; --card-bg: #ffffff; --user-bg: #e3f2fd; --user-border: #1976d2; --assistant-bg: #f5f5f5; --assistant-border: #9e9e9e; --thinking-bg: #fff8e1; --thinking-border: #ffc107; --thinking-text: #666; --tool-bg: #f3e5f5; --tool-border: #9c27b0; --tool-result-bg: #e8f5e9; --tool-error-bg: #ffebee; --text-color: #212121; --text-muted: #757575; --code-bg: #263238; --code-text: #aed581; }
+* { box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg-color); color: var(--text-color); margin: 0; padding: 16px; line-height: 1.6; }
+.container { max-width: 800px; margin: 0 auto; }
+h1 { font-size: 1.5rem; margin-bottom: 24px; padding-bottom: 8px; border-bottom: 2px solid var(--user-border); }
+.header-row { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; border-bottom: 2px solid var(--user-border); padding-bottom: 8px; margin-bottom: 24px; }
+.header-row h1 { border-bottom: none; padding-bottom: 0; margin-bottom: 0; flex: 1; min-width: 200px; }
+.message { margin-bottom: 16px; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.message.user { background: var(--user-bg); border-left: 4px solid var(--user-border); }
+.message.assistant { background: var(--card-bg); border-left: 4px solid var(--assistant-border); }
+.message.tool-reply { background: #fff8e1; border-left: 4px solid #ff9800; }
+.tool-reply .role-label { color: #e65100; }
+.tool-reply .tool-result { background: transparent; padding: 0; margin: 0; }
+.tool-reply .tool-result .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff8e1); }
+.message-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 16px; background: rgba(0,0,0,0.03); font-size: 0.85rem; }
+.role-label { font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
+.user .role-label { color: var(--user-border); }
+time { color: var(--text-muted); font-size: 0.8rem; }
+.timestamp-link { color: inherit; text-decoration: none; }
+.timestamp-link:hover { text-decoration: underline; }
+.message:target { animation: highlight 2s ease-out; }
+@keyframes highlight { 0% { background-color: rgba(25, 118, 210, 0.2); } 100% { background-color: transparent; } }
+.message-content { padding: 16px; }
+.message-content p { margin: 0 0 12px 0; }
+.message-content p:last-child { margin-bottom: 0; }
+.thinking { background: var(--thinking-bg); border: 1px solid var(--thinking-border); border-radius: 8px; padding: 12px; margin: 12px 0; font-size: 0.9rem; color: var(--thinking-text); }
+.thinking-label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: #f57c00; margin-bottom: 8px; }
+.thinking p { margin: 8px 0; }
+.assistant-text { margin: 8px 0; }
+.tool-use { background: var(--tool-bg); border: 1px solid var(--tool-border); border-radius: 8px; padding: 12px; margin: 12px 0; }
+.tool-header { font-weight: 600; color: var(--tool-border); margin-bottom: 8px; display: flex; align-items: center; gap: 8px; }
+.tool-icon { font-size: 1.1rem; }
+.tool-description { font-size: 0.9rem; color: var(--text-muted); margin-bottom: 8px; font-style: italic; }
+.tool-result { background: var(--tool-result-bg); border-radius: 8px; padding: 12px; margin: 12px 0; }
+.tool-result.tool-error { background: var(--tool-error-bg); }
+.file-tool { border-radius: 8px; padding: 12px; margin: 12px 0; }
+.write-tool { background: linear-gradient(135deg, #e3f2fd 0%, #e8f5e9 100%); border: 1px solid #4caf50; }
+.edit-tool { background: linear-gradient(135deg, #fff3e0 0%, #fce4ec 100%); border: 1px solid #ff9800; }
+.file-tool-header { font-weight: 600; margin-bottom: 4px; display: flex; align-items: center; gap: 8px; font-size: 0.95rem; }
+.write-header { color: #2e7d32; }
+.edit-header { color: #e65100; }
+.file-tool-icon { font-size: 1rem; }
+.file-tool-path { font-family: monospace; background: rgba(0,0,0,0.08); padding: 2px 8px; border-radius: 4px; }
+.file-tool-fullpath { font-family: monospace; font-size: 0.8rem; color: var(--text-muted); margin-bottom: 8px; word-break: break-all; }
+.file-content { margin: 0; }
+.edit-section { display: flex; margin: 4px 0; border-radius: 4px; overflow: hidden; }
+.edit-label { padding: 8px 12px; font-weight: bold; font-family: monospace; display: flex; align-items: flex-start; }
+.edit-old { background: #fce4ec; }
+.edit-old .edit-label { color: #b71c1c; background: #f8bbd9; }
+.edit-old .edit-content { color: #880e4f; }
+.edit-new { background: #e8f5e9; }
+.edit-new .edit-label { color: #1b5e20; background: #a5d6a7; }
+.edit-new .edit-content { color: #1b5e20; }
+.edit-content { margin: 0; flex: 1; background: transparent; font-size: 0.85rem; }
+.edit-replace-all { font-size: 0.75rem; font-weight: normal; color: var(--text-muted); }
+.write-tool .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #e6f4ea); }
+.edit-tool .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff0e5); }
+.todo-list { background: linear-gradient(135deg, #e8f5e9 0%, #f1f8e9 100%); border: 1px solid #81c784; border-radius: 8px; padding: 12px; margin: 12px 0; }
+.todo-header { font-weight: 600; color: #2e7d32; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; font-size: 0.95rem; }
+.todo-items { list-style: none; margin: 0; padding: 0; }
+.todo-item { display: flex; align-items: flex-start; gap: 10px; padding: 6px 0; border-bottom: 1px solid rgba(0,0,0,0.06); font-size: 0.9rem; }
+.todo-item:last-child { border-bottom: none; }
+.todo-icon { flex-shrink: 0; width: 20px; height: 20px; display: flex; align-items: center; justify-content: center; font-weight: bold; border-radius: 50%; }
+.todo-completed .todo-icon { color: #2e7d32; background: rgba(46, 125, 50, 0.15); }
+.todo-completed .todo-content { color: #558b2f; text-decoration: line-through; }
+.todo-in-progress .todo-icon { color: #f57c00; background: rgba(245, 124, 0, 0.15); }
+.todo-in-progress .todo-content { color: #e65100; font-weight: 500; }
+.todo-pending .todo-icon { color: #757575; background: rgba(0,0,0,0.05); }
+.todo-pending .todo-content { color: #616161; }
+pre { background: var(--code-bg); color: var(--code-text); padding: 12px; border-radius: 6px; overflow-x: auto; font-size: 0.85rem; line-height: 1.5; margin: 8px 0; white-space: pre-wrap; word-wrap: break-word; }
+pre.json { color: #e0e0e0; }
+code { background: rgba(0,0,0,0.08); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+pre code { background: none; padding: 0; }
+.user-content { margin: 0; }
+.truncatable { position: relative; }
+.truncatable.truncated .truncatable-content { max-height: 200px; overflow: hidden; }
+.truncatable.truncated::after { content: ''; position: absolute; bottom: 32px; left: 0; right: 0; height: 60px; background: linear-gradient(to bottom, transparent, var(--card-bg)); pointer-events: none; }
+.message.user .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--user-bg)); }
+.message.tool-reply .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff8e1); }
+.tool-use .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--tool-bg)); }
+.tool-result .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--tool-result-bg)); }
+.expand-btn { display: none; width: 100%; padding: 8px 16px; margin-top: 4px; background: rgba(0,0,0,0.05); border: 1px solid rgba(0,0,0,0.1); border-radius: 6px; cursor: pointer; font-size: 0.85rem; color: var(--text-muted); }
+.expand-btn:hover { background: rgba(0,0,0,0.1); }
+.truncatable.truncated .expand-btn, .truncatable.expanded .expand-btn { display: block; }
+.pagination { display: flex; justify-content: center; gap: 8px; margin: 24px 0; flex-wrap: wrap; }
+.pagination a, .pagination span { padding: 5px 10px; border-radius: 6px; text-decoration: none; font-size: 0.85rem; }
+.pagination a { background: var(--card-bg); color: var(--user-border); border: 1px solid var(--user-border); }
+.pagination a:hover { background: var(--user-bg); }
+.pagination .current { background: var(--user-border); color: white; }
+.pagination .disabled { color: var(--text-muted); border: 1px solid #ddd; }
+.pagination .index-link { background: var(--user-border); color: white; }
+details.continuation { margin-bottom: 16px; }
+details.continuation summary { cursor: pointer; padding: 12px 16px; background: var(--user-bg); border-left: 4px solid var(--user-border); border-radius: 12px; font-weight: 500; color: var(--text-muted); }
+details.continuation summary:hover { background: rgba(25, 118, 210, 0.15); }
+details.continuation[open] summary { border-radius: 12px 12px 0 0; margin-bottom: 0; }
+.index-item { margin-bottom: 16px; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); background: var(--user-bg); border-left: 4px solid var(--user-border); }
+.index-item a { display: block; text-decoration: none; color: inherit; }
+.index-item a:hover { background: rgba(25, 118, 210, 0.1); }
+.index-item-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 16px; background: rgba(0,0,0,0.03); font-size: 0.85rem; }
+.index-item-number { font-weight: 600; color: var(--user-border); }
+.index-item-content { padding: 16px; }
+.index-item-stats { padding: 8px 16px 12px 32px; font-size: 0.85rem; color: var(--text-muted); border-top: 1px solid rgba(0,0,0,0.06); }
+.index-item-commit { margin-top: 6px; padding: 4px 8px; background: #fff3e0; border-radius: 4px; font-size: 0.85rem; color: #e65100; }
+.index-item-commit code { background: rgba(0,0,0,0.08); padding: 1px 4px; border-radius: 3px; font-size: 0.8rem; margin-right: 6px; }
+.commit-card { margin: 8px 0; padding: 10px 14px; background: #fff3e0; border-left: 4px solid #ff9800; border-radius: 6px; }
+.commit-card a { text-decoration: none; color: #5d4037; display: block; }
+.commit-card a:hover { color: #e65100; }
+.commit-card-hash { font-family: monospace; color: #e65100; font-weight: 600; margin-right: 8px; }
+.index-commit { margin-bottom: 12px; padding: 10px 16px; background: #fff3e0; border-left: 4px solid #ff9800; border-radius: 8px; box-shadow: 0 1px 2px rgba(0,0,0,0.05); }
+.index-commit a { display: block; text-decoration: none; color: inherit; }
+.index-commit a:hover { background: rgba(255, 152, 0, 0.1); margin: -10px -16px; padding: 10px 16px; border-radius: 8px; }
+.index-commit-header { display: flex; justify-content: space-between; align-items: center; font-size: 0.85rem; margin-bottom: 4px; }
+.index-commit-hash { font-family: monospace; color: #e65100; font-weight: 600; }
+.index-commit-msg { color: #5d4037; }
+.index-item-long-text { margin-top: 8px; padding: 12px; background: var(--card-bg); border-radius: 8px; border-left: 3px solid var(--assistant-border); }
+.index-item-long-text .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--card-bg)); }
+.index-item-long-text-content { color: var(--text-color); }
+#search-box { display: none; align-items: center; gap: 8px; }
+#search-box input { padding: 6px 12px; border: 1px solid var(--assistant-border); border-radius: 6px; font-size: 16px; width: 180px; }
+#search-box button, #modal-search-btn, #modal-close-btn { background: var(--user-border); color: white; border: none; border-radius: 6px; padding: 6px 10px; cursor: pointer; display: flex; align-items: center; justify-content: center; }
+#search-box button:hover, #modal-search-btn:hover { background: #1565c0; }
+#modal-close-btn { background: var(--text-muted); margin-left: 8px; }
+#modal-close-btn:hover { background: #616161; }
+#search-modal[open] { border: none; border-radius: 12px; box-shadow: 0 4px 24px rgba(0,0,0,0.2); padding: 0; width: 90vw; max-width: 900px; height: 80vh; max-height: 80vh; display: flex; flex-direction: column; }
+#search-modal::backdrop { background: rgba(0,0,0,0.5); }
+.search-modal-header { display: flex; align-items: center; gap: 8px; padding: 16px; border-bottom: 1px solid var(--assistant-border); background: var(--bg-color); border-radius: 12px 12px 0 0; }
+.search-modal-header input { flex: 1; padding: 8px 12px; border: 1px solid var(--assistant-border); border-radius: 6px; font-size: 16px; }
+#search-status { padding: 8px 16px; font-size: 0.85rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
+#search-results { flex: 1; overflow-y: auto; padding: 16px; }
+.search-result { margin-bottom: 16px; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.search-result a { display: block; text-decoration: none; color: inherit; }
+.search-result a:hover { background: rgba(25, 118, 210, 0.05); }
+.search-result-page { padding: 6px 12px; background: rgba(0,0,0,0.03); font-size: 0.8rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
+.search-result-content { padding: 12px; }
+.search-result mark { background: #fff59d; padding: 1px 2px; border-radius: 2px; }
+@media (max-width: 600px) { body { padding: 8px; } .message, .index-item { border-radius: 8px; } .message-content, .index-item-content { padding: 12px; } pre { font-size: 0.8rem; padding: 8px; } #search-box input { width: 120px; } #search-modal[open] { width: 95vw; height: 90vh; } }
+</style>
+</head>
+<body>
+    <div class="container">
+        <h1><a href="index.html" style="color: inherit; text-decoration: none;">Claude Code transcript</a> - page 2/2</h1>
+        
+
+<div class="pagination">
+<a href="index.html" class="index-link">Index</a>
+<a href="page-001.html">&larr; Prev</a>
+<a href="page-001.html">1</a>
+<span class="current">2</span>
+<span class="disabled">Next &rarr;</span>
+</div>
+
+        
+<div class="message user" id="msg-2026-04-09T12-10-30-961Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-09T12-10-30-961Z" class="timestamp-link"><time datetime="2026-04-09T12:10:30.961Z" data-timestamp="2026-04-09T12:10:30.961Z">2026-04-09T12:10:30.961Z</time></a></div><div class="message-content">
+<div class="user-content"><p>I cloned git into the 'git' dir. Figure out where it determines what text to print in git status, I want to read it. What I mean is the bit where it decides to say "On branch handle-non-branch" or "HEAD detached at d84ca28"</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-10-39-487Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-10-39-487Z" class="timestamp-link"><time datetime="2026-04-09T12:10:39.487Z" data-timestamp="2026-04-09T12:10:39.487Z">2026-04-09T12:10:39.487Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_0159Wma7byyNtsRZ7fUFnoFw"><div class="tool-header"><span class="tool-icon">⚙</span> Agent</div><div class="tool-description">Find git status branch display</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;subagent_type&#34;: &#34;Explore&#34;,
+  &#34;prompt&#34;: &#34;In the git source code at /Users/llimllib/code/git-ls/handle-non-branch/git, find the exact location where `git status` determines what text to print for the branch/HEAD state line — specifically where it decides between \&#34;On branch X\&#34; vs \&#34;HEAD detached at X\&#34; and similar states. I want the specific file and line numbers. Look in the C source code. Search for strings like \&#34;On branch\&#34;, \&#34;HEAD detached at\&#34;, \&#34;HEAD detached from\&#34; in the codebase.&#34;
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-10-51-007Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-10-51-007Z" class="timestamp-link"><time datetime="2026-04-09T12:10:51.007Z" data-timestamp="2026-04-09T12:10:51.007Z">2026-04-09T12:10:51.007Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Excellent! I found the exact location. Let me verify the function name and provide the complete details.
+
+## Summary
+
+The code that determines what text to print for the branch/HEAD state line in `git status` is located in:
+
+**File:** `/Users/llimllib/code/git-ls/handle-non-branch/git/wt-status.c`
+
+**Function:** `wt_longstatus_print` (starting at line 1890)
+
+**Key decision points:**
+
+- **Line 1897:** Default text is set to `_(&quot;On branch &quot;)`
+- **Lines 1899-1917:** Logic that determines which state message to display:
+  - **Line 1899:** Checks if `branch_name` is &quot;HEAD&quot;
+  - **Lines 1901-1906:** If rebase is in progress, uses `_(&quot;rebase in progress; onto &quot;)` or `_(&quot;interactive rebase in progress; onto &quot;)`
+  - **Lines 1908-1913:** If detached HEAD state:
+    - **Line 1910-1911:** If `detached_at` is true, uses `_(&quot;HEAD detached at &quot;)`
+    - **Line 1912-1913:** Otherwise uses `_(&quot;HEAD detached from &quot;)`
+  - **Lines 1914-1916:** If none of the above, uses `_(&quot;Not currently on any branch.&quot;)`
+- **Lines 1921-1922:** The selected message is printed along with the branch name
+
+This is the core logic that decides between &quot;On branch X&quot;, &quot;HEAD detached at X&quot;, &quot;HEAD detached from X&quot;, and other state messages.</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-10-55-845Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-10-55-845Z" class="timestamp-link"><time datetime="2026-04-09T12:10:55.845Z" data-timestamp="2026-04-09T12:10:55.845Z">2026-04-09T12:10:55.845Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>The logic is in <code>git/wt-status.c</code>, function <code>wt_longstatus_print</code> starting at line 1890. Here are the key lines:</p>
+<ul>
+<li><strong>Line 1897:</strong> Default is <code>"On branch "</code></li>
+<li><strong>Lines 1899-1916:</strong> If <code>branch_name</code> is <code>"HEAD"</code>:</li>
+<li>During rebase: <code>"rebase in progress; onto "</code> or <code>"interactive rebase in progress; onto "</code></li>
+<li>Detached: <code>"HEAD detached at "</code> vs <code>"HEAD detached from "</code> (depending on <code>detached_at</code> flag)</li>
+<li>Fallback: <code>"Not currently on any branch."</code></li>
+<li><strong>Lines 1921-1922:</strong> Prints the chosen message with the branch/ref name</li>
+</ul>
+<p>Want to read it?</p></div></div></div>
+<div class="message user" id="msg-2026-04-09T12-11-29-051Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-09T12-11-29-051Z" class="timestamp-link"><time datetime="2026-04-09T12:11:29.051Z" data-timestamp="2026-04-09T12:11:29.051Z">2026-04-09T12:11:29.051Z</time></a></div><div class="message-content">
+<div class="user-content"><p>perfect! I'd like to have the same text in git-ls, it will be familiar to users</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-11-32-187Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-11-32-187Z" class="timestamp-link"><time datetime="2026-04-09T12:11:32.187Z" data-timestamp="2026-04-09T12:11:32.187Z">2026-04-09T12:11:32.187Z</time></a></div><div class="message-content">
+<div class="thinking"><div class="thinking-label">Thinking</div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-11-32-717Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-11-32-717Z" class="timestamp-link"><time datetime="2026-04-09T12:11:32.717Z" data-timestamp="2026-04-09T12:11:32.717Z">2026-04-09T12:11:32.717Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01LAVF9mAfcn6VRG8nQWG4vZ"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/git/wt-status.c&#34;,
+  &#34;offset&#34;: 1885,
+  &#34;limit&#34;: 50
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-11-32-726Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-11-32-726Z" class="timestamp-link"><time datetime="2026-04-09T12:11:32.726Z" data-timestamp="2026-04-09T12:11:32.726Z">2026-04-09T12:11:32.726Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>1885	
+1886		if (state-&gt;sparse_checkout_percentage != SPARSE_CHECKOUT_DISABLED)
+1887			show_sparse_checkout_in_use(s, state_color);
+1888	}
+1889	
+1890	static void wt_longstatus_print(struct wt_status *s)
+1891	{
+1892		const char *branch_color = color(WT_STATUS_ONBRANCH, s);
+1893		const char *branch_status_color = color(WT_STATUS_HEADER, s);
+1894		enum fsmonitor_mode fsm_mode = fsm_settings__get_mode(s-&gt;repo);
+1895	
+1896		if (s-&gt;branch) {
+1897			const char *on_what = _(&quot;On branch &quot;);
+1898			const char *branch_name = s-&gt;branch;
+1899			if (!strcmp(branch_name, &quot;HEAD&quot;)) {
+1900				branch_status_color = color(WT_STATUS_NOBRANCH, s);
+1901				if (s-&gt;state.rebase_in_progress ||
+1902				    s-&gt;state.rebase_interactive_in_progress) {
+1903					if (s-&gt;state.rebase_interactive_in_progress)
+1904						on_what = _(&quot;interactive rebase in progress; onto &quot;);
+1905					else
+1906						on_what = _(&quot;rebase in progress; onto &quot;);
+1907					branch_name = s-&gt;state.onto;
+1908				} else if (s-&gt;state.detached_from) {
+1909					branch_name = s-&gt;state.detached_from;
+1910					if (s-&gt;state.detached_at)
+1911						on_what = _(&quot;HEAD detached at &quot;);
+1912					else
+1913						on_what = _(&quot;HEAD detached from &quot;);
+1914				} else {
+1915					branch_name = &quot;&quot;;
+1916					on_what = _(&quot;Not currently on any branch.&quot;);
+1917				}
+1918			} else
+1919				skip_prefix(branch_name, &quot;refs/heads/&quot;, &amp;branch_name);
+1920			status_printf(s, color(WT_STATUS_HEADER, s), &quot;%s&quot;, &quot;&quot;);
+1921			status_printf_more(s, branch_status_color, &quot;%s&quot;, on_what);
+1922			status_printf_more(s, branch_color, &quot;%s\n&quot;, branch_name);
+1923			if (!s-&gt;is_initial)
+1924				wt_longstatus_print_tracking(s);
+1925		}
+1926	
+1927		wt_longstatus_print_state(s);
+1928	
+1929		if (s-&gt;is_initial) {
+1930			status_printf_ln(s, color(WT_STATUS_HEADER, s), &quot;%s&quot;, &quot;&quot;);
+1931			status_printf_ln(s, color(WT_STATUS_HEADER, s),
+1932					 s-&gt;commit_template
+1933					 ? _(&quot;Initial commit&quot;)
+1934					 : _(&quot;No commits yet&quot;));
+[result-id: r11]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-11-36-042Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-11-36-042Z" class="timestamp-link"><time datetime="2026-04-09T12:11:36.042Z" data-timestamp="2026-04-09T12:11:36.042Z">2026-04-09T12:11:36.042Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now let me understand what determines <code>detached_at</code> vs <code>detached_from</code>. Let me find that logic.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-11-37-060Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-11-37-060Z" class="timestamp-link"><time datetime="2026-04-09T12:11:37.060Z" data-timestamp="2026-04-09T12:11:37.060Z">2026-04-09T12:11:37.060Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_014ANq4uxWNZEYbQRgyAoWkE"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;detached_at|detached_from&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/git/wt-status.c&#34;,
+  &#34;-n&#34;: true
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-11-37-074Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-11-37-074Z" class="timestamp-link"><time datetime="2026-04-09T12:11:37.074Z" data-timestamp="2026-04-09T12:11:37.074Z">2026-04-09T12:11:37.074Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>897:	FREE_AND_NULL(state-&gt;detached_from);
+1709:static void wt_status_get_detached_from(struct repository *r,
+1733:		state-&gt;detached_from = xstrdup(from);
+1735:		state-&gt;detached_from =
+1738:	state-&gt;detached_at = !repo_get_oid(r, &quot;HEAD&quot;, &amp;oid) &amp;&amp;
+1825:			 int get_detached_from)
+1857:	if (get_detached_from)
+1858:		wt_status_get_detached_from(r, state);
+1908:			} else if (s-&gt;state.detached_from) {
+1909:				branch_name = s-&gt;state.detached_from;
+1910:				if (s-&gt;state.detached_at)
+2254:			else if (s-&gt;state.detached_from)
+2255:				branch_name = s-&gt;state.detached_from;
+[result-id: r12]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-11-40-936Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-11-40-936Z" class="timestamp-link"><time datetime="2026-04-09T12:11:40.936Z" data-timestamp="2026-04-09T12:11:40.936Z">2026-04-09T12:11:40.936Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01CtutZvaMV4ARq4Rt2rSMVG"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/git/wt-status.c&#34;,
+  &#34;offset&#34;: 1709,
+  &#34;limit&#34;: 40
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-11-40-943Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-11-40-943Z" class="timestamp-link"><time datetime="2026-04-09T12:11:40.943Z" data-timestamp="2026-04-09T12:11:40.943Z">2026-04-09T12:11:40.943Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>1709	static void wt_status_get_detached_from(struct repository *r,
+1710						struct wt_status_state *state)
+1711	{
+1712		struct grab_1st_switch_cbdata cb;
+1713		struct commit *commit;
+1714		struct object_id oid;
+1715		char *ref = NULL;
+1716	
+1717		strbuf_init(&amp;cb.buf, 0);
+1718		if (refs_for_each_reflog_ent_reverse(get_main_ref_store(r), &quot;HEAD&quot;, grab_1st_switch, &amp;cb) &lt;= 0) {
+1719			strbuf_release(&amp;cb.buf);
+1720			return;
+1721		}
+1722	
+1723		if (repo_dwim_ref(r, cb.buf.buf, cb.buf.len, &amp;oid, &amp;ref,
+1724				  1) == 1 &amp;&amp;
+1725		    /* oid is a commit? match without further lookup */
+1726		    (oideq(&amp;cb.noid, &amp;oid) ||
+1727		     /* perhaps oid is a tag, try to dereference to a commit */
+1728		     ((commit = lookup_commit_reference_gently(r, &amp;oid, 1)) != NULL &amp;&amp;
+1729		      oideq(&amp;cb.noid, &amp;commit-&gt;object.oid)))) {
+1730			const char *from = ref;
+1731			if (!skip_prefix(from, &quot;refs/tags/&quot;, &amp;from))
+1732				skip_prefix(from, &quot;refs/remotes/&quot;, &amp;from);
+1733			state-&gt;detached_from = xstrdup(from);
+1734		} else
+1735			state-&gt;detached_from =
+1736				xstrdup(repo_find_unique_abbrev(r, &amp;cb.noid, DEFAULT_ABBREV));
+1737		oidcpy(&amp;state-&gt;detached_oid, &amp;cb.noid);
+1738		state-&gt;detached_at = !repo_get_oid(r, &quot;HEAD&quot;, &amp;oid) &amp;&amp;
+1739				     oideq(&amp;oid, &amp;state-&gt;detached_oid);
+1740	
+1741		free(ref);
+1742		strbuf_release(&amp;cb.buf);
+1743	}
+1744	
+1745	int wt_status_check_rebase(const struct worktree *wt,
+1746				   struct wt_status_state *state)
+1747	{
+1748		struct stat st;
+[result-id: r13]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-11-57-530Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-11-57-530Z" class="timestamp-link"><time datetime="2026-04-09T12:11:57.530Z" data-timestamp="2026-04-09T12:11:57.530Z">2026-04-09T12:11:57.530Z</time></a></div><div class="message-content">
+<div class="thinking"><div class="thinking-label">Thinking</div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-11-58-752Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-11-58-752Z" class="timestamp-link"><time datetime="2026-04-09T12:11:58.752Z" data-timestamp="2026-04-09T12:11:58.752Z">2026-04-09T12:11:58.752Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now I understand the full logic. Let me check what we're already getting from git status in git-ls, since we may already have the info we need.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-11-59-331Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-11-59-331Z" class="timestamp-link"><time datetime="2026-04-09T12:11:59.331Z" data-timestamp="2026-04-09T12:11:59.331Z">2026-04-09T12:11:59.331Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01YM7dcZtevM8MT77a63jkkK"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;git.*status|porcelain&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main.go&#34;
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-11-59-346Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-11-59-346Z" class="timestamp-link"><time datetime="2026-04-09T12:11:59.346Z" data-timestamp="2026-04-09T12:11:59.346Z">2026-04-09T12:11:59.346Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>226:    Displays the files in the current directory, their current git status, a short diffstat, their last modified date, the author and a portion of the last commit message for that file.
+251:        Replace git status letters with Nerd Font icons (requires a Nerd
+255:        Only show files that have changes (appear in git status). This
+359:	fileStatus(gitData.status, files, curdir)
+361:	// Parse deleted files from git status and merge into file list
+362:	deletedFiles := parseDeletedFiles(gitData.status, curdir)
+641:		log.Fatalf(&quot;Failed to get git status: %v&quot;, err)
+678:		log.Fatalf(&quot;Failed to get git status: %v&quot;, err)
+683:// gitStatus accepts a dir and a slice of files, and adds the git status to
+686:	cmd := exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;status&quot;, &quot;--porcelain&quot;, &quot;--ignored&quot;)
+689:		log.Fatalf(&quot;Failed to get git status: %v&quot;, err)
+709:			// For renames and copies, git&#x27;s porcelain output looks like:
+724:			gitStatusMap[fileName] = append(gitStatusMap[fileName], status)
+742:// parseDeletedFiles extracts deleted files from git status output and returns
+[result-id: r14]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-12-05-820Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-12-05-820Z" class="timestamp-link"><time datetime="2026-04-09T12:12:05.820Z" data-timestamp="2026-04-09T12:12:05.820Z">2026-04-09T12:12:05.820Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>We're using <code>--porcelain</code> which doesn't include branch info. Let me check if <code>--porcelain=v2 -b</code> gives us what we need — it would let us avoid the separate <code>symbolic-ref</code> call entirely.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-12-06-266Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-12-06-266Z" class="timestamp-link"><time datetime="2026-04-09T12:12:06.266Z" data-timestamp="2026-04-09T12:12:06.266Z">2026-04-09T12:12:06.266Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01CQhvqKcUcrojNbqo7Sqkvp">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git status --porcelain=v2 -b 2&gt;&amp;1 | head -5</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-12-06-947Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-12-06-947Z" class="timestamp-link"><time datetime="2026-04-09T12:12:06.947Z" data-timestamp="2026-04-09T12:12:06.947Z">2026-04-09T12:12:06.947Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01163GQHxCunAmAN4mnYUpi3">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git stash &amp;&amp; git checkout --detach HEAD~1 &amp;&amp; git status --porcelain=v2 -b 2&gt;&amp;1 | head -5</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-16-14-760Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-16-14-760Z" class="timestamp-link"><time datetime="2026-04-09T12:16:14.760Z" data-timestamp="2026-04-09T12:16:14.760Z">2026-04-09T12:16:14.760Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre># branch.oid 84a45fbfea57d4968a60965a6cec76790aaeea10
+# branch.head handle-non-branch
+1 .M N... 100644 100644 100644 ade6ee78562e13682de5f6854238b7e17042188d ade6ee78562e13682de5f6854238b7e17042188d main.go
+1 .M N... 100644 100644 100644 2ab09b75907c93cbdcb2abca87de6a10c20aca66 2ab09b75907c93cbdcb2abca87de6a10c20aca66 main_test.go
+? .claude/
+[result-id: r15]
+[rerun: b4]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-16-17-186Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-16-17-186Z" class="timestamp-link"><time datetime="2026-04-09T12:16:17.186Z" data-timestamp="2026-04-09T12:16:17.186Z">2026-04-09T12:16:17.186Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Saved working directory and index state WIP on handle-non-branch: 84a45fb chore: bump version to 5.8.0
+HEAD is now at d84ca28 fix: unmodified tracked files show no commit info after --changed-only was added (#43)
+# branch.oid d84ca28b7bfa7875b2d90d6579e66da606fa2de3
+# branch.head (detached)
+? .claude/
+[result-id: r16]
+[rerun: b5]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-16-22-814Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-16-22-814Z" class="timestamp-link"><time datetime="2026-04-09T12:16:22.814Z" data-timestamp="2026-04-09T12:16:22.814Z">2026-04-09T12:16:22.814Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Porcelain v2 gives <code># branch.head (detached)</code> but doesn't tell us "at" vs "from" or the ref name. Let me check what info is available in detached state:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-16-23-439Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-16-23-439Z" class="timestamp-link"><time datetime="2026-04-09T12:16:23.439Z" data-timestamp="2026-04-09T12:16:23.439Z">2026-04-09T12:16:23.439Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01AszWk1sy8XZ2R5wRNq3GrV">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git reflog -1 HEAD 2&gt;&amp;1 &amp;&amp; git status -b 2&gt;&amp;1 | head -1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-16-23-488Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-16-23-488Z" class="timestamp-link"><time datetime="2026-04-09T12:16:23.488Z" data-timestamp="2026-04-09T12:16:23.488Z">2026-04-09T12:16:23.488Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>d84ca28 HEAD@{0}: checkout: moving from handle-non-branch to HEAD~1
+HEAD detached at d84ca28
+[rerun: b6]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-16-26-985Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-16-26-985Z" class="timestamp-link"><time datetime="2026-04-09T12:16:26.985Z" data-timestamp="2026-04-09T12:16:26.985Z">2026-04-09T12:16:26.985Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01Pp4eJ4PgJXPMLX7VheH9kE">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git commit --allow-empty -m &#34;test commit while detached&#34; &amp;&amp; git status -b 2&gt;&amp;1 | head -1 &amp;&amp; git reflog -1 HEAD 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-16-29-531Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-16-29-531Z" class="timestamp-link"><time datetime="2026-04-09T12:16:29.531Z" data-timestamp="2026-04-09T12:16:29.531Z">2026-04-09T12:16:29.531Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>[detached HEAD 4972824] test commit while detached
+HEAD detached from d84ca28
+4972824 HEAD@{0}: commit: test commit while detached
+[rerun: b7]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-16-33-651Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-16-33-651Z" class="timestamp-link"><time datetime="2026-04-09T12:16:33.651Z" data-timestamp="2026-04-09T12:16:33.651Z">2026-04-09T12:16:33.651Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Good — so after making a commit in detached state, it becomes "HEAD detached from". Let me also check rebase state:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-16-33-730Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-16-33-730Z" class="timestamp-link"><time datetime="2026-04-09T12:16:33.730Z" data-timestamp="2026-04-09T12:16:33.730Z">2026-04-09T12:16:33.730Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01NqVFbsFF4mZoxn5zJFCjio">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git checkout d84ca28 &amp;&amp; git status -b 2&gt;&amp;1 | head -2</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-16-33-779Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-16-33-779Z" class="timestamp-link"><time datetime="2026-04-09T12:16:33.779Z" data-timestamp="2026-04-09T12:16:33.779Z">2026-04-09T12:16:33.779Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Warning: you are leaving 1 commit behind, not connected to
+any of your branches:
+
+  4972824 test commit while detached
+
+If you want to keep it by creating a new branch, this may be a good time
+to do so with:
+
+ git branch &lt;new-branch-name&gt; 4972824
+
+HEAD is now at d84ca28 fix: unmodified tracked files show no commit info after --changed-only was added (#43)
+HEAD detached at d84ca28
+Untracked files:
+[result-id: r17]
+[rerun: b8]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-16-37-615Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-16-37-615Z" class="timestamp-link"><time datetime="2026-04-09T12:16:37.615Z" data-timestamp="2026-04-09T12:16:37.615Z">2026-04-09T12:16:37.615Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_014jZYsNYBijXFjWYbgyzzmL">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git switch handle-non-branch &amp;&amp; git stash pop</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-16-37-683Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-16-37-683Z" class="timestamp-link"><time datetime="2026-04-09T12:16:37.683Z" data-timestamp="2026-04-09T12:16:37.683Z">2026-04-09T12:16:37.683Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Previous HEAD position was d84ca28 fix: unmodified tracked files show no commit info after --changed-only was added (#43)
+Switched to branch &#x27;handle-non-branch&#x27;
+On branch handle-non-branch
+Changes not staged for commit:
+  (use &quot;git add &lt;file&gt;...&quot; to update what will be committed)
+  (use &quot;git restore &lt;file&gt;...&quot; to discard changes in working directory)
+	modified:   main.go
+	modified:   main_test.go
+
+Untracked files:
+  (use &quot;git add &lt;file&gt;...&quot; to include in what will be committed)
+	.claude/
+
+no changes added to commit (use &quot;git add&quot; and/or &quot;git commit -a&quot;)
+Dropped refs/stash@{0} (c11a0ea9b5a0fd9ef33fb507e7f793048cddb49f)
+[result-id: r18]
+[rerun: b9]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-16-42-792Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-16-42-792Z" class="timestamp-link"><time datetime="2026-04-09T12:16:42.792Z" data-timestamp="2026-04-09T12:16:42.792Z">2026-04-09T12:16:42.792Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>OK, the simplest reliable approach: <code>git status -b</code> already computes exactly the right text. But that's a full status run and we already run porcelain status separately. The cleanest option is to replicate git's logic using the reflog approach. Let me now read the current state of the function and the display code to implement this properly.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-16-43-811Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-16-43-811Z" class="timestamp-link"><time datetime="2026-04-09T12:16:43.811Z" data-timestamp="2026-04-09T12:16:43.811Z">2026-04-09T12:16:43.811Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01PcgRBj2bdJ3dRxW3X6fptb"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main.go&#34;,
+  &#34;offset&#34;: 651,
+  &#34;limit&#34;: 20
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-16-43-818Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-16-43-818Z" class="timestamp-link"><time datetime="2026-04-09T12:16:43.818Z" data-timestamp="2026-04-09T12:16:43.818Z">2026-04-09T12:16:43.818Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>651		}
+652		return &quot;&quot;
+653	}
+654	
+655	// gitCurrentBranchSymbolic gets the current branch name using symbolic-ref.
+656	// This works in empty repos (no commits) where rev-parse would fail.
+657	// In detached HEAD state, falls back to &quot;HEAD detached at &lt;short-hash&gt;&quot;.
+658	func gitCurrentBranchSymbolic() string {
+659		cmd := exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;symbolic-ref&quot;, &quot;--short&quot;, &quot;HEAD&quot;)
+660		out, err := cmd.Output()
+661		if err != nil {
+662			// detached HEAD — fall back to short commit hash
+663			cmd = exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;rev-parse&quot;, &quot;--short&quot;, &quot;HEAD&quot;)
+664			out, err = cmd.Output()
+665			if err != nil {
+666				return &quot;unknown&quot;
+667			}
+668			return &quot;HEAD detached at &quot; + strings.TrimSpace(string(out))
+669		}
+670		return strings.TrimSpace(string(out))
+[result-id: r19]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-16-46-385Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-16-46-385Z" class="timestamp-link"><time datetime="2026-04-09T12:16:46.385Z" data-timestamp="2026-04-09T12:16:46.385Z">2026-04-09T12:16:46.385Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now let me look at what the display code currently does:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-16-46-900Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-16-46-900Z" class="timestamp-link"><time datetime="2026-04-09T12:16:46.900Z" data-timestamp="2026-04-09T12:16:46.900Z">2026-04-09T12:16:46.900Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_015pMmrfau4JsBuER5J2yXDV"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main.go&#34;,
+  &#34;offset&#34;: 441,
+  &#34;limit&#34;: 10
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-16-46-908Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-16-46-908Z" class="timestamp-link"><time datetime="2026-04-09T12:16:46.908Z" data-timestamp="2026-04-09T12:16:46.908Z">2026-04-09T12:16:46.908Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>441		if strings.HasPrefix(gitData.currentBranch, &quot;HEAD detached&quot;) {
+442			fmt.Printf(&quot;%s%s%s\n\n&quot;, RED, gitData.currentBranch, RESET)
+443		} else {
+444			fmt.Printf(&quot;On branch %s%s%s\n\n&quot;, RED, gitData.currentBranch, RESET)
+445		}
+446		rctx := &amp;RenderContext{
+447			GithubURL: isGithub(gitData.remotes),
+448			Dir:       must(filepath.Abs(&quot;.&quot;)),
+449			MonoHash:  monoHash,
+450			NerdFont:  nerdFont,
+[result-id: r20]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-16-51-519Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-16-51-519Z" class="timestamp-link"><time datetime="2026-04-09T12:16:51.519Z" data-timestamp="2026-04-09T12:16:51.519Z">2026-04-09T12:16:51.519Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now let me also check how git determines "at" vs "from" and the ref name. Looking at the C code again: it looks at the reflog to find the last switch, gets the ref we came from, then checks if HEAD still points at the same oid. Let me also check rebase state detection:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-16-52-317Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-16-52-317Z" class="timestamp-link"><time datetime="2026-04-09T12:16:52.317Z" data-timestamp="2026-04-09T12:16:52.317Z">2026-04-09T12:16:52.317Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_0126JK2TPiHFMn7ixfa3sCEc"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/git/wt-status.c&#34;,
+  &#34;offset&#34;: 1745,
+  &#34;limit&#34;: 80
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-16-52-329Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-16-52-329Z" class="timestamp-link"><time datetime="2026-04-09T12:16:52.329Z" data-timestamp="2026-04-09T12:16:52.329Z">2026-04-09T12:16:52.329Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>1745	int wt_status_check_rebase(const struct worktree *wt,
+1746				   struct wt_status_state *state)
+1747	{
+1748		struct stat st;
+1749	
+1750		if (!wt)
+1751			BUG(&quot;wt_status_check_rebase() called with NULL worktree&quot;);
+1752	
+1753		if (!stat(worktree_git_path(wt, &quot;rebase-apply&quot;), &amp;st)) {
+1754			if (!stat(worktree_git_path(wt, &quot;rebase-apply/applying&quot;), &amp;st)) {
+1755				state-&gt;am_in_progress = 1;
+1756				if (!stat(worktree_git_path(wt, &quot;rebase-apply/patch&quot;), &amp;st) &amp;&amp; !st.st_size)
+1757					state-&gt;am_empty_patch = 1;
+1758			} else {
+1759				state-&gt;rebase_in_progress = 1;
+1760				state-&gt;branch = get_branch(wt, &quot;rebase-apply/head-name&quot;);
+1761				state-&gt;onto = get_branch(wt, &quot;rebase-apply/onto&quot;);
+1762			}
+1763		} else if (!stat(worktree_git_path(wt, &quot;rebase-merge&quot;), &amp;st)) {
+1764			if (!stat(worktree_git_path(wt, &quot;rebase-merge/interactive&quot;), &amp;st))
+1765				state-&gt;rebase_interactive_in_progress = 1;
+1766			else
+1767				state-&gt;rebase_in_progress = 1;
+1768			state-&gt;branch = get_branch(wt, &quot;rebase-merge/head-name&quot;);
+1769			state-&gt;onto = get_branch(wt, &quot;rebase-merge/onto&quot;);
+1770		} else
+1771			return 0;
+1772		return 1;
+1773	}
+1774	
+1775	int wt_status_check_bisect(const struct worktree *wt,
+1776				   struct wt_status_state *state)
+1777	{
+1778		struct stat st;
+1779	
+1780		if (!wt)
+1781			BUG(&quot;wt_status_check_bisect() called with NULL worktree&quot;);
+1782	
+1783		if (!stat(worktree_git_path(wt, &quot;BISECT_LOG&quot;), &amp;st)) {
+1784			state-&gt;bisect_in_progress = 1;
+1785			state-&gt;bisecting_from = get_branch(wt, &quot;BISECT_START&quot;);
+1786			return 1;
+1787		}
+1788		return 0;
+1789	}
+1790	
+1791	static void wt_status_check_sparse_checkout(struct repository *r,
+1792						    struct wt_status_state *state)
+1793	{
+1794		int skip_worktree = 0;
+1795		int i;
+1796		struct repo_config_values *cfg = repo_config_values(the_repository);
+1797	
+1798		if (!cfg-&gt;apply_sparse_checkout ||
+1799		    r-&gt;index-&gt;cache_nr == 0) {
+1800			/*
+1801			 * Don&#x27;t compute percentage of checked out files if we
+1802			 * aren&#x27;t in a sparse checkout or would get division by 0.
+1803			 */
+1804			state-&gt;sparse_checkout_percentage = SPARSE_CHECKOUT_DISABLED;
+1805			return;
+1806		}
+1807	
+1808		if (r-&gt;index-&gt;sparse_index) {
+1809			state-&gt;sparse_checkout_percentage = SPARSE_CHECKOUT_SPARSE_INDEX;
+1810			return;
+1811		}
+1812	
+1813		for (i = 0; i &lt; r-&gt;index-&gt;cache_nr; i++) {
+1814			struct cache_entry *ce = r-&gt;index-&gt;cache[i];
+1815			if (ce_skip_worktree(ce))
+1816				skip_worktree++;
+1817		}
+1818	
+1819		state-&gt;sparse_checkout_percentage =
+1820			100 - (100 * skip_worktree)/r-&gt;index-&gt;cache_nr;
+1821	}
+1822	
+1823	void wt_status_get_state(struct repository *r,
+1824				 struct wt_status_state *state,
+[result-id: r21]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-17-04-680Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-17-04-680Z" class="timestamp-link"><time datetime="2026-04-09T12:17:04.680Z" data-timestamp="2026-04-09T12:17:04.680Z">2026-04-09T12:17:04.680Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Good. Now I have the full picture. Let me implement this. The key states are:</p>
+<ol>
+<li><strong>On branch X</strong> — <code>symbolic-ref</code> succeeds</li>
+<li><strong>HEAD detached at X</strong> — detached, HEAD hasn't moved from where we detached</li>
+<li><strong>HEAD detached from X</strong> — detached, HEAD has moved (e.g. made commits)</li>
+<li><strong>rebase in progress; onto X</strong> — <code>.git/rebase-apply</code> exists (non-interactive)</li>
+<li><strong>interactive rebase in progress; onto X</strong> — <code>.git/rebase-merge</code> exists</li>
+<li><strong>Not currently on any branch.</strong> — fallback</li>
+</ol>
+<p>For "at" vs "from", git checks the reflog to find what ref/commit we detached at, then compares current HEAD to that oid. For the ref name, it tries to resolve the reflog entry to a tag or remote branch name, falling back to a short hash.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-17-05-716Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-17-05-716Z" class="timestamp-link"><time datetime="2026-04-09T12:17:05.716Z" data-timestamp="2026-04-09T12:17:05.716Z">2026-04-09T12:17:05.716Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_011kB8RC7VgYyHxkrUmmbhuP"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main.go&#34;,
+  &#34;offset&#34;: 130,
+  &#34;limit&#34;: 10
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-17-05-722Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-17-05-722Z" class="timestamp-link"><time datetime="2026-04-09T12:17:05.722Z" data-timestamp="2026-04-09T12:17:05.722Z">2026-04-09T12:17:05.722Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>130		root          string
+131		status        []byte
+132		diffStat      []byte
+133		currentBranch string
+134		remotes       []byte
+135		isEmpty       bool // true if repo has no commits yet
+136	}
+137	
+138	// isEmptyRepo checks if the repository has no commits yet by verifying if HEAD
+139	// exists. If it doesn&#x27;t, this could mean:
+[result-id: r22]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-17-09-438Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-17-09-438Z" class="timestamp-link"><time datetime="2026-04-09T12:17:09.438Z" data-timestamp="2026-04-09T12:17:09.438Z">2026-04-09T12:17:09.438Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now let me check if we have access to <code>gitRoot</code> to find <code>.git</code> dir:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-17-10-436Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-17-10-436Z" class="timestamp-link"><time datetime="2026-04-09T12:17:10.436Z" data-timestamp="2026-04-09T12:17:10.436Z">2026-04-09T12:17:10.436Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_019qT1PbQb9fshvC1FmekCgd"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;func gitRoot&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main.go&#34;,
+  &#34;-A&#34;: 8
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-17-10-457Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-17-10-457Z" class="timestamp-link"><time datetime="2026-04-09T12:17:10.457Z" data-timestamp="2026-04-09T12:17:10.457Z">2026-04-09T12:17:10.457Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>674:func gitRoot() string {
+675-	cmd := exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;rev-parse&quot;, &quot;--show-toplevel&quot;)
+676-	out, err := cmd.Output()
+677-	if err != nil {
+678-		log.Fatalf(&quot;Failed to get git status: %v&quot;, err)
+679-	}
+680-	return strings.TrimSpace(string(out))
+681-}
+682-
+[result-id: r23]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-17-14-099Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-17-14-099Z" class="timestamp-link"><time datetime="2026-04-09T12:17:14.099Z" data-timestamp="2026-04-09T12:17:14.099Z">2026-04-09T12:17:14.099Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now let me also check the <code>bytes</code> and <code>path/filepath</code> imports, and see what's already imported:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-17-14-643Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-17-14-643Z" class="timestamp-link"><time datetime="2026-04-09T12:17:14.643Z" data-timestamp="2026-04-09T12:17:14.643Z">2026-04-09T12:17:14.643Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01RaF42wHELRNHEzpy9MXkM7"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main.go&#34;,
+  &#34;limit&#34;: 25
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-17-14-652Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-17-14-652Z" class="timestamp-link"><time datetime="2026-04-09T12:17:14.652Z" data-timestamp="2026-04-09T12:17:14.652Z">2026-04-09T12:17:14.652Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>1	package main
+2	
+3	import (
+4		&quot;bufio&quot;
+5		&quot;fmt&quot;
+6		&quot;io&quot;
+7		&quot;log&quot;
+8		&quot;os&quot;
+9		&quot;os/exec&quot;
+10		&quot;path/filepath&quot;
+11		&quot;regexp&quot;
+12		&quot;runtime/debug&quot;
+13		&quot;slices&quot;
+14		&quot;strconv&quot;
+15		&quot;strings&quot;
+16		&quot;sync&quot;
+17		&quot;syscall&quot;
+18		&quot;unsafe&quot;
+19	
+20		&quot;github.com/mattn/go-runewidth&quot;
+21	)
+22	
+23	const VERSION = &quot;5.8.0&quot;
+24	
+25	// HistoryLimit is the maximum number of commits to review; we&#x27;ll exit if we
+[result-id: r24]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-17-20-396Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-17-20-396Z" class="timestamp-link"><time datetime="2026-04-09T12:17:20.396Z" data-timestamp="2026-04-09T12:17:20.396Z">2026-04-09T12:17:20.396Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now let me implement the full logic. I'll replace <code>gitCurrentBranchSymbolic</code> with a more complete function that mirrors git's behavior:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-17-44-004Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-17-44-004Z" class="timestamp-link"><time datetime="2026-04-09T12:17:44.004Z" data-timestamp="2026-04-09T12:17:44.004Z">2026-04-09T12:17:44.004Z</time></a></div><div class="message-content"><div class="file-tool edit-tool" data-tool-id="toolu_01CAYiMb1EtNLHZZwN9xdftd">
+<div class="file-tool-header edit-header"><span class="file-tool-icon">✏️</span> Edit <span class="file-tool-path">main.go</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/handle-non-branch/main.go</div>
+<div class="truncatable"><div class="truncatable-content">
+<div class="edit-section edit-old"><div class="edit-label">−</div><pre class="edit-content">// gitCurrentBranchSymbolic gets the current branch name using symbolic-ref.
+// This works in empty repos (no commits) where rev-parse would fail.
+// In detached HEAD state, falls back to &#34;HEAD detached at &lt;short-hash&gt;&#34;.
+func gitCurrentBranchSymbolic() string {
+	cmd := exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;, &#34;symbolic-ref&#34;, &#34;--short&#34;, &#34;HEAD&#34;)
+	out, err := cmd.Output()
+	if err != nil {
+		// detached HEAD — fall back to short commit hash
+		cmd = exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;, &#34;rev-parse&#34;, &#34;--short&#34;, &#34;HEAD&#34;)
+		out, err = cmd.Output()
+		if err != nil {
+			return &#34;unknown&#34;
+		}
+		return &#34;HEAD detached at &#34; + strings.TrimSpace(string(out))
+	}
+	return strings.TrimSpace(string(out))
+}</pre></div>
+<div class="edit-section edit-new"><div class="edit-label">+</div><pre class="edit-content">// headDescription returns a string describing the current HEAD state,
+// matching git-status output: &#34;On branch X&#34;, &#34;HEAD detached at X&#34;,
+// &#34;HEAD detached from X&#34;, or rebase-in-progress messages.
+// The returned string includes the prefix (e.g. &#34;On branch &#34;).
+func headDescription() string {
+	// Try symbolic-ref first — if it works, we&#39;re on a branch
+	cmd := exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;, &#34;symbolic-ref&#34;, &#34;--short&#34;, &#34;HEAD&#34;)
+	out, err := cmd.Output()
+	if err == nil {
+		return &#34;On branch &#34; + strings.TrimSpace(string(out))
+	}
+
+	// We&#39;re in detached HEAD state. Check for rebase.
+	gitDir := gitCommonDir()
+	if desc := rebaseDescription(gitDir); desc != &#34;&#34; {
+		return desc
+	}
+
+	// Determine &#34;detached at&#34; vs &#34;detached from&#34; by comparing HEAD to the
+	// commit we originally detached at (found via reflog).
+	return detachedDescription()
+}
+
+// gitCommonDir returns the path to the git common dir (handles worktrees).
+func gitCommonDir() string {
+	cmd := exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;, &#34;rev-parse&#34;, &#34;--git-common-dir&#34;)
+	out, err := cmd.Output()
+	if err != nil {
+		return &#34;.git&#34;
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// rebaseDescription checks for an in-progress rebase and returns the
+// appropriate status string, or &#34;&#34; if no rebase is active.
+func rebaseDescription(gitDir string) string {
+	ontoBytes, err := os.ReadFile(filepath.Join(gitDir, &#34;rebase-merge&#34;, &#34;onto&#34;))
+	if err == nil {
+		onto := strings.TrimSpace(string(ontoBytes))
+		onto = shortOid(onto)
+		if _, err := os.Stat(filepath.Join(gitDir, &#34;rebase-merge&#34;, &#34;interactive&#34;)); err == nil {
+			return &#34;interactive rebase in progress; onto &#34; + onto
+		}
+		return &#34;rebase in progress; onto &#34; + onto
+	}
+	ontoBytes, err = os.ReadFile(filepath.Join(gitDir, &#34;rebase-apply&#34;, &#34;onto&#34;))
+	if err == nil {
+		onto := strings.TrimSpace(string(ontoBytes))
+		onto = shortOid(onto)
+		return &#34;rebase in progress; onto &#34; + onto
+	}
+	return &#34;&#34;
+}
+
+// shortOid abbreviates a full hex oid via rev-parse --short.
+func shortOid(oid string) string {
+	cmd := exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;, &#34;rev-parse&#34;, &#34;--short&#34;, oid)
+	out, err := cmd.Output()
+	if err != nil {
+		return oid
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// detachedDescription returns &#34;HEAD detached at X&#34; or &#34;HEAD detached from X&#34;
+// by inspecting the reflog, mirroring git-status behavior.
+func detachedDescription() string {
+	// Get the oid that HEAD pointed to when we detached (last reflog switch)
+	cmd := exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;, &#34;reflog&#34;, &#34;-1&#34;, &#34;--format=%H&#34;, &#34;HEAD&#34;)
+	reflogOut, err := cmd.Output()
+	if err != nil {
+		return &#34;Not currently on any branch.&#34;
+	}
+	detachedOid := strings.TrimSpace(string(reflogOut))
+	if detachedOid == &#34;&#34; {
+		return &#34;Not currently on any branch.&#34;
+	}
+
+	// Get current HEAD oid
+	cmd = exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;, &#34;rev-parse&#34;, &#34;HEAD&#34;)
+	headOut, err := cmd.Output()
+	if err != nil {
+		return &#34;Not currently on any branch.&#34;
+	}
+	headOid := strings.TrimSpace(string(headOut))
+
+	atOrFrom := &#34;at&#34;
+	if headOid != detachedOid {
+		atOrFrom = &#34;from&#34;
+	}
+
+	// Try to find a friendly name (tag or branch) that points at detachedOid
+	name := friendlyRefName(detachedOid)
+
+	return &#34;HEAD detached &#34; + atOrFrom + &#34; &#34; + name
+}
+
+// friendlyRefName tries to describe an oid with a tag or branch name.
+// Falls back to the short hash.
+func friendlyRefName(oid string) string {
+	// Try describe --tags --exact-match first for tags
+	cmd := exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;, &#34;describe&#34;, &#34;--tags&#34;, &#34;--exact-match&#34;, oid)
+	out, err := cmd.Output()
+	if err == nil {
+		return strings.TrimSpace(string(out))
+	}
+	// Try branch name via name-rev
+	cmd = exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;, &#34;name-rev&#34;, &#34;--name-only&#34;, &#34;--no-undefined&#34;, &#34;--refs=refs/heads/*&#34;, oid)
+	out, err = cmd.Output()
+	if err == nil {
+		name := strings.TrimSpace(string(out))
+		if name != &#34;&#34; &amp;&amp; !strings.Contains(name, &#34;~&#34;) &amp;&amp; !strings.Contains(name, &#34;^&#34;) {
+			return name
+		}
+	}
+	return shortOid(oid)
+}</pre></div>
+</div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-17-44-028Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-17-44-028Z" class="timestamp-link"><time datetime="2026-04-09T12:17:44.028Z" data-timestamp="2026-04-09T12:17:44.028Z">2026-04-09T12:17:44.028Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/handle-non-branch/main.go has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-17-47-809Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-17-47-809Z" class="timestamp-link"><time datetime="2026-04-09T12:17:47.809Z" data-timestamp="2026-04-09T12:17:47.809Z">2026-04-09T12:17:47.809Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now update the call site and the display code — since the description now includes the prefix, the display logic can be simplified:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-17-49-287Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-17-49-287Z" class="timestamp-link"><time datetime="2026-04-09T12:17:49.287Z" data-timestamp="2026-04-09T12:17:49.287Z">2026-04-09T12:17:49.287Z</time></a></div><div class="message-content"><div class="file-tool edit-tool" data-tool-id="toolu_01YZEsqAhGhoWEc2Fax8qJpQ">
+<div class="file-tool-header edit-header"><span class="file-tool-icon">✏️</span> Edit <span class="file-tool-path">main.go</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/handle-non-branch/main.go</div>
+<div class="truncatable"><div class="truncatable-content">
+<div class="edit-section edit-old"><div class="edit-label">−</div><pre class="edit-content">		results.currentBranch = gitCurrentBranchSymbolic()</pre></div>
+<div class="edit-section edit-new"><div class="edit-label">+</div><pre class="edit-content">		results.currentBranch = headDescription()</pre></div>
+</div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-17-49-303Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-17-49-303Z" class="timestamp-link"><time datetime="2026-04-09T12:17:49.303Z" data-timestamp="2026-04-09T12:17:49.303Z">2026-04-09T12:17:49.303Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/handle-non-branch/main.go has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-17-53-708Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-17-53-708Z" class="timestamp-link"><time datetime="2026-04-09T12:17:53.708Z" data-timestamp="2026-04-09T12:17:53.708Z">2026-04-09T12:17:53.708Z</time></a></div><div class="message-content"><div class="file-tool edit-tool" data-tool-id="toolu_01988fvo38ZhSpC9iKz82APm">
+<div class="file-tool-header edit-header"><span class="file-tool-icon">✏️</span> Edit <span class="file-tool-path">main.go</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/handle-non-branch/main.go</div>
+<div class="truncatable"><div class="truncatable-content">
+<div class="edit-section edit-old"><div class="edit-label">−</div><pre class="edit-content">	if strings.HasPrefix(gitData.currentBranch, &#34;HEAD detached&#34;) {
+		fmt.Printf(&#34;%s%s%s\n\n&#34;, RED, gitData.currentBranch, RESET)
+	} else {
+		fmt.Printf(&#34;On branch %s%s%s\n\n&#34;, RED, gitData.currentBranch, RESET)
+	}</pre></div>
+<div class="edit-section edit-new"><div class="edit-label">+</div><pre class="edit-content">	fmt.Printf(&#34;%s%s%s\n\n&#34;, RED, gitData.currentBranch, RESET)</pre></div>
+</div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-17-53-731Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-17-53-731Z" class="timestamp-link"><time datetime="2026-04-09T12:17:53.731Z" data-timestamp="2026-04-09T12:17:53.731Z">2026-04-09T12:17:53.731Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/handle-non-branch/main.go has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-17-56-710Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-17-56-710Z" class="timestamp-link"><time datetime="2026-04-09T12:17:56.710Z" data-timestamp="2026-04-09T12:17:56.710Z">2026-04-09T12:17:56.710Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01KgJdBX3GqChREMR72D2mM3">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go build -o /tmp/git-ls-test . 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-17-56-925Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-17-56-925Z" class="timestamp-link"><time datetime="2026-04-09T12:17:56.925Z" data-timestamp="2026-04-09T12:17:56.925Z">2026-04-09T12:17:56.925Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>[rerun: b10]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-18-00-017Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-18-00-017Z" class="timestamp-link"><time datetime="2026-04-09T12:18:00.017Z" data-timestamp="2026-04-09T12:18:00.017Z">2026-04-09T12:18:00.017Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now let me test all the states:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-18-00-297Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-18-00-297Z" class="timestamp-link"><time datetime="2026-04-09T12:18:00.297Z" data-timestamp="2026-04-09T12:18:00.297Z">2026-04-09T12:18:00.297Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_016YrS9dpGpFjDVRgxwrhZZ1">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">echo &#34;=== On branch ===&#34; &amp;&amp; /tmp/git-ls-test 2&gt;&amp;1 | head -1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-18-00-739Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-18-00-739Z" class="timestamp-link"><time datetime="2026-04-09T12:18:00.739Z" data-timestamp="2026-04-09T12:18:00.739Z">2026-04-09T12:18:00.739Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>=== On branch ===
+[31mOn branch handle-non-branch[0m
+[rerun: b11]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-18-05-969Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-18-05-969Z" class="timestamp-link"><time datetime="2026-04-09T12:18:05.969Z" data-timestamp="2026-04-09T12:18:05.969Z">2026-04-09T12:18:05.969Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01N9j8kRjXZtH3fkpmjTdPKu">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git stash &amp;&amp; git checkout --detach HEAD~1 &amp;&amp; echo &#34;=== Detached at ===&#34; &amp;&amp; /tmp/git-ls-test 2&gt;&amp;1 | head -1 &amp;&amp; git commit --allow-empty -m &#34;test&#34; &amp;&amp; echo &#34;=== Detached from ===&#34; &amp;&amp; /tmp/git-ls-test 2&gt;&amp;1 | head -1 &amp;&amp; git checkout d84ca28 &amp;&amp; git switch handle-non-branch &amp;&amp; git stash pop</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T12-18-06-252Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T12-18-06-252Z" class="timestamp-link"><time datetime="2026-04-09T12:18:06.252Z" data-timestamp="2026-04-09T12:18:06.252Z">2026-04-09T12:18:06.252Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Saved working directory and index state WIP on handle-non-branch: 84a45fb chore: bump version to 5.8.0
+HEAD is now at d84ca28 fix: unmodified tracked files show no commit info after --changed-only was added (#43)
+=== Detached at ===
+[31mHEAD detached at d84ca28[0m
+[detached HEAD 5199811] test
+=== Detached from ===
+[31mHEAD detached at 5199811[0m
+Warning: you are leaving 1 commit behind, not connected to
+any of your branches:
+
+  5199811 test
+
+If you want to keep it by creating a new branch, this may be a good time
+to do so with:
+
+ git branch &lt;new-branch-name&gt; 5199811
+
+HEAD is now at d84ca28 fix: unmodified tracked files show no commit info after --changed-only was added (#43)
+Previous HEAD position was d84ca28 fix: unmodified tracked files show no commit info after --changed-only was added (#43)
+Switched to branch &#x27;handle-non-branch&#x27;
+On branch handle-non-branch
+Changes not staged for commit:
+  (use &quot;git add &lt;file&gt;...&quot; to update what will be committed)
+  (use &quot;git restore &lt;file&gt;...&quot; to discard changes in working directory)
+	modified:   main.go
+	modified:   main_test.go
+
+Untracked files:
+  (use &quot;git add &lt;file&gt;...&quot; to include in what will be committed)
+	.claude/
+
+no changes added to commit (use &quot;git add&quot; and/or &quot;git commit -a&quot;)
+Dropped refs/stash@{0} (b37b988decd661c503cc70de580125a9900e3086)
+[result-id: r25]
+[rerun: b12]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-18-10-980Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-18-10-980Z" class="timestamp-link"><time datetime="2026-04-09T12:18:10.980Z" data-timestamp="2026-04-09T12:18:10.980Z">2026-04-09T12:18:10.980Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Hmm, "detached from" showed "at 5199811" instead. The issue is that <code>reflog -1 HEAD</code> returns the last reflog entry, which after a commit is the commit itself, not the original detach point. I need to look further back in the reflog for the checkout/switch entry. Let me fix this:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T12-18-11-695Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T12-18-11-695Z" class="timestamp-link"><time datetime="2026-04-09T12:18:11.695Z" data-timestamp="2026-04-09T12:18:11.695Z">2026-04-09T12:18:11.695Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01BNAhZakBCsdeYZD8xGP1MB">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git stash &amp;&amp; git checkout --detach HEAD~1 &amp;&amp; git commit --allow-empty -m &#34;test&#34; &amp;&amp; git reflog --format=&#34;%H %gs&#34; HEAD 2&gt;&amp;1 | head -5</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T13-19-48-671Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T13-19-48-671Z" class="timestamp-link"><time datetime="2026-04-09T13:19:48.671Z" data-timestamp="2026-04-09T13:19:48.671Z">2026-04-09T13:19:48.671Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Saved working directory and index state WIP on handle-non-branch: 84a45fb chore: bump version to 5.8.0
+HEAD is now at d84ca28 fix: unmodified tracked files show no commit info after --changed-only was added (#43)
+[detached HEAD da44250] test
+da44250ecb3fab6575c41c75f59932e55bbfd5b2 commit: test
+d84ca28b7bfa7875b2d90d6579e66da606fa2de3 checkout: moving from handle-non-branch to HEAD~1
+84a45fbfea57d4968a60965a6cec76790aaeea10 reset: moving to HEAD
+84a45fbfea57d4968a60965a6cec76790aaeea10 checkout: moving from d84ca28b7bfa7875b2d90d6579e66da606fa2de3 to handle-non-branch
+d84ca28b7bfa7875b2d90d6579e66da606fa2de3 checkout: moving from 5199811adf805d7d870041250dba33a75da74884 to d84ca28
+[result-id: r26]
+[rerun: b13]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-19-54-749Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-19-54-749Z" class="timestamp-link"><time datetime="2026-04-09T13:19:54.749Z" data-timestamp="2026-04-09T13:19:54.749Z">2026-04-09T13:19:54.749Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>I see — the reflog approach needs to find the checkout entry specifically. Let me look at how git does it more carefully. The <code>grab_1st_switch</code> callback in git walks the reflog backwards looking for the first checkout entry, and uses its "old" oid as the detach point.</p>
+<p>The simpler approach: I should find the reflog entry where we switched/checked out, and use <em>that</em> entry's oid to compare against current HEAD.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-19-55-445Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-19-55-445Z" class="timestamp-link"><time datetime="2026-04-09T13:19:55.445Z" data-timestamp="2026-04-09T13:19:55.445Z">2026-04-09T13:19:55.445Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01UkpTUD579KgKpRibtCXbh1">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git reflog --format=&#34;%H %gD %gs&#34; HEAD 2&gt;&amp;1 | grep &#34;checkout:&#34; | head -1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T13-19-55-497Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T13-19-55-497Z" class="timestamp-link"><time datetime="2026-04-09T13:19:55.497Z" data-timestamp="2026-04-09T13:19:55.497Z">2026-04-09T13:19:55.497Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>d84ca28b7bfa7875b2d90d6579e66da606fa2de3 HEAD@{1} checkout: moving from handle-non-branch to HEAD~1
+[rerun: b14]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-19-58-984Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-19-58-984Z" class="timestamp-link"><time datetime="2026-04-09T13:19:58.984Z" data-timestamp="2026-04-09T13:19:58.984Z">2026-04-09T13:19:58.984Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>So the detach point oid is <code>d84ca28</code> and current HEAD is <code>da44250</code> — they differ, so it should be "from". Let me fix the <code>detachedDescription</code> function:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-20-11-037Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-20-11-037Z" class="timestamp-link"><time datetime="2026-04-09T13:20:11.037Z" data-timestamp="2026-04-09T13:20:11.037Z">2026-04-09T13:20:11.037Z</time></a></div><div class="message-content"><div class="file-tool edit-tool" data-tool-id="toolu_01U4x86WXbUA5npxUo9BkRXv">
+<div class="file-tool-header edit-header"><span class="file-tool-icon">✏️</span> Edit <span class="file-tool-path">main.go</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/handle-non-branch/main.go</div>
+<div class="truncatable"><div class="truncatable-content">
+<div class="edit-section edit-old"><div class="edit-label">−</div><pre class="edit-content">// detachedDescription returns &#34;HEAD detached at X&#34; or &#34;HEAD detached from X&#34;
+// by inspecting the reflog, mirroring git-status behavior.
+func detachedDescription() string {
+	// Get the oid that HEAD pointed to when we detached (last reflog switch)
+	cmd := exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;, &#34;reflog&#34;, &#34;-1&#34;, &#34;--format=%H&#34;, &#34;HEAD&#34;)
+	reflogOut, err := cmd.Output()
+	if err != nil {
+		return &#34;Not currently on any branch.&#34;
+	}
+	detachedOid := strings.TrimSpace(string(reflogOut))
+	if detachedOid == &#34;&#34; {
+		return &#34;Not currently on any branch.&#34;
+	}
+
+	// Get current HEAD oid
+	cmd = exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;, &#34;rev-parse&#34;, &#34;HEAD&#34;)
+	headOut, err := cmd.Output()
+	if err != nil {
+		return &#34;Not currently on any branch.&#34;
+	}
+	headOid := strings.TrimSpace(string(headOut))
+
+	atOrFrom := &#34;at&#34;
+	if headOid != detachedOid {
+		atOrFrom = &#34;from&#34;
+	}
+
+	// Try to find a friendly name (tag or branch) that points at detachedOid
+	name := friendlyRefName(detachedOid)
+
+	return &#34;HEAD detached &#34; + atOrFrom + &#34; &#34; + name
+}</pre></div>
+<div class="edit-section edit-new"><div class="edit-label">+</div><pre class="edit-content">// detachedDescription returns &#34;HEAD detached at X&#34; or &#34;HEAD detached from X&#34;
+// by inspecting the reflog, mirroring git-status behavior.
+func detachedDescription() string {
+	// Walk the reflog to find the checkout/switch entry where we detached.
+	// That entry&#39;s oid is the commit we originally landed on.
+	cmd := exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;,
+		&#34;reflog&#34;, &#34;--format=%H %gs&#34;, &#34;HEAD&#34;)
+	reflogOut, err := cmd.Output()
+	if err != nil {
+		return &#34;Not currently on any branch.&#34;
+	}
+
+	var detachedOid string
+	for _, line := range strings.Split(strings.TrimSpace(string(reflogOut)), &#34;\n&#34;) {
+		if strings.Contains(line, &#34;checkout: &#34;) || strings.Contains(line, &#34;switch: &#34;) {
+			detachedOid, _, _ = strings.Cut(line, &#34; &#34;)
+			break
+		}
+	}
+	if detachedOid == &#34;&#34; {
+		return &#34;Not currently on any branch.&#34;
+	}
+
+	// Get current HEAD oid
+	cmd = exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;, &#34;rev-parse&#34;, &#34;HEAD&#34;)
+	headOut, err := cmd.Output()
+	if err != nil {
+		return &#34;Not currently on any branch.&#34;
+	}
+	headOid := strings.TrimSpace(string(headOut))
+
+	atOrFrom := &#34;at&#34;
+	if headOid != detachedOid {
+		atOrFrom = &#34;from&#34;
+	}
+
+	// Try to find a friendly name (tag or branch) that points at detachedOid
+	name := friendlyRefName(detachedOid)
+
+	return &#34;HEAD detached &#34; + atOrFrom + &#34; &#34; + name
+}</pre></div>
+</div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T13-20-11-051Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T13-20-11-051Z" class="timestamp-link"><time datetime="2026-04-09T13:20:11.051Z" data-timestamp="2026-04-09T13:20:11.051Z">2026-04-09T13:20:11.051Z</time></a></div><div class="message-content"><div class="tool-result tool-error"><div class="truncatable"><div class="truncatable-content"><pre>&lt;tool_use_error&gt;String to replace not found in file.
+String: // detachedDescription returns &quot;HEAD detached at X&quot; or &quot;HEAD detached from X&quot;
+// by inspecting the reflog, mirroring git-status behavior.
+func detachedDescription() string {
+	// Get the oid that HEAD pointed to when we detached (last reflog switch)
+	cmd := exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;reflog&quot;, &quot;-1&quot;, &quot;--format=%H&quot;, &quot;HEAD&quot;)
+	reflogOut, err := cmd.Output()
+	if err != nil {
+		return &quot;Not currently on any branch.&quot;
+	}
+	detachedOid := strings.TrimSpace(string(reflogOut))
+	if detachedOid == &quot;&quot; {
+		return &quot;Not currently on any branch.&quot;
+	}
+
+	// Get current HEAD oid
+	cmd = exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;rev-parse&quot;, &quot;HEAD&quot;)
+	headOut, err := cmd.Output()
+	if err != nil {
+		return &quot;Not currently on any branch.&quot;
+	}
+	headOid := strings.TrimSpace(string(headOut))
+
+	atOrFrom := &quot;at&quot;
+	if headOid != detachedOid {
+		atOrFrom = &quot;from&quot;
+	}
+
+	// Try to find a friendly name (tag or branch) that points at detachedOid
+	name := friendlyRefName(detachedOid)
+
+	return &quot;HEAD detached &quot; + atOrFrom + &quot; &quot; + name
+}&lt;/tool_use_error&gt;</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-20-16-374Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-20-16-374Z" class="timestamp-link"><time datetime="2026-04-09T13:20:16.374Z" data-timestamp="2026-04-09T13:20:16.374Z">2026-04-09T13:20:16.374Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>The file was reverted by a linter/formatter. Let me re-read the current state:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-20-17-872Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-20-17-872Z" class="timestamp-link"><time datetime="2026-04-09T13:20:17.872Z" data-timestamp="2026-04-09T13:20:17.872Z">2026-04-09T13:20:17.872Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_014MwfkbyrmrSFZetSU1jP1i"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main.go&#34;,
+  &#34;offset&#34;: 650,
+  &#34;limit&#34;: 20
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T13-20-17-881Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T13-20-17-881Z" class="timestamp-link"><time datetime="2026-04-09T13:20:17.881Z" data-timestamp="2026-04-09T13:20:17.881Z">2026-04-09T13:20:17.881Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>650	
+651	// gitCurrentBranchSymbolic gets the current branch name using symbolic-ref.
+652	// This works in empty repos (no commits) where rev-parse would fail.
+653	func gitCurrentBranchSymbolic() string {
+654		cmd := exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;symbolic-ref&quot;, &quot;--short&quot;, &quot;HEAD&quot;)
+655		out, err := cmd.Output()
+656		if err != nil {
+657			log.Fatalf(&quot;Failed to get current branch: %v&quot;, err)
+658		}
+659		return strings.TrimSpace(string(out))
+660	}
+661	
+662	// gitRoot returns the root directory of the git repository
+663	func gitRoot() string {
+664		cmd := exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;rev-parse&quot;, &quot;--show-toplevel&quot;)
+665		out, err := cmd.Output()
+666		if err != nil {
+667			log.Fatalf(&quot;Failed to get git status: %v&quot;, err)
+668		}
+669		return strings.TrimSpace(string(out))
+[result-id: r27]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-20-20-328Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-20-20-328Z" class="timestamp-link"><time datetime="2026-04-09T13:20:20.328Z" data-timestamp="2026-04-09T13:20:20.328Z">2026-04-09T13:20:20.328Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>The file was fully reverted. Let me check the display line too:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-20-20-967Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-20-20-967Z" class="timestamp-link"><time datetime="2026-04-09T13:20:20.967Z" data-timestamp="2026-04-09T13:20:20.967Z">2026-04-09T13:20:20.967Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_016RW84RqoV1RtHWgthJFcHZ"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main.go&#34;,
+  &#34;offset&#34;: 440,
+  &#34;limit&#34;: 3
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T13-20-20-984Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T13-20-20-984Z" class="timestamp-link"><time datetime="2026-04-09T13:20:20.984Z" data-timestamp="2026-04-09T13:20:20.984Z">2026-04-09T13:20:20.984Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>440		}
+441		fmt.Printf(&quot;On branch %s%s%s\n\n&quot;, RED, gitData.currentBranch, RESET)
+442		rctx := &amp;RenderContext{</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-20-24-424Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-20-24-424Z" class="timestamp-link"><time datetime="2026-04-09T13:20:24.424Z" data-timestamp="2026-04-09T13:20:24.424Z">2026-04-09T13:20:24.424Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>OK, the file was fully reverted (version changed back to 5.7.0 and all my changes gone). Let me also clean up the detached state and reapply everything from scratch:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-20-25-810Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-20-25-810Z" class="timestamp-link"><time datetime="2026-04-09T13:20:25.810Z" data-timestamp="2026-04-09T13:20:25.810Z">2026-04-09T13:20:25.810Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01WqMC9R5sHMNtvsVEfmDyH9">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git switch handle-non-branch 2&gt;&amp;1; git stash pop 2&gt;&amp;1; echo &#34;---&#34;; git status --short 2&gt;&amp;1 | head -5</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T13-20-25-895Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T13-20-25-895Z" class="timestamp-link"><time datetime="2026-04-09T13:20:25.895Z" data-timestamp="2026-04-09T13:20:25.895Z">2026-04-09T13:20:25.895Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Warning: you are leaving 1 commit behind, not connected to
+any of your branches:
+
+  da44250 test
+
+If you want to keep it by creating a new branch, this may be a good time
+to do so with:
+
+ git branch &lt;new-branch-name&gt; da44250
+
+Switched to branch &#x27;handle-non-branch&#x27;
+On branch handle-non-branch
+Changes not staged for commit:
+  (use &quot;git add &lt;file&gt;...&quot; to update what will be committed)
+  (use &quot;git restore &lt;file&gt;...&quot; to discard changes in working directory)
+	modified:   main.go
+	modified:   main_test.go
+
+Untracked files:
+  (use &quot;git add &lt;file&gt;...&quot; to include in what will be committed)
+	.claude/
+
+no changes added to commit (use &quot;git add&quot; and/or &quot;git commit -a&quot;)
+Dropped refs/stash@{0} (d4419fe3907942b4ac7117bc3170e23acd9ac714)
+---
+ M main.go
+ M main_test.go
+?? .claude/
+[result-id: r28]
+[rerun: b15]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-20-29-646Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-20-29-646Z" class="timestamp-link"><time datetime="2026-04-09T13:20:29.646Z" data-timestamp="2026-04-09T13:20:29.646Z">2026-04-09T13:20:29.646Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Good, I'm back on the branch. But the file still has local modifications from the linter revert. Let me check what version is in the file vs what we want:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-20-30-080Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-20-30-080Z" class="timestamp-link"><time datetime="2026-04-09T13:20:30.080Z" data-timestamp="2026-04-09T13:20:30.080Z">2026-04-09T13:20:30.080Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01GAZxZRqfZwbKbxydcYrqD5">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git diff main.go | head -40</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T13-20-30-133Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T13-20-30-133Z" class="timestamp-link"><time datetime="2026-04-09T13:20:30.133Z" data-timestamp="2026-04-09T13:20:30.133Z">2026-04-09T13:20:30.133Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>diff --git i/main.go w/main.go
+index ade6ee7..93cb3aa 100644
+--- i/main.go
++++ w/main.go
+@@ -171,7 +171,7 @@ func fetchGitData() *gitResults {
+ 	})
+ 
+ 	wg.Go(func() {
+-		results.currentBranch = gitCurrentBranchSymbolic()
++		results.currentBranch = headDescription()
+ 	})
+ 
+ 	wg.Go(func() {
+@@ -438,7 +438,7 @@ func main() {
+ 	if maxWidth == 0 {
+ 		maxWidth = 80 // default when not a TTY
+ 	}
+-	fmt.Printf(&quot;On branch %s%s%s\n\n&quot;, RED, gitData.currentBranch, RESET)
++	fmt.Printf(&quot;%s%s%s\n\n&quot;, RED, gitData.currentBranch, RESET)
+ 	rctx := &amp;RenderContext{
+ 		GithubURL: isGithub(gitData.remotes),
+ 		Dir:       must(filepath.Abs(&quot;.&quot;)),
+@@ -648,17 +648,124 @@ func isGithub(out []byte) string {
+ 	return &quot;&quot;
+ }
+ 
+-// gitCurrentBranchSymbolic gets the current branch name using symbolic-ref.
+-// This works in empty repos (no commits) where rev-parse would fail.
+-func gitCurrentBranchSymbolic() string {
++// headDescription returns a string describing the current HEAD state,
++// matching git-status output: &quot;On branch X&quot;, &quot;HEAD detached at X&quot;,
++// &quot;HEAD detached from X&quot;, or rebase-in-progress messages.
++// The returned string includes the prefix (e.g. &quot;On branch &quot;).
++func headDescription() string {
++	// Try symbolic-ref first — if it works, we&#x27;re on a branch
+ 	cmd := exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;symbolic-ref&quot;, &quot;--short&quot;, &quot;HEAD&quot;)
+ 	out, err := cmd.Output()
++	if err == nil {
++		return &quot;On branch &quot; + strings.TrimSpace(string(out))
++	}
+[result-id: r29]
+[rerun: b16]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-20-32-763Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-20-32-763Z" class="timestamp-link"><time datetime="2026-04-09T13:20:32.763Z" data-timestamp="2026-04-09T13:20:32.763Z">2026-04-09T13:20:32.763Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01GfH4doZoLHZUxumBBqxRLX">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git diff main.go | wc -l</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T13-20-32-805Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T13-20-32-805Z" class="timestamp-link"><time datetime="2026-04-09T13:20:32.805Z" data-timestamp="2026-04-09T13:20:32.805Z">2026-04-09T13:20:32.805Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>     151
+[rerun: b17]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-20-38-582Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-20-38-582Z" class="timestamp-link"><time datetime="2026-04-09T13:20:38.582Z" data-timestamp="2026-04-09T13:20:38.582Z">2026-04-09T13:20:38.582Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>OK good — my changes are actually still in the file as local modifications. The system reminder was misleading — the linter didn't actually revert, the diff is correct. The Edit tool failed because it was comparing against the on-disk content which already has my changes. Let me verify:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-20-39-584Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-20-39-584Z" class="timestamp-link"><time datetime="2026-04-09T13:20:39.584Z" data-timestamp="2026-04-09T13:20:39.584Z">2026-04-09T13:20:39.584Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01ALVUJZgLEdHpPHJRTWS3GR"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;func detachedDescription\&#34;&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main.go&#34;
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T13-20-39-602Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T13-20-39-602Z" class="timestamp-link"><time datetime="2026-04-09T13:20:39.602Z" data-timestamp="2026-04-09T13:20:39.602Z">2026-04-09T13:20:39.602Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>No matches found</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-20-42-457Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-20-42-457Z" class="timestamp-link"><time datetime="2026-04-09T13:20:42.457Z" data-timestamp="2026-04-09T13:20:42.457Z">2026-04-09T13:20:42.457Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01AgVsMik4vEb7cvuG3GQmc3"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;func detachedDescription&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main.go&#34;
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T13-20-42-471Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T13-20-42-471Z" class="timestamp-link"><time datetime="2026-04-09T13:20:42.471Z" data-timestamp="2026-04-09T13:20:42.471Z">2026-04-09T13:20:42.471Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>717:func detachedDescription() string {</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-20-45-414Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-20-45-414Z" class="timestamp-link"><time datetime="2026-04-09T13:20:45.414Z" data-timestamp="2026-04-09T13:20:45.414Z">2026-04-09T13:20:45.414Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_016w2pWqQihvPaeZmE4A5DVP"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main.go&#34;,
+  &#34;offset&#34;: 717,
+  &#34;limit&#34;: 40
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T13-20-45-428Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T13-20-45-428Z" class="timestamp-link"><time datetime="2026-04-09T13:20:45.428Z" data-timestamp="2026-04-09T13:20:45.428Z">2026-04-09T13:20:45.428Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>717	func detachedDescription() string {
+718		// Get the oid that HEAD pointed to when we detached (last reflog switch)
+719		cmd := exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;reflog&quot;, &quot;-1&quot;, &quot;--format=%H&quot;, &quot;HEAD&quot;)
+720		reflogOut, err := cmd.Output()
+721		if err != nil {
+722			return &quot;Not currently on any branch.&quot;
+723		}
+724		detachedOid := strings.TrimSpace(string(reflogOut))
+725		if detachedOid == &quot;&quot; {
+726			return &quot;Not currently on any branch.&quot;
+727		}
+728	
+729		// Get current HEAD oid
+730		cmd = exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;rev-parse&quot;, &quot;HEAD&quot;)
+731		headOut, err := cmd.Output()
+732		if err != nil {
+733			return &quot;Not currently on any branch.&quot;
+734		}
+735		headOid := strings.TrimSpace(string(headOut))
+736	
+737		atOrFrom := &quot;at&quot;
+738		if headOid != detachedOid {
+739			atOrFrom = &quot;from&quot;
+740		}
+741	
+742		// Try to find a friendly name (tag or branch) that points at detachedOid
+743		name := friendlyRefName(detachedOid)
+744	
+745		return &quot;HEAD detached &quot; + atOrFrom + &quot; &quot; + name
+746	}
+747	
+748	// friendlyRefName tries to describe an oid with a tag or branch name.
+749	// Falls back to the short hash.
+750	func friendlyRefName(oid string) string {
+751		// Try describe --tags --exact-match first for tags
+752		cmd := exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;describe&quot;, &quot;--tags&quot;, &quot;--exact-match&quot;, oid)
+753		out, err := cmd.Output()
+754		if err == nil {
+755			return strings.TrimSpace(string(out))
+756		}
+[result-id: r30]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-20-49-935Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-20-49-935Z" class="timestamp-link"><time datetime="2026-04-09T13:20:49.935Z" data-timestamp="2026-04-09T13:20:49.935Z">2026-04-09T13:20:49.935Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Good, the old version with the <code>reflog -1</code> bug is there. Let me fix it now:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-20-57-539Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-20-57-539Z" class="timestamp-link"><time datetime="2026-04-09T13:20:57.539Z" data-timestamp="2026-04-09T13:20:57.539Z">2026-04-09T13:20:57.539Z</time></a></div><div class="message-content"><div class="file-tool edit-tool" data-tool-id="toolu_01GJeQrGHmZ3g7sQEY3USMNa">
+<div class="file-tool-header edit-header"><span class="file-tool-icon">✏️</span> Edit <span class="file-tool-path">main.go</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/handle-non-branch/main.go</div>
+<div class="truncatable"><div class="truncatable-content">
+<div class="edit-section edit-old"><div class="edit-label">−</div><pre class="edit-content">func detachedDescription() string {
+	// Get the oid that HEAD pointed to when we detached (last reflog switch)
+	cmd := exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;, &#34;reflog&#34;, &#34;-1&#34;, &#34;--format=%H&#34;, &#34;HEAD&#34;)
+	reflogOut, err := cmd.Output()
+	if err != nil {
+		return &#34;Not currently on any branch.&#34;
+	}
+	detachedOid := strings.TrimSpace(string(reflogOut))
+	if detachedOid == &#34;&#34; {
+		return &#34;Not currently on any branch.&#34;
+	}
+
+	// Get current HEAD oid
+	cmd = exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;, &#34;rev-parse&#34;, &#34;HEAD&#34;)
+	headOut, err := cmd.Output()
+	if err != nil {
+		return &#34;Not currently on any branch.&#34;
+	}
+	headOid := strings.TrimSpace(string(headOut))
+
+	atOrFrom := &#34;at&#34;
+	if headOid != detachedOid {
+		atOrFrom = &#34;from&#34;
+	}
+
+	// Try to find a friendly name (tag or branch) that points at detachedOid
+	name := friendlyRefName(detachedOid)
+
+	return &#34;HEAD detached &#34; + atOrFrom + &#34; &#34; + name
+}</pre></div>
+<div class="edit-section edit-new"><div class="edit-label">+</div><pre class="edit-content">func detachedDescription() string {
+	// Walk the reflog to find the checkout/switch entry where we detached.
+	// That entry&#39;s oid is the commit we originally landed on.
+	cmd := exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;,
+		&#34;reflog&#34;, &#34;--format=%H %gs&#34;, &#34;HEAD&#34;)
+	reflogOut, err := cmd.Output()
+	if err != nil {
+		return &#34;Not currently on any branch.&#34;
+	}
+
+	var detachedOid string
+	for _, line := range strings.Split(strings.TrimSpace(string(reflogOut)), &#34;\n&#34;) {
+		if strings.Contains(line, &#34;checkout: &#34;) || strings.Contains(line, &#34;switch: &#34;) {
+			detachedOid, _, _ = strings.Cut(line, &#34; &#34;)
+			break
+		}
+	}
+	if detachedOid == &#34;&#34; {
+		return &#34;Not currently on any branch.&#34;
+	}
+
+	// Get current HEAD oid
+	cmd = exec.Command(&#34;git&#34;, &#34;-c&#34;, &#34;core.fsmonitor=false&#34;, &#34;rev-parse&#34;, &#34;HEAD&#34;)
+	headOut, err := cmd.Output()
+	if err != nil {
+		return &#34;Not currently on any branch.&#34;
+	}
+	headOid := strings.TrimSpace(string(headOut))
+
+	atOrFrom := &#34;at&#34;
+	if headOid != detachedOid {
+		atOrFrom = &#34;from&#34;
+	}
+
+	// Try to find a friendly name (tag or branch) that points at detachedOid
+	name := friendlyRefName(detachedOid)
+
+	return &#34;HEAD detached &#34; + atOrFrom + &#34; &#34; + name
+}</pre></div>
+</div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T13-20-57-563Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T13-20-57-563Z" class="timestamp-link"><time datetime="2026-04-09T13:20:57.563Z" data-timestamp="2026-04-09T13:20:57.563Z">2026-04-09T13:20:57.563Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/handle-non-branch/main.go has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-21-00-178Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-21-00-178Z" class="timestamp-link"><time datetime="2026-04-09T13:21:00.178Z" data-timestamp="2026-04-09T13:21:00.178Z">2026-04-09T13:21:00.178Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01M238qTxfJpJkuJ57c2nqbu">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go build -o /tmp/git-ls-test . 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T13-21-00-415Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T13-21-00-415Z" class="timestamp-link"><time datetime="2026-04-09T13:21:00.415Z" data-timestamp="2026-04-09T13:21:00.415Z">2026-04-09T13:21:00.415Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>[rerun: b18]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-21-03-152Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-21-03-152Z" class="timestamp-link"><time datetime="2026-04-09T13:21:03.152Z" data-timestamp="2026-04-09T13:21:03.152Z">2026-04-09T13:21:03.152Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now let me test all three states properly:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-21-03-502Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-21-03-502Z" class="timestamp-link"><time datetime="2026-04-09T13:21:03.502Z" data-timestamp="2026-04-09T13:21:03.502Z">2026-04-09T13:21:03.502Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01CSTpwFNA8Hp33QJ4WKyBoJ">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">echo &#34;=== On branch ===&#34; &amp;&amp; /tmp/git-ls-test 2&gt;&amp;1 | head -1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T13-21-03-997Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T13-21-03-997Z" class="timestamp-link"><time datetime="2026-04-09T13:21:03.997Z" data-timestamp="2026-04-09T13:21:03.997Z">2026-04-09T13:21:03.997Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>=== On branch ===
+[31mOn branch handle-non-branch[0m
+[rerun: b19]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-21-07-347Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-21-07-347Z" class="timestamp-link"><time datetime="2026-04-09T13:21:07.347Z" data-timestamp="2026-04-09T13:21:07.347Z">2026-04-09T13:21:07.347Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01XxRvUYzMP9utpkJC1fFFSU">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git stash &amp;&amp; git checkout --detach HEAD~1 &amp;&amp; echo &#34;=== Detached at ===&#34; &amp;&amp; /tmp/git-ls-test 2&gt;&amp;1 | head -1 &amp;&amp; echo &#34;=== git status ===&#34; &amp;&amp; git status -b 2&gt;&amp;1 | head -1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T13-21-07-510Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T13-21-07-510Z" class="timestamp-link"><time datetime="2026-04-09T13:21:07.510Z" data-timestamp="2026-04-09T13:21:07.510Z">2026-04-09T13:21:07.510Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Saved working directory and index state WIP on handle-non-branch: 84a45fb chore: bump version to 5.8.0
+HEAD is now at d84ca28 fix: unmodified tracked files show no commit info after --changed-only was added (#43)
+=== Detached at ===
+[31mHEAD detached at d84ca28[0m
+=== git status ===
+HEAD detached at d84ca28
+[result-id: r31]
+[rerun: b20]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-21-10-518Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-21-10-518Z" class="timestamp-link"><time datetime="2026-04-09T13:21:10.518Z" data-timestamp="2026-04-09T13:21:10.518Z">2026-04-09T13:21:10.518Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Matches git. Now test "detached from":</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-21-12-066Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-21-12-066Z" class="timestamp-link"><time datetime="2026-04-09T13:21:12.066Z" data-timestamp="2026-04-09T13:21:12.066Z">2026-04-09T13:21:12.066Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01MjYPjYkRNswMkM3mrdJAea">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git commit --allow-empty -m &#34;test&#34; &amp;&amp; echo &#34;=== Detached from ===&#34; &amp;&amp; /tmp/git-ls-test 2&gt;&amp;1 | head -1 &amp;&amp; echo &#34;=== git status ===&#34; &amp;&amp; git status -b 2&gt;&amp;1 | head -1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T13-21-12-197Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T13-21-12-197Z" class="timestamp-link"><time datetime="2026-04-09T13:21:12.197Z" data-timestamp="2026-04-09T13:21:12.197Z">2026-04-09T13:21:12.197Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>[detached HEAD ec41a09] test
+=== Detached from ===
+[31mHEAD detached from d84ca28[0m
+=== git status ===
+HEAD detached from d84ca28
+[rerun: b21]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-21-16-035Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-21-16-035Z" class="timestamp-link"><time datetime="2026-04-09T13:21:16.035Z" data-timestamp="2026-04-09T13:21:16.035Z">2026-04-09T13:21:16.035Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Both match git exactly. Let me clean up and go back:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-21-16-675Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-21-16-675Z" class="timestamp-link"><time datetime="2026-04-09T13:21:16.675Z" data-timestamp="2026-04-09T13:21:16.675Z">2026-04-09T13:21:16.675Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01LMo29DcvedADCxbhRwd4i5">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git checkout d84ca28 2&gt;&amp;1 | tail -1 &amp;&amp; git switch handle-non-branch &amp;&amp; git stash pop</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T13-21-16-758Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T13-21-16-758Z" class="timestamp-link"><time datetime="2026-04-09T13:21:16.758Z" data-timestamp="2026-04-09T13:21:16.758Z">2026-04-09T13:21:16.758Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>HEAD is now at d84ca28 fix: unmodified tracked files show no commit info after --changed-only was added (#43)
+Previous HEAD position was d84ca28 fix: unmodified tracked files show no commit info after --changed-only was added (#43)
+Switched to branch &#x27;handle-non-branch&#x27;
+On branch handle-non-branch
+Changes not staged for commit:
+  (use &quot;git add &lt;file&gt;...&quot; to update what will be committed)
+  (use &quot;git restore &lt;file&gt;...&quot; to discard changes in working directory)
+	modified:   main.go
+	modified:   main_test.go
+
+Untracked files:
+  (use &quot;git add &lt;file&gt;...&quot; to include in what will be committed)
+	.claude/
+
+no changes added to commit (use &quot;git add&quot; and/or &quot;git commit -a&quot;)
+Dropped refs/stash@{0} (7b47e1d8435e2b25e6aaa5a3a7f900b33f420258)
+[result-id: r32]
+[rerun: b22]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-21-20-231Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-21-20-231Z" class="timestamp-link"><time datetime="2026-04-09T13:21:20.231Z" data-timestamp="2026-04-09T13:21:20.231Z">2026-04-09T13:21:20.231Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now let me update the test to cover all these states:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-21-21-138Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-21-21-138Z" class="timestamp-link"><time datetime="2026-04-09T13:21:21.138Z" data-timestamp="2026-04-09T13:21:21.138Z">2026-04-09T13:21:21.138Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01J6H72vQiPvum6aqFGcbMTm"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/handle-non-branch/main_test.go&#34;,
+  &#34;offset&#34;: 1145,
+  &#34;limit&#34;: 60
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T13-21-21-154Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T13-21-21-154Z" class="timestamp-link"><time datetime="2026-04-09T13:21:21.154Z" data-timestamp="2026-04-09T13:21:21.154Z">2026-04-09T13:21:21.154Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>1145	}
+1146	
+1147	func TestDetachedHead(t *testing.T) {
+1148		tmpDir := t.TempDir()
+1149		repoDir := tmpDir + &quot;/repo&quot;
+1150		if err := os.Mkdir(repoDir, 0o755); err != nil {
+1151			t.Fatalf(&quot;Failed to create repo dir: %v&quot;, err)
+1152		}
+1153	
+1154		for _, args := range [][]string{
+1155			{&quot;init&quot;, &quot;-b&quot;, &quot;main&quot;},
+1156			{&quot;config&quot;, &quot;user.email&quot;, &quot;test@example.com&quot;},
+1157			{&quot;config&quot;, &quot;user.name&quot;, &quot;Test User&quot;},
+1158		} {
+1159			if err := runCmd(repoDir, &quot;git&quot;, args...); err != nil {
+1160				t.Fatalf(&quot;git %v failed: %v&quot;, args, err)
+1161			}
+1162		}
+1163	
+1164		// Create two commits so we can detach at the first one
+1165		if err := os.WriteFile(repoDir+&quot;/a.txt&quot;, []byte(&quot;a&quot;), 0o644); err != nil {
+1166			t.Fatal(err)
+1167		}
+1168		if err := runCmd(repoDir, &quot;git&quot;, &quot;add&quot;, &quot;.&quot;); err != nil {
+1169			t.Fatal(err)
+1170		}
+1171		if err := runCmd(repoDir, &quot;git&quot;, &quot;commit&quot;, &quot;-m&quot;, &quot;first&quot;); err != nil {
+1172			t.Fatal(err)
+1173		}
+1174		if err := os.WriteFile(repoDir+&quot;/b.txt&quot;, []byte(&quot;b&quot;), 0o644); err != nil {
+1175			t.Fatal(err)
+1176		}
+1177		if err := runCmd(repoDir, &quot;git&quot;, &quot;add&quot;, &quot;.&quot;); err != nil {
+1178			t.Fatal(err)
+1179		}
+1180		if err := runCmd(repoDir, &quot;git&quot;, &quot;commit&quot;, &quot;-m&quot;, &quot;second&quot;); err != nil {
+1181			t.Fatal(err)
+1182		}
+1183	
+1184		// Detach HEAD at the first commit
+1185		if err := runCmd(repoDir, &quot;git&quot;, &quot;checkout&quot;, &quot;--detach&quot;, &quot;HEAD~1&quot;); err != nil {
+1186			t.Fatal(err)
+1187		}
+1188	
+1189		oldDir, _ := os.Getwd()
+1190		defer func() { _ = os.Chdir(oldDir) }()
+1191		if err := os.Chdir(repoDir); err != nil {
+1192			t.Fatal(err)
+1193		}
+1194	
+1195		branch := gitCurrentBranchSymbolic()
+1196		if !strings.HasPrefix(branch, &quot;HEAD detached at &quot;) {
+1197			t.Fatalf(&quot;expected &#x27;HEAD detached at &lt;hash&gt;&#x27;, got %q&quot;, branch)
+1198		}
+1199		hash := strings.TrimPrefix(branch, &quot;HEAD detached at &quot;)
+1200		if len(hash) &lt; 7 {
+1201			t.Fatalf(&quot;expected at least 7-char short hash, got %q&quot;, hash)
+1202		}
+1203	}
+1204	
+[result-id: r33]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-21-43-355Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-21-43-355Z" class="timestamp-link"><time datetime="2026-04-09T13:21:43.355Z" data-timestamp="2026-04-09T13:21:43.355Z">2026-04-09T13:21:43.355Z</time></a></div><div class="message-content"><div class="file-tool edit-tool" data-tool-id="toolu_016E64fet9C8U9uTTsgVH9Se">
+<div class="file-tool-header edit-header"><span class="file-tool-icon">✏️</span> Edit <span class="file-tool-path">main_test.go</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/handle-non-branch/main_test.go</div>
+<div class="truncatable"><div class="truncatable-content">
+<div class="edit-section edit-old"><div class="edit-label">−</div><pre class="edit-content">func TestDetachedHead(t *testing.T) {
+	tmpDir := t.TempDir()
+	repoDir := tmpDir + &#34;/repo&#34;
+	if err := os.Mkdir(repoDir, 0o755); err != nil {
+		t.Fatalf(&#34;Failed to create repo dir: %v&#34;, err)
+	}
+
+	for _, args := range [][]string{
+		{&#34;init&#34;, &#34;-b&#34;, &#34;main&#34;},
+		{&#34;config&#34;, &#34;user.email&#34;, &#34;test@example.com&#34;},
+		{&#34;config&#34;, &#34;user.name&#34;, &#34;Test User&#34;},
+	} {
+		if err := runCmd(repoDir, &#34;git&#34;, args...); err != nil {
+			t.Fatalf(&#34;git %v failed: %v&#34;, args, err)
+		}
+	}
+
+	// Create two commits so we can detach at the first one
+	if err := os.WriteFile(repoDir+&#34;/a.txt&#34;, []byte(&#34;a&#34;), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;add&#34;, &#34;.&#34;); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;commit&#34;, &#34;-m&#34;, &#34;first&#34;); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(repoDir+&#34;/b.txt&#34;, []byte(&#34;b&#34;), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;add&#34;, &#34;.&#34;); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;commit&#34;, &#34;-m&#34;, &#34;second&#34;); err != nil {
+		t.Fatal(err)
+	}
+
+	// Detach HEAD at the first commit
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;checkout&#34;, &#34;--detach&#34;, &#34;HEAD~1&#34;); err != nil {
+		t.Fatal(err)
+	}
+
+	oldDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldDir) }()
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatal(err)
+	}
+
+	branch := gitCurrentBranchSymbolic()
+	if !strings.HasPrefix(branch, &#34;HEAD detached at &#34;) {
+		t.Fatalf(&#34;expected &#39;HEAD detached at &lt;hash&gt;&#39;, got %q&#34;, branch)
+	}
+	hash := strings.TrimPrefix(branch, &#34;HEAD detached at &#34;)
+	if len(hash) &lt; 7 {
+		t.Fatalf(&#34;expected at least 7-char short hash, got %q&#34;, hash)
+	}
+}</pre></div>
+<div class="edit-section edit-new"><div class="edit-label">+</div><pre class="edit-content">func TestHeadDescription(t *testing.T) {
+	tmpDir := t.TempDir()
+	repoDir := tmpDir + &#34;/repo&#34;
+	if err := os.Mkdir(repoDir, 0o755); err != nil {
+		t.Fatalf(&#34;Failed to create repo dir: %v&#34;, err)
+	}
+
+	for _, args := range [][]string{
+		{&#34;init&#34;, &#34;-b&#34;, &#34;main&#34;},
+		{&#34;config&#34;, &#34;user.email&#34;, &#34;test@example.com&#34;},
+		{&#34;config&#34;, &#34;user.name&#34;, &#34;Test User&#34;},
+	} {
+		if err := runCmd(repoDir, &#34;git&#34;, args...); err != nil {
+			t.Fatalf(&#34;git %v failed: %v&#34;, args, err)
+		}
+	}
+
+	// Create two commits so we can detach at the first one
+	if err := os.WriteFile(repoDir+&#34;/a.txt&#34;, []byte(&#34;a&#34;), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;add&#34;, &#34;.&#34;); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;commit&#34;, &#34;-m&#34;, &#34;first&#34;); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(repoDir+&#34;/b.txt&#34;, []byte(&#34;b&#34;), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;add&#34;, &#34;.&#34;); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;commit&#34;, &#34;-m&#34;, &#34;second&#34;); err != nil {
+		t.Fatal(err)
+	}
+
+	oldDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldDir) }()
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// On a branch
+	t.Run(&#34;on branch&#34;, func(t *testing.T) {
+		desc := headDescription()
+		if desc != &#34;On branch main&#34; {
+			t.Fatalf(&#34;expected &#39;On branch main&#39;, got %q&#34;, desc)
+		}
+	})
+
+	// Detach HEAD at the first commit
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;checkout&#34;, &#34;--detach&#34;, &#34;HEAD~1&#34;); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run(&#34;detached at&#34;, func(t *testing.T) {
+		desc := headDescription()
+		if !strings.HasPrefix(desc, &#34;HEAD detached at &#34;) {
+			t.Fatalf(&#34;expected &#39;HEAD detached at &lt;hash&gt;&#39;, got %q&#34;, desc)
+		}
+		hash := strings.TrimPrefix(desc, &#34;HEAD detached at &#34;)
+		if len(hash) &lt; 7 {
+			t.Fatalf(&#34;expected at least 7-char short hash, got %q&#34;, hash)
+		}
+	})
+
+	// Make a commit while detached — now it should be &#34;detached from&#34;
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;commit&#34;, &#34;--allow-empty&#34;, &#34;-m&#34;, &#34;detached commit&#34;); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run(&#34;detached from&#34;, func(t *testing.T) {
+		desc := headDescription()
+		if !strings.HasPrefix(desc, &#34;HEAD detached from &#34;) {
+			t.Fatalf(&#34;expected &#39;HEAD detached from &lt;hash&gt;&#39;, got %q&#34;, desc)
+		}
+	})
+
+	// Go back to main for rebase test
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;switch&#34;, &#34;main&#34;); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a branch with a conflicting change for rebase
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;checkout&#34;, &#34;-b&#34;, &#34;feature&#34;); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(repoDir+&#34;/a.txt&#34;, []byte(&#34;feature change&#34;), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;add&#34;, &#34;.&#34;); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;commit&#34;, &#34;-m&#34;, &#34;feature&#34;); err != nil {
+		t.Fatal(err)
+	}
+
+	// Start a rebase that will conflict
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;switch&#34;, &#34;main&#34;); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(repoDir+&#34;/a.txt&#34;, []byte(&#34;main change&#34;), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;add&#34;, &#34;.&#34;); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;commit&#34;, &#34;-m&#34;, &#34;main diverge&#34;); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCmd(repoDir, &#34;git&#34;, &#34;switch&#34;, &#34;feature&#34;); err != nil {
+		t.Fatal(err)
+	}
+	// This rebase will fail due to conflict — that&#39;s what we want
+	_ = runCmd(repoDir, &#34;git&#34;, &#34;rebase&#34;, &#34;main&#34;)
+
+	t.Run(&#34;rebase in progress&#34;, func(t *testing.T) {
+		desc := headDescription()
+		if !strings.Contains(desc, &#34;rebase in progress; onto &#34;) {
+			t.Fatalf(&#34;expected rebase message, got %q&#34;, desc)
+		}
+	})
+}</pre></div>
+</div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T13-21-43-373Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T13-21-43-373Z" class="timestamp-link"><time datetime="2026-04-09T13:21:43.373Z" data-timestamp="2026-04-09T13:21:43.373Z">2026-04-09T13:21:43.373Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/handle-non-branch/main_test.go has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-21-45-468Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-21-45-468Z" class="timestamp-link"><time datetime="2026-04-09T13:21:45.468Z" data-timestamp="2026-04-09T13:21:45.468Z">2026-04-09T13:21:45.468Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01FcJXYfHefXNxDBRA5wgLHi">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go test -run TestHeadDescription -v 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T13-21-46-480Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T13-21-46-480Z" class="timestamp-link"><time datetime="2026-04-09T13:21:46.480Z" data-timestamp="2026-04-09T13:21:46.480Z">2026-04-09T13:21:46.480Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>=== RUN   TestHeadDescription
+=== RUN   TestHeadDescription/on_branch
+=== RUN   TestHeadDescription/detached_at
+=== RUN   TestHeadDescription/detached_from
+=== RUN   TestHeadDescription/rebase_in_progress
+--- PASS: TestHeadDescription (0.31s)
+    --- PASS: TestHeadDescription/on_branch (0.01s)
+    --- PASS: TestHeadDescription/detached_at (0.04s)
+    --- PASS: TestHeadDescription/detached_from (0.04s)
+    --- PASS: TestHeadDescription/rebase_in_progress (0.02s)
+PASS
+ok  	github.com/llimllib/git-ls	0.686s
+[result-id: r34]
+[rerun: b23]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-21-49-972Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-21-49-972Z" class="timestamp-link"><time datetime="2026-04-09T13:21:49.972Z" data-timestamp="2026-04-09T13:21:49.972Z">2026-04-09T13:21:49.972Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>All four states pass. Let me also run the full test suite to make sure nothing is broken:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-21-50-088Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-21-50-088Z" class="timestamp-link"><time datetime="2026-04-09T13:21:50.088Z" data-timestamp="2026-04-09T13:21:50.088Z">2026-04-09T13:21:50.088Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01CMYciyEQ2e3GUAj15Xp78G">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go test ./... 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T13-21-51-269Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T13-21-51-269Z" class="timestamp-link"><time datetime="2026-04-09T13:21:51.269Z" data-timestamp="2026-04-09T13:21:51.269Z">2026-04-09T13:21:51.269Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>ok  	github.com/llimllib/git-ls	0.863s
+[rerun: b24]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T13-21-58-620Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T13-21-58-620Z" class="timestamp-link"><time datetime="2026-04-09T13:21:58.620Z" data-timestamp="2026-04-09T13:21:58.620Z">2026-04-09T13:21:58.620Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>All tests pass. Here's a summary of what changed:</p>
+<p><strong>States now handled</strong> (matching <code>git status</code> output exactly):
+- <strong>"On branch X"</strong> — normal branch
+- <strong>"HEAD detached at X"</strong> — detached, HEAD still at the detach point
+- <strong>"HEAD detached from X"</strong> — detached but HEAD has moved (e.g. made commits)
+- <strong>"rebase in progress; onto X"</strong> / <strong>"interactive rebase in progress; onto X"</strong> — mid-rebase
+- <strong>"Not currently on any branch."</strong> — fallback (e.g. no reflog)</p>
+<p>The ref name resolution also tries tag names and branch names before falling back to a short hash, matching git's behavior.</p></div></div></div>
+<div class="message user" id="msg-2026-04-09T16-59-17-817Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-09T16-59-17-817Z" class="timestamp-link"><time datetime="2026-04-09T16:59:17.817Z" data-timestamp="2026-04-09T16:59:17.817Z">2026-04-09T16:59:17.817Z</time></a></div><div class="message-content">
+<div class="user-content"><p>commit and file a PR, and create a transcript of this conversation in transcripts/ using https://github.com/simonw/claude-code-transcripts which is named <pr number>-slug.html</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T16-59-21-837Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T16-59-21-837Z" class="timestamp-link"><time datetime="2026-04-09T16:59:21.837Z" data-timestamp="2026-04-09T16:59:21.837Z">2026-04-09T16:59:21.837Z</time></a></div><div class="message-content">
+<div class="thinking"><div class="thinking-label">Thinking</div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T16-59-22-723Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T16-59-22-723Z" class="timestamp-link"><time datetime="2026-04-09T16:59:22.723Z" data-timestamp="2026-04-09T16:59:22.723Z">2026-04-09T16:59:22.723Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01DoBZ6dKsF1xEw7bNn9U3Zp">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git status &amp;&amp; echo &#34;---&#34; &amp;&amp; git diff --stat</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message assistant" id="msg-2026-04-09T16-59-22-729Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T16-59-22-729Z" class="timestamp-link"><time datetime="2026-04-09T16:59:22.729Z" data-timestamp="2026-04-09T16:59:22.729Z">2026-04-09T16:59:22.729Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_019v8QjvhLkPwEbEo1KvDMpC">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git log --oneline -5</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T16-59-22-776Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T16-59-22-776Z" class="timestamp-link"><time datetime="2026-04-09T16:59:22.776Z" data-timestamp="2026-04-09T16:59:22.776Z">2026-04-09T16:59:22.776Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>84a45fb chore: bump version to 5.8.0
+d84ca28 fix: unmodified tracked files show no commit info after --changed-only was added (#43)
+a700680 chore: bump to 5.7.0
+3ef7191 docs: add man page for git-ls (#42)
+927bb9c chore: bump version to 5.6.0
+[rerun: b26]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T16-59-22-790Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T16-59-22-790Z" class="timestamp-link"><time datetime="2026-04-09T16:59:22.790Z" data-timestamp="2026-04-09T16:59:22.790Z">2026-04-09T16:59:22.790Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>On branch handle-non-branch
+Changes not staged for commit:
+  (use &quot;git add &lt;file&gt;...&quot; to update what will be committed)
+  (use &quot;git restore &lt;file&gt;...&quot; to discard changes in working directory)
+	modified:   main.go
+	modified:   main_test.go
+
+Untracked files:
+  (use &quot;git add &lt;file&gt;...&quot; to include in what will be committed)
+	.claude/
+
+no changes added to commit (use &quot;git add&quot; and/or &quot;git commit -a&quot;)
+---
+ main.go      | 128 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++---
+ main_test.go | 125 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 247 insertions(+), 6 deletions(-)
+[result-id: r35]
+[rerun: b25]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T16-59-27-517Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T16-59-27-517Z" class="timestamp-link"><time datetime="2026-04-09T16:59:27.517Z" data-timestamp="2026-04-09T16:59:27.517Z">2026-04-09T16:59:27.517Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01Wo74iec4R86KY7KtFa49y6">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git add main.go main_test.go &amp;&amp; git commit -m &#34;$(cat &lt;&lt;&#39;EOF&#39;
+fix: handle detached HEAD and rebase states gracefully
+
+Previously git-ls would crash with &#34;Failed to get current branch&#34; when
+not on a branch. Now matches git-status output exactly: &#34;HEAD detached
+at/from &lt;ref&gt;&#34;, &#34;rebase in progress; onto &lt;ref&gt;&#34;, etc.
+EOF
+)&#34;</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T16-59-30-655Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T16-59-30-655Z" class="timestamp-link"><time datetime="2026-04-09T16:59:30.655Z" data-timestamp="2026-04-09T16:59:30.655Z">2026-04-09T16:59:30.655Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><div class="commit-card"><a href="https://github.com/llimllib/git-ls/commit/0453722"><span class="commit-card-hash">0453722</span> fix: handle detached HEAD and rebase states gracefully</a></div><pre>2 files changed, 247 insertions(+), 6 deletions(-)
+[rerun: b27]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T16-59-32-726Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T16-59-32-726Z" class="timestamp-link"><time datetime="2026-04-09T16:59:32.726Z" data-timestamp="2026-04-09T16:59:32.726Z">2026-04-09T16:59:32.726Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_011XHqPBHdYZqxesQ86NJMEe">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git push -u origin handle-non-branch 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-09T17-49-56-454Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-09T17-49-56-454Z" class="timestamp-link"><time datetime="2026-04-09T17:49:56.454Z" data-timestamp="2026-04-09T17:49:56.454Z">2026-04-09T17:49:56.454Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>remote: 
+remote: Create a pull request for &#x27;handle-non-branch&#x27; on GitHub by visiting:        
+remote:      https://github.com/llimllib/git-ls/pull/new/handle-non-branch        
+remote: 
+To https://github.com/llimllib/git-ls.git
+ * [new branch]      handle-non-branch -&gt; handle-non-branch
+branch &#x27;handle-non-branch&#x27; set up to track &#x27;origin/handle-non-branch&#x27;.
+[result-id: r36]
+[rerun: b28]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-09T17-50-06-643Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-09T17-50-06-643Z" class="timestamp-link"><time datetime="2026-04-09T17:50:06.643Z" data-timestamp="2026-04-09T17:50:06.643Z">2026-04-09T17:50:06.643Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_017YqftyHsbvFui1n3UiGpGL">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">gh pr create --title &#34;fix: handle detached HEAD and rebase states&#34; --body &#34;$(cat &lt;&lt;&#39;EOF&#39;
+## Summary
+- Previously `git-ls` crashed with `Failed to get current branch` in detached HEAD state
+- Now matches `git status` output exactly for all HEAD states:
+  - `On branch X`
+  - `HEAD detached at X` (still at detach point)
+  - `HEAD detached from X` (moved since detaching)
+  - `rebase in progress; onto X` / `interactive rebase in progress; onto X`
+  - `Not currently on any branch.` (fallback)
+- Resolves friendly ref names (tags, branches) before falling back to short hash
+
+## Test plan
+- [x] `TestHeadDescription/on_branch` — normal branch
+- [x] `TestHeadDescription/detached_at` — detached, HEAD unchanged
+- [x] `TestHeadDescription/detached_from` — detached, HEAD moved
+- [x] `TestHeadDescription/rebase_in_progress` — mid-rebase with conflict
+- [x] Full test suite passes
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)&#34;</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-10T03-08-21-363Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-10T03-08-21-363Z" class="timestamp-link"><time datetime="2026-04-10T03:08:21.363Z" data-timestamp="2026-04-10T03:08:21.363Z">2026-04-10T03:08:21.363Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Warning: 1 uncommitted change
+https://github.com/llimllib/git-ls/pull/45
+[rerun: b29]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-10T03-08-25-941Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-10T03-08-25-941Z" class="timestamp-link"><time datetime="2026-04-10T03:08:25.941Z" data-timestamp="2026-04-10T03:08:25.941Z">2026-04-10T03:08:25.941Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>PR #45 created. Now let me generate the transcript.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-10T03-08-26-912Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-10T03-08-26-912Z" class="timestamp-link"><time datetime="2026-04-10T03:08:26.912Z" data-timestamp="2026-04-10T03:08:26.912Z">2026-04-10T03:08:26.912Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_011WDsvMdawX2X4todpRZRdL">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">ls transcripts/ 2&gt;&amp;1; which claude-code-transcripts 2&gt;&amp;1 || pip show claude-code-transcripts 2&gt;&amp;1 || echo &#34;not installed&#34;</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-10T03-08-30-626Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-10T03-08-30-626Z" class="timestamp-link"><time datetime="2026-04-10T03:08:30.626Z" data-timestamp="2026-04-10T03:08:30.626Z">2026-04-10T03:08:30.626Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>25-fix-directory-arg-hang.html
+28-show-deleted-files.html
+30-fix-hyperlinks.html
+33-optimize-git-log-streaming.html
+35-fix-symlink-worktree-panic.html
+36-fix-empty-repo.html
+37-fix-subdirectory-git-info.html
+38-fix-rename-copy-status.html
+39-nerdfont-flag.html
+41-changed-only-flag.html
+42-add-man-page.html
+43-fix-unmodified-files-git-info.html
+claude-code-transcripts not found
+WARNING: Package(s) not found: claude-code-transcripts
+not installed
+[rerun: b30]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-10T03-08-33-933Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-10T03-08-33-933Z" class="timestamp-link"><time datetime="2026-04-10T03:08:33.933Z" data-timestamp="2026-04-10T03:08:33.933Z">2026-04-10T03:08:33.933Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01HhkU8izSkbWr6d2LYMQGtk">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">pip install claude-code-transcripts 2&gt;&amp;1 | tail -3</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-10T03-08-38-311Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-10T03-08-38-311Z" class="timestamp-link"><time datetime="2026-04-10T03:08:38.311Z" data-timestamp="2026-04-10T03:08:38.311Z">2026-04-10T03:08:38.311Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Installing collected packages: MarkupSafe, markdown, h11, click-default-group, anyio, questionary, jinja2, httpcore, httpx, claude-code-transcripts
+
+Successfully installed MarkupSafe-3.0.3 anyio-4.13.0 claude-code-transcripts-0.6 click-default-group-1.2.4 h11-0.16.0 httpcore-1.0.9 httpx-0.28.1 jinja2-3.1.6 markdown-3.10.2 questionary-2.1.1
+[rerun: b31]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-10T03-08-41-068Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-10T03-08-41-068Z" class="timestamp-link"><time datetime="2026-04-10T03:08:41.068Z" data-timestamp="2026-04-10T03:08:41.068Z">2026-04-10T03:08:41.068Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01DGSiVFZ5N5VhSQWGhaDLXn">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">claude-code-transcripts --help 2&gt;&amp;1 | head -20</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-10T03-08-44-444Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-10T03-08-44-444Z" class="timestamp-link"><time datetime="2026-04-10T03:08:44.444Z" data-timestamp="2026-04-10T03:08:44.444Z">2026-04-10T03:08:44.444Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Usage: claude-code-transcripts [OPTIONS] COMMAND [ARGS]...
+
+  Convert Claude Code session JSON to mobile-friendly HTML pages.
+
+Options:
+  -v, --version  Show the version and exit.
+  --help         Show this message and exit.
+
+Commands:
+  local*  Select and convert a local Claude Code session to HTML.
+  all     Convert all local Claude Code sessions to a browsable HTML archive.
+  json    Convert a Claude Code session JSON/JSONL file or URL to HTML.
+  web     Select and convert a web session from the Claude API to HTML.
+[rerun: b32]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-10T03-08-47-319Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-10T03-08-47-319Z" class="timestamp-link"><time datetime="2026-04-10T03:08:47.319Z" data-timestamp="2026-04-10T03:08:47.319Z">2026-04-10T03:08:47.319Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01XtcyBcB1ekQxJM9ZM3b1eA">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">claude-code-transcripts local --help 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-10T03-08-48-906Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-10T03-08-48-906Z" class="timestamp-link"><time datetime="2026-04-10T03:08:48.906Z" data-timestamp="2026-04-10T03:08:48.906Z">2026-04-10T03:08:48.906Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Usage: claude-code-transcripts local [OPTIONS]
+
+  Select and convert a local Claude Code session to HTML.
+
+Options:
+  -o, --output PATH  Output directory. If not specified, writes to temp dir
+                     and opens in browser.
+  -a, --output-auto  Auto-name output subdirectory based on session filename
+                     (uses -o as parent, or current dir).
+  --repo TEXT        GitHub repo (owner/name) for commit links. Auto-detected
+                     from git push output if not specified.
+  --gist             Upload to GitHub Gist and output a gisthost.github.io
+                     URL.
+  --json             Include the original JSONL session file in the output
+                     directory.
+  --open             Open the generated index.html in your default browser
+                     (default if no -o specified).
+  --limit INTEGER    Maximum number of sessions to show (default: 10)
+  --help             Show this message and exit.
+[rerun: b33]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-10T03-08-52-024Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-10T03-08-52-024Z" class="timestamp-link"><time datetime="2026-04-10T03:08:52.024Z" data-timestamp="2026-04-10T03:08:52.024Z">2026-04-10T03:08:52.024Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01PKeiM6Fn1f5KpjD4ZLovjG">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">claude-code-transcripts local -o /tmp/transcript-out --limit 5 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-10T03-08-52-234Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-10T03-08-52-234Z" class="timestamp-link"><time datetime="2026-04-10T03:08:52.234Z" data-timestamp="2026-04-10T03:08:52.234Z">2026-04-10T03:08:52.234Z</time></a></div><div class="message-content"><div class="tool-result tool-error"><div class="truncatable"><div class="truncatable-content"><pre>Exit code 1
+Loading local sessions...
+Warning: Input is not a terminal (fd=0).
+Traceback (most recent call last):
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/bin/claude-code-transcripts&quot;, line 6, in &lt;module&gt;
+    sys.exit(main())
+             ~~~~^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/site-packages/claude_code_transcripts/__init__.py&quot;, line 2224, in main
+    cli()
+    ~~~^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/site-packages/click/core.py&quot;, line 1485, in __call__
+    return self.main(*args, **kwargs)
+           ~~~~~~~~~^^^^^^^^^^^^^^^^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/site-packages/click/core.py&quot;, line 1406, in main
+    rv = self.invoke(ctx)
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/site-packages/click/core.py&quot;, line 1873, in invoke
+    return _process_result(sub_ctx.command.invoke(sub_ctx))
+                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/site-packages/click/core.py&quot;, line 1269, in invoke
+    return ctx.invoke(self.callback, **ctx.params)
+           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/site-packages/click/core.py&quot;, line 824, in invoke
+    return callback(*args, **kwargs)
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/site-packages/claude_code_transcripts/__init__.py&quot;, line 1551, in local_cmd
+    ).ask()
+      ~~~^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/site-packages/questionary/question.py&quot;, line 64, in ask
+    return self.unsafe_ask(patch_stdout)
+           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/site-packages/questionary/question.py&quot;, line 89, in unsafe_ask
+    return self.application.run()
+           ~~~~~~~~~~~~~~~~~~~~^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/site-packages/prompt_toolkit/application/application.py&quot;, line 1002, in run
+    return asyncio.run(coro)
+           ~~~~~~~~~~~^^^^^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/asyncio/runners.py&quot;, line 204, in run
+    return runner.run(main)
+           ~~~~~~~~~~^^^^^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/asyncio/runners.py&quot;, line 127, in run
+    return self._loop.run_until_complete(task)
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/asyncio/base_events.py&quot;, line 719, in run_until_complete
+    return future.result()
+           ~~~~~~~~~~~~~^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/site-packages/prompt_toolkit/application/application.py&quot;, line 886, in run_async
+    return await _run_async(f)
+           ^^^^^^^^^^^^^^^^^^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/site-packages/prompt_toolkit/application/application.py&quot;, line 734, in _run_async
+    with self.input.raw_mode(), self.input.attach(
+                                ~~~~~~~~~~~~~~~~~^
+        read_from_input_in_context
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ), attach_winch_signal_handler(self._on_resize):
+    ^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/contextlib.py&quot;, line 141, in __enter__
+    return next(self.gen)
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/site-packages/prompt_toolkit/input/vt100.py&quot;, line 165, in _attached_input
+    loop.add_reader(fd, callback_wrapper)
+    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/asyncio/selector_events.py&quot;, line 351, in add_reader
+    self._add_reader(fd, callback, *args)
+    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/asyncio/selector_events.py&quot;, line 283, in _add_reader
+    self._selector.register(fd, selectors.EVENT_READ,
+    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
+                            (handle, None))
+                            ^^^^^^^^^^^^^^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/selectors.py&quot;, line 505, in register
+    self._selector.control([kev], 0, 0)
+    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
+OSError: [Errno 22] Invalid argument
+[rerun: b34]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-10T03-08-55-814Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-10T03-08-55-814Z" class="timestamp-link"><time datetime="2026-04-10T03:08:55.814Z" data-timestamp="2026-04-10T03:08:55.814Z">2026-04-10T03:08:55.814Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>It needs interactive selection. Let me use the <code>json</code> subcommand with the session file directly. I need to find the current session.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-10T03-08-56-836Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-10T03-08-56-836Z" class="timestamp-link"><time datetime="2026-04-10T03:08:56.836Z" data-timestamp="2026-04-10T03:08:56.836Z">2026-04-10T03:08:56.836Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01SiyibMi4NYLtnWsyC2Py5R">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">ls -lt ~/.claude/projects/-Users-llimllib-code-git-ls-handle-non-branch/ 2&gt;&amp;1 | head -10</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-10T03-08-56-876Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-10T03-08-56-876Z" class="timestamp-link"><time datetime="2026-04-10T03:08:56.876Z" data-timestamp="2026-04-10T03:08:56.876Z">2026-04-10T03:08:56.876Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>total 708
+-rw------- 1 llimllib 681970 Apr  9 23:08 bd3d4877-dd81-4d87-9286-e6bfd04eecc3.jsonl
+drwxr-xr-x 4 llimllib    128 Apr  8 07:36 bd3d4877-dd81-4d87-9286-e6bfd04eecc3/
+[rerun: b35]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-10T03-09-00-732Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-10T03-09-00-732Z" class="timestamp-link"><time datetime="2026-04-10T03:09:00.732Z" data-timestamp="2026-04-10T03:09:00.732Z">2026-04-10T03:09:00.732Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_0191RavXxqCvJ388EKdjJuus">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">claude-code-transcripts json ~/.claude/projects/-Users-llimllib-code-git-ls-handle-non-branch/bd3d4877-dd81-4d87-9286-e6bfd04eecc3.jsonl -o transcripts/45-handle-detached-head.html 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-10T03-09-01-934Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-10T03-09-01-934Z" class="timestamp-link"><time datetime="2026-04-10T03:09:01.934Z" data-timestamp="2026-04-10T03:09:01.934Z">2026-04-10T03:09:01.934Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Auto-detected GitHub repo: llimllib/git-ls
+Generated page-001.html
+Generated page-002.html
+Generated /Users/llimllib/code/git-ls/handle-non-branch/transcripts/45-handle-detached-head.html/index.html (8 prompts, 2 pages)
+Output: /Users/llimllib/code/git-ls/handle-non-branch/transcripts/45-handle-detached-head.html
+[rerun: b36]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-10T03-09-05-062Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-10T03-09-05-062Z" class="timestamp-link"><time datetime="2026-04-10T03:09:05.062Z" data-timestamp="2026-04-10T03:09:05.062Z">2026-04-10T03:09:05.062Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Hmm, it created a directory instead of a single file. Let me check:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-10T03-09-05-076Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-10T03-09-05-076Z" class="timestamp-link"><time datetime="2026-04-10T03:09:05.076Z" data-timestamp="2026-04-10T03:09:05.076Z">2026-04-10T03:09:05.076Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01F1DwGaF1BQz3Fx2n43B7qn">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">ls transcripts/45-handle-detached-head.html/</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-10T03-09-05-106Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-10T03-09-05-106Z" class="timestamp-link"><time datetime="2026-04-10T03:09:05.106Z" data-timestamp="2026-04-10T03:09:05.106Z">2026-04-10T03:09:05.106Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>index.html
+page-001.html
+page-002.html
+[rerun: b37]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-10T03-09-08-162Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-10T03-09-08-162Z" class="timestamp-link"><time datetime="2026-04-10T03:09:08.162Z" data-timestamp="2026-04-10T03:09:08.162Z">2026-04-10T03:09:08.162Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Looking at the existing transcripts, they're single files:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-10T03-09-08-585Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-10T03-09-08-585Z" class="timestamp-link"><time datetime="2026-04-10T03:09:08.585Z" data-timestamp="2026-04-10T03:09:08.585Z">2026-04-10T03:09:08.585Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01Ey2s5NSTMmLDSHiypXdTqd">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">file transcripts/43-fix-unmodified-files-git-info.html</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-10T03-09-08-626Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-10T03-09-08-626Z" class="timestamp-link"><time datetime="2026-04-10T03:09:08.626Z" data-timestamp="2026-04-10T03:09:08.626Z">2026-04-10T03:09:08.626Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>transcripts/43-fix-unmodified-files-git-info.html: HTML document text, Unicode text, UTF-8 text, with very long lines (40758)
+[rerun: b38]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-10T03-09-12-739Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-10T03-09-12-739Z" class="timestamp-link"><time datetime="2026-04-10T03:09:12.739Z" data-timestamp="2026-04-10T03:09:12.739Z">2026-04-10T03:09:12.739Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>The existing ones are single files. The tool creates a directory with pages. Let me remove the directory and see if the conversation fits in one page — it might just be the tool's new multi-page format. Let me check what the other transcripts used.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-10T03-09-13-119Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-10T03-09-13-119Z" class="timestamp-link"><time datetime="2026-04-10T03:09:13.119Z" data-timestamp="2026-04-10T03:09:13.119Z">2026-04-10T03:09:13.119Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_015pm9x7ou9sDasvJ8ny34Xm">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">rm -rf transcripts/45-handle-detached-head.html &amp;&amp; claude-code-transcripts json --help 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-10T03-09-13-302Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-10T03-09-13-302Z" class="timestamp-link"><time datetime="2026-04-10T03:09:13.302Z" data-timestamp="2026-04-10T03:09:13.302Z">2026-04-10T03:09:13.302Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Usage: claude-code-transcripts json [OPTIONS] JSON_FILE
+
+  Convert a Claude Code session JSON/JSONL file or URL to HTML.
+
+Options:
+  -o, --output PATH  Output directory. If not specified, writes to temp dir
+                     and opens in browser.
+  -a, --output-auto  Auto-name output subdirectory based on filename (uses -o
+                     as parent, or current dir).
+  --repo TEXT        GitHub repo (owner/name) for commit links. Auto-detected
+                     from git push output if not specified.
+  --gist             Upload to GitHub Gist and output a gisthost.github.io
+                     URL.
+  --json             Include the original JSON session file in the output
+                     directory.
+  --open             Open the generated index.html in your default browser
+                     (default if no -o specified).
+  --help             Show this message and exit.
+[rerun: b39]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-10T03-09-18-402Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-10T03-09-18-402Z" class="timestamp-link"><time datetime="2026-04-10T03:09:18.402Z" data-timestamp="2026-04-10T03:09:18.402Z">2026-04-10T03:09:18.402Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>The tool always creates a directory. The existing single-file transcripts were probably from an older version. Let me just use this format — put it in the right place:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-10T03-09-19-058Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-10T03-09-19-058Z" class="timestamp-link"><time datetime="2026-04-10T03:09:19.058Z" data-timestamp="2026-04-10T03:09:19.058Z">2026-04-10T03:09:19.058Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01WP37jPq7JazzpsSXcKSqhc">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">claude-code-transcripts json ~/.claude/projects/-Users-llimllib-code-git-ls-handle-non-branch/bd3d4877-dd81-4d87-9286-e6bfd04eecc3.jsonl -o transcripts/45-handle-detached-head 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-10T03-09-19-266Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-10T03-09-19-266Z" class="timestamp-link"><time datetime="2026-04-10T03:09:19.266Z" data-timestamp="2026-04-10T03:09:19.266Z">2026-04-10T03:09:19.266Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Auto-detected GitHub repo: llimllib/git-ls
+Generated page-001.html
+Generated page-002.html
+Generated /Users/llimllib/code/git-ls/handle-non-branch/transcripts/45-handle-detached-head/index.html (8 prompts, 2 pages)
+Output: /Users/llimllib/code/git-ls/handle-non-branch/transcripts/45-handle-detached-head
+[rerun: b40]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-10T03-09-23-739Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-10T03-09-23-739Z" class="timestamp-link"><time datetime="2026-04-10T03:09:23.739Z" data-timestamp="2026-04-10T03:09:23.739Z">2026-04-10T03:09:23.739Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Wait, looking at the naming convention — the existing transcripts are <code>&lt;pr-number&gt;-slug.html</code>. Let me check if the user wants a directory or a single file. Given the tool now produces multi-page output, I'll keep it as a directory but name it to match the convention:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-10T03-09-24-281Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-10T03-09-24-281Z" class="timestamp-link"><time datetime="2026-04-10T03:09:24.281Z" data-timestamp="2026-04-10T03:09:24.281Z">2026-04-10T03:09:24.281Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01PTGt9FqKJDAhCw5o6VAwWz">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">rm -rf transcripts/45-handle-detached-head &amp;&amp; cat transcripts/43-fix-unmodified-files-git-info.html | head -5</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-10T03-09-24-334Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-10T03-09-24-334Z" class="timestamp-link"><time datetime="2026-04-10T03:09:24.334Z" data-timestamp="2026-04-10T03:09:24.334Z">2026-04-10T03:09:24.334Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>&lt;!DOCTYPE html&gt;
+&lt;html lang=&quot;en&quot;&gt;
+&lt;head&gt;
+  &lt;meta charset=&quot;UTF-8&quot;&gt;
+  &lt;meta name=&quot;viewport&quot; content=&quot;width=device-width, initial-scale=1.0&quot;&gt;
+[rerun: b41]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-10T03-09-28-785Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-10T03-09-28-785Z" class="timestamp-link"><time datetime="2026-04-10T03:09:28.785Z" data-timestamp="2026-04-10T03:09:28.785Z">2026-04-10T03:09:28.785Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>The user asked for it to be named <code>&lt;pr number&gt;-slug.html</code>. Since the tool now outputs a directory, and the conversation is 2 pages, let me just concatenate or use page-001 as the single file. Actually, let me check if the pages are self-contained:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-10T03-09-29-813Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-10T03-09-29-813Z" class="timestamp-link"><time datetime="2026-04-10T03:09:29.813Z" data-timestamp="2026-04-10T03:09:29.813Z">2026-04-10T03:09:29.813Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_013xRMdepSUr7bFWK8kzer39">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">claude-code-transcripts json ~/.claude/projects/-Users-llimllib-code-git-ls-handle-non-branch/bd3d4877-dd81-4d87-9286-e6bfd04eecc3.jsonl -o /tmp/transcript-test 2&gt;&amp;1 &amp;&amp; wc -l /tmp/transcript-test/*.html</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+        
+
+<div class="pagination">
+<a href="index.html" class="index-link">Index</a>
+<a href="page-001.html">&larr; Prev</a>
+<a href="page-001.html">1</a>
+<span class="current">2</span>
+<span class="disabled">Next &rarr;</span>
+</div>
+
+    </div>
+    <script>
+document.querySelectorAll('time[data-timestamp]').forEach(function(el) {
+    const timestamp = el.getAttribute('data-timestamp');
+    const date = new Date(timestamp);
+    const now = new Date();
+    const isToday = date.toDateString() === now.toDateString();
+    const timeStr = date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+    if (isToday) { el.textContent = timeStr; }
+    else { el.textContent = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' ' + timeStr; }
+});
+document.querySelectorAll('pre.json').forEach(function(el) {
+    let text = el.textContent;
+    text = text.replace(/"([^"]+)":/g, '<span style="color: #ce93d8">"$1"</span>:');
+    text = text.replace(/: "([^"]*)"/g, ': <span style="color: #81d4fa">"$1"</span>');
+    text = text.replace(/: (\d+)/g, ': <span style="color: #ffcc80">$1</span>');
+    text = text.replace(/: (true|false|null)/g, ': <span style="color: #f48fb1">$1</span>');
+    el.innerHTML = text;
+});
+document.querySelectorAll('.truncatable').forEach(function(wrapper) {
+    const content = wrapper.querySelector('.truncatable-content');
+    const btn = wrapper.querySelector('.expand-btn');
+    if (content.scrollHeight > 250) {
+        wrapper.classList.add('truncated');
+        btn.addEventListener('click', function() {
+            if (wrapper.classList.contains('truncated')) { wrapper.classList.remove('truncated'); wrapper.classList.add('expanded'); btn.textContent = 'Show less'; }
+            else { wrapper.classList.remove('expanded'); wrapper.classList.add('truncated'); btn.textContent = 'Show more'; }
+        });
+    }
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Previously `git-ls` crashed with `Failed to get current branch` in detached HEAD state
- Now matches `git status` output exactly for all HEAD states:
  - `On branch X`
  - `HEAD detached at X` (still at detach point)
  - `HEAD detached from X` (moved since detaching)
  - `rebase in progress; onto X` / `interactive rebase in progress; onto X`
  - `Not currently on any branch.` (fallback)
- Resolves friendly ref names (tags, branches) before falling back to short hash

## Test plan
- [x] `TestHeadDescription/on_branch` — normal branch
- [x] `TestHeadDescription/detached_at` — detached, HEAD unchanged
- [x] `TestHeadDescription/detached_from` — detached, HEAD moved
- [x] `TestHeadDescription/rebase_in_progress` — mid-rebase with conflict
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)