### PR TITLE
feat: strip ignored files from --changed-only

### DIFF
--- a/main.go
+++ b/main.go
@@ -362,15 +362,8 @@ func main() {
 	deletedFiles := parseDeletedFiles(gitData.status, curdir)
 	files = append(files, deletedFiles...)
 
-	// Filter to only changed files if requested
 	if changedOnly {
-		var changedFiles []*File
-		for _, file := range files {
-			if file.status != "" {
-				changedFiles = append(changedFiles, file)
-			}
-		}
-		files = changedFiles
+		files = changedFilesFilter(files)
 	}
 
 	// Now run git log on the files we'll show
@@ -446,6 +439,17 @@ func main() {
 		NerdFont:  nerdFont,
 	}
 	showColumns(os.Stdout, maxWidth, files, rctx, formatColumns)
+}
+
+// changedFilesFilter strips unchanged files from the files to display
+func changedFilesFilter(files []*File) []*File {
+	var changedFiles []*File
+	for _, file := range files {
+		if file.status != "" && file.status != "I" && file.status != "*" {
+			changedFiles = append(changedFiles, file)
+		}
+	}
+	return changedFiles
 }
 
 func parseFormat(formatStr string) []Column {

--- a/main_test.go
+++ b/main_test.go
@@ -827,17 +827,14 @@ func TestChangedOnly(t *testing.T) {
 		{entry: &mockDirEntry{name: "added.go"}, status: "A "},
 		{entry: &mockDirEntry{name: "another-clean.go"}, status: ""},
 		{name: "deleted.go", status: "D ", isDeleted: true},
+		{entry: &mockDirEntry{name: "ignored.log"}, status: "I"},
+		{entry: &mockDirEntry{name: ".git"}, status: "*"},
 	}
 
-	// Filter to only changed files (mimicking the --changed-only logic)
-	var changedFiles []*File
-	for _, file := range files {
-		if file.status != "" {
-			changedFiles = append(changedFiles, file)
-		}
-	}
+	// Filter to only changed files
+	changedFiles := changedFilesFilter(files)
 
-	// Verify we got only the files with status
+	// Verify we got only the files with status (ignored files excluded)
 	if len(changedFiles) != 4 {
 		t.Errorf("Expected 4 changed files, got %d", len(changedFiles))
 	}


### PR DESCRIPTION
`--changed-files` aka `-c` was listing .git and ignored files, which it shouldn't have been

### Before

```
$ git ls -c
On branch more-changed

 *      .git
 I      git-ls
MM ++-- main.go      079d7ed 2026-04-09 Bill Mill chore: bump to 5.9.0
MM ++-- main_test.go cad5a9c 2026-04-09 Bill Mill fix: handle detached HEAD and rebase states (#45)
 I      mise.toml
```

### After

```
$ ./git-ls -c
On branch more-changed

MM ++-- main.go      079d7ed 2026-04-09 Bill Mill chore: bump to 5.9.0
MM ++-- main_test.go cad5a9c 2026-04-09 Bill Mill fix: handle detached HEAD and rebase states (#45)
```
