### PR TITLE
feat: --changed-only shows full relative paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,13 @@ module github.com/llimllib/git-ls
 
 go 1.25.0
 
-require github.com/mattn/go-runewidth v0.0.21
+require (
+	github.com/mattn/go-runewidth v0.0.21
+	github.com/rogpeppe/go-internal v1.14.1
+)
 
-require github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
+require (
+	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
+	golang.org/x/sys v0.26.0 // indirect
+	golang.org/x/tools v0.26.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,9 @@ github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdoh
 github.com/clipperhouse/uax29/v2 v2.2.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/mattn/go-runewidth v0.0.21 h1:jJKAZiQH+2mIinzCJIaIG9Be1+0NR+5sz/lYEEjdM8w=
 github.com/mattn/go-runewidth v0.0.21/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
+github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
+github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
+golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/tools v0.26.0 h1:v/60pFQmzmT9ExmjDv2gGIfi3OqfKoEP6I5+umXlbnQ=
+golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func (f *File) Name() string {
 	return f.name
 }
 
-const (
+var (
 	BLUE      = "\x1b[34m"
 	CYAN      = "\x1b[36m"
 	GREEN     = "\x1b[32m"
@@ -74,7 +74,21 @@ const (
 	RESET     = "\x1b[0m"
 	YELLOW    = "\x1b[33m"
 	STRIKEOUT = "\x1b[9m"
+	NOCOLOR   = false
 )
+
+func init() {
+	if _, ok := os.LookupEnv("NO_COLOR"); ok {
+		NOCOLOR = true
+		BLUE = ""
+		CYAN = ""
+		GREEN = ""
+		RED = ""
+		RESET = ""
+		YELLOW = ""
+		STRIKEOUT = ""
+	}
+}
 
 // validHashColors contains pre-computed 8-bit terminal color codes
 // from the 6x6x6 RGB cube (16-231), excluding colors that are too dark,
@@ -103,6 +117,10 @@ var validHashColors = []int{
 // hashToColor generates a color code for a commit hash.
 // It uses 8-bit terminal colors (\e[38;5;<n>m) from the pre-computed validHashColors.
 func hashToColor(hash string) string {
+	if NOCOLOR {
+		return ""
+	}
+
 	if hash == "" {
 		return CYAN
 	}
@@ -261,6 +279,10 @@ OPTIONS
 }
 
 func main() {
+	os.Exit(run())
+}
+
+func run() int {
 	argv := os.Args[1:]
 	diffWidth := 4
 	monoHash := false
@@ -271,11 +293,11 @@ func main() {
 	for len(argv) > 0 {
 		if argv[0] == "--version" {
 			printVersion()
-			os.Exit(0)
+			return 0
 		}
 		if argv[0] == "--help" || argv[0] == "-h" {
 			usage()
-			os.Exit(0)
+			return 0
 		}
 		if argv[0] == "--mono-hash" {
 			monoHash = true
@@ -292,7 +314,8 @@ func main() {
 					parts := strings.SplitN(argv[0], "=", 2)
 					diffWidth = must(strconv.Atoi(parts[1]))
 				} else {
-					log.Fatalf("--diffWidth requires an argument")
+					fmt.Fprintf(os.Stderr, "--diffWidth requires an argument\n")
+					return 1
 				}
 				argv = argv[1:]
 			} else {
@@ -305,7 +328,8 @@ func main() {
 					parts := strings.SplitN(argv[0], "=", 2)
 					formatColumns = parseFormat(parts[1])
 				} else {
-					log.Fatalf("--format requires an argument")
+					fmt.Fprintf(os.Stderr, "--format requires an argument\n")
+					return 1
 				}
 				argv = argv[1:]
 			} else {
@@ -326,25 +350,11 @@ func main() {
 		dir = argv[0]
 
 		if err := os.Chdir(dir); err != nil {
-			log.Fatalf("Failed to change directory to %s: %v", dir, err)
+			fmt.Fprintf(os.Stderr, "Failed to change directory to %s: %v\n", dir, err)
+			return 1
 		}
 	} else {
 		dir = "."
-	}
-
-	osfiles, err := os.ReadDir(".")
-	if err != nil {
-		log.Fatalf("Failed to read directory %s: %v", dir, err)
-	}
-
-	var files []*File
-	for _, file := range osfiles {
-		stat, _ := os.Stat(file.Name())
-		files = append(files, &File{
-			entry: file,
-			isDir: file.IsDir(),
-			isExe: !file.IsDir() && stat.Mode()&0o111 != 0,
-		})
 	}
 
 	// Fetch all git data in parallel
@@ -356,14 +366,20 @@ func main() {
 	// https://github.com/llimllib/git-ls/issues/34
 	resolved := must(filepath.EvalSymlinks(must(filepath.Abs("."))))
 	curdir := must(filepath.Rel(gitData.root, resolved))
-	fileStatus(gitData.status, files, curdir)
 
-	// Parse deleted files from git status and merge into file list
-	deletedFiles := parseDeletedFiles(gitData.status, curdir)
-	files = append(files, deletedFiles...)
-
+	var files []*File
 	if changedOnly {
-		files = changedFilesFilter(files)
+		// In --changed-only mode, build the file list directly from git
+		// status so we can show files from subdirectories with their full
+		// relative paths (e.g. "src/network/server.go" not just "src/")
+		files = changedFilesFromStatus(gitData.status, curdir)
+	} else {
+		var err error
+		files, err = filesFromCurDir(dir, gitData, curdir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			return 1
+		}
 	}
 
 	// Now run git log on the files we'll show
@@ -403,12 +419,13 @@ func main() {
 
 	if debug {
 		for _, file := range filesNeedingLog {
-			log.Printf("%s,", file.Name())
+			fmt.Fprintf(os.Stderr, "%s,", file.Name())
 		}
 		fmt.Printf("\n")
 	}
 	if err := parseGitLog(filesNeedingLog); err != nil {
-		log.Fatalf("Error: git log streaming failed: %v", err)
+		fmt.Fprintf(os.Stderr, "Error: git log streaming failed: %v\n", err)
+		return 1
 	}
 	parseDiffStat(gitData.diffStat, files)
 
@@ -439,6 +456,7 @@ func main() {
 		NerdFont:  nerdFont,
 	}
 	showColumns(os.Stdout, maxWidth, files, rctx, formatColumns)
+	return 0
 }
 
 // changedFilesFilter strips unchanged files from the files to display
@@ -450,6 +468,92 @@ func changedFilesFilter(files []*File) []*File {
 		}
 	}
 	return changedFiles
+}
+
+// filesFromCurDir lists the files in the current directory. `dir` is the
+// directory as the user specified it, and `curdir` is the directory as we
+// resolved it from the git root
+func filesFromCurDir(dir string, gitData *gitResults, curdir string) ([]*File, error) {
+	var files []*File
+	osfiles, err := os.ReadDir(".")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read directory %s: %v", dir, err)
+	}
+
+	for _, file := range osfiles {
+		stat, _ := os.Stat(file.Name())
+		files = append(files, &File{
+			entry: file,
+			isDir: file.IsDir(),
+			isExe: !file.IsDir() && stat.Mode()&0o111 != 0,
+		})
+	}
+
+	fileStatus(gitData.status, files, curdir)
+
+	// Parse deleted files from git status and merge into file list
+	deletedFiles := parseDeletedFiles(gitData.status, curdir)
+	return append(files, deletedFiles...), nil
+}
+
+// changedFilesFromStatus builds a list of changed File structs directly from
+// git status output. Unlike the normal flow (which reads the current directory
+// and then filters), this produces files with full relative paths so that
+// --changed-only can show files from subdirectories.
+func changedFilesFromStatus(status []byte, curdir string) []*File {
+	var files []*File
+	seen := make(map[string]bool)
+	for line := range strings.SplitSeq(string(status), "\n") {
+		if len(line) < 3 {
+			continue
+		}
+		statusCode := line[:2]
+		path := line[3:]
+
+		// Skip ignored files
+		if statusCode == "!!" {
+			continue
+		}
+
+		// For renames/copies, use the new name and record the old name
+		var oldName string
+		if (statusCode[0] == 'R' || statusCode[0] == 'C') && strings.Contains(path, " -> ") {
+			parts := strings.SplitN(path, " -> ", 2)
+			oldName = must(filepath.Rel(curdir, parts[0]))
+			path = parts[1]
+		}
+
+		relPath := must(filepath.Rel(curdir, path))
+
+		// Skip files outside the current directory (would start with "..")
+		if strings.HasPrefix(relPath, "..") {
+			continue
+		}
+
+		// Deduplicate (a file can appear in status with different codes)
+		if seen[relPath] {
+			continue
+		}
+		seen[relPath] = true
+
+		isDeleted := statusCode == " D" || statusCode == "D "
+		isExe := false
+		if !isDeleted {
+			if stat, err := os.Stat(relPath); err == nil {
+				isExe = !stat.IsDir() && stat.Mode()&0o111 != 0
+			}
+		}
+
+		file := &File{
+			name:      relPath,
+			status:    statusCode,
+			oldName:   oldName,
+			isDeleted: isDeleted,
+			isExe:     isExe,
+		}
+		files = append(files, file)
+	}
+	return files
 }
 
 func parseFormat(formatStr string) []Column {
@@ -956,12 +1060,24 @@ func parseGitLog(files []*File) error {
 			// This is a filename line
 			filename := strings.TrimSpace(line)
 
-			// Extract the first component (for directories)
-			// e.g., "builtin/add.c" -> "builtin", "main.go" -> "main.go"
-			firstPart := first(filename)
+			// Try to match the full path first (for --changed-only files
+			// with relative paths like "src/network/server.go"), then
+			// fall back to the first component (for directory-level
+			// matching in normal mode, e.g. "builtin/add.c" -> "builtin")
+			var file *File
+			var matchKey string
+			if f, ok := filesNeeded[filename]; ok {
+				file = f
+				matchKey = filename
+			} else {
+				firstPart := first(filename)
+				if f, ok := filesNeeded[firstPart]; ok {
+					file = f
+					matchKey = firstPart
+				}
+			}
 
-			// Check if this is a file/dir we're looking for
-			if file, needed := filesNeeded[firstPart]; needed {
+			if file != nil {
 				// Found it! Populate the file info
 				file.hash = currentCommit.hash
 				file.shortHash = currentCommit.shortHash
@@ -973,7 +1089,7 @@ func parseGitLog(files []*File) error {
 				// Remove from needed set. For renamed/copied files we
 				// may have two keys (old name + new name) pointing to
 				// the same File, so delete both.
-				delete(filesNeeded, firstPart)
+				delete(filesNeeded, matchKey)
 				if file.oldName != "" {
 					delete(filesNeeded, first(file.oldName))
 					delete(filesNeeded, file.Name())
@@ -1068,8 +1184,14 @@ func parseDiffStat(diffStat []byte, files []*File) {
 
 		plus := diffInt(parts[0])
 		minus := diffInt(parts[1])
-		path := first(strings.TrimSpace(parts[2]))
-		diffStats[path] = append(diffStats[path], Diff{plus, minus})
+		fullPath := strings.TrimSpace(parts[2])
+		d := Diff{plus, minus}
+		// Store under both the full relative path (for --changed-only) and
+		// the first component (for directory-level aggregation in normal mode)
+		diffStats[fullPath] = append(diffStats[fullPath], d)
+		if firstPart := first(fullPath); firstPart != fullPath {
+			diffStats[firstPart] = append(diffStats[firstPart], d)
+		}
 	}
 
 	for _, file := range files {

--- a/script_test.go
+++ b/script_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/rogpeppe/go-internal/testscript"
+)
+
+func TestMain(m *testing.M) {
+	testscript.Main(m, map[string]func(){
+		"git-ls": func() { os.Exit(run()) },
+	})
+}
+
+func TestScript(t *testing.T) {
+	testscript.Run(t, testscript.Params{
+		Dir: "testdata/scripts",
+	})
+}

--- a/testdata/scripts/basic.txtar
+++ b/testdata/scripts/basic.txtar
@@ -1,0 +1,26 @@
+# Basic git-ls should list current directory entries
+env NO_COLOR=1
+env HOME=$WORK
+
+mkdir repo
+cd repo
+exec git init -b main
+exec git config user.email test@test.com
+exec git config user.name Test
+
+cp $WORK/files/main.go main.go
+mkdir src
+cp $WORK/files/server.go src/server.go
+exec git add .
+exec git commit -m 'initial commit'
+
+exec git-ls
+stdout 'main\.go'
+# Directories should show as directory name, not expanded contents
+stdout '\\src'
+! stdout 'server\.go'
+
+-- files/main.go --
+package main
+-- files/server.go --
+package server

--- a/testdata/scripts/changed_only_filter.txtar
+++ b/testdata/scripts/changed_only_filter.txtar
@@ -1,0 +1,28 @@
+# --changed-only should only show files with git status changes
+env NO_COLOR=1
+env HOME=$WORK
+
+mkdir repo
+cd repo
+exec git init -b main
+exec git config user.email test@test.com
+exec git config user.name Test
+
+cp $WORK/files/clean.go clean.go
+cp $WORK/files/modified-v1.go modified.go
+exec git add .
+exec git commit -m 'initial commit'
+
+# Modify one file, leave the other untouched
+cp $WORK/files/modified-v2.go modified.go
+
+exec git-ls --changed-only
+stdout 'modified\.go'
+! stdout 'clean\.go'
+
+-- files/clean.go --
+package main
+-- files/modified-v1.go --
+package main // v1
+-- files/modified-v2.go --
+package main // v2

--- a/testdata/scripts/changed_only_paths.txtar
+++ b/testdata/scripts/changed_only_paths.txtar
@@ -1,0 +1,61 @@
+# --changed-only shows full relative paths for files in subdirectories
+env NO_COLOR=1
+env HOME=$WORK
+
+mkdir repo
+cd repo
+exec git init -b main
+exec git config user.email test@test.com
+exec git config user.name Test
+
+# Create files in nested directories
+mkdir src/network
+mkdir src/trimble
+cp $WORK/files/readme.txt README.md
+cp $WORK/files/server.txt src/network/server.go
+cp $WORK/files/tork.txt src/network/tork.go
+cp $WORK/files/alpha.txt src/trimble/alpha.go
+
+exec git add .
+exec git commit -m 'initial commit'
+
+# Modify files at different levels
+cp $WORK/files/modified-readme.txt README.md
+cp $WORK/files/modified-server.txt src/network/server.go
+cp $WORK/files/modified-tork.txt src/network/tork.go
+
+# From repo root, --changed-only should show full relative paths
+exec git-ls --changed-only
+stdout 'README\.md'
+stdout 'src/network/server\.go'
+stdout 'src/network/tork\.go'
+! stdout 'trimble'
+
+# From a subdirectory, only files at or below that dir should appear
+cd src
+exec git-ls --changed-only
+stdout 'network/server\.go'
+stdout 'network/tork\.go'
+! stdout 'README'
+! stdout 'trimble'
+
+# From a leaf directory, just basenames
+cd network
+exec git-ls --changed-only
+stdout '\\server\.go'
+stdout '\\tork\.go'
+
+-- files/readme.txt --
+# readme
+-- files/modified-readme.txt --
+# updated readme
+-- files/server.txt --
+package network
+-- files/modified-server.txt --
+package network // modified server
+-- files/tork.txt --
+package network
+-- files/modified-tork.txt --
+package network // modified tork
+-- files/alpha.txt --
+package trimble

--- a/transcripts/47-changed-relative-paths.html/index.html
+++ b/transcripts/47-changed-relative-paths.html/index.html
@@ -1,0 +1,821 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Claude Code transcript - Index</title>
+    <style>
+:root { --bg-color: #f5f5f5; --card-bg: #ffffff; --user-bg: #e3f2fd; --user-border: #1976d2; --assistant-bg: #f5f5f5; --assistant-border: #9e9e9e; --thinking-bg: #fff8e1; --thinking-border: #ffc107; --thinking-text: #666; --tool-bg: #f3e5f5; --tool-border: #9c27b0; --tool-result-bg: #e8f5e9; --tool-error-bg: #ffebee; --text-color: #212121; --text-muted: #757575; --code-bg: #263238; --code-text: #aed581; }
+* { box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg-color); color: var(--text-color); margin: 0; padding: 16px; line-height: 1.6; }
+.container { max-width: 800px; margin: 0 auto; }
+h1 { font-size: 1.5rem; margin-bottom: 24px; padding-bottom: 8px; border-bottom: 2px solid var(--user-border); }
+.header-row { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; border-bottom: 2px solid var(--user-border); padding-bottom: 8px; margin-bottom: 24px; }
+.header-row h1 { border-bottom: none; padding-bottom: 0; margin-bottom: 0; flex: 1; min-width: 200px; }
+.message { margin-bottom: 16px; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.message.user { background: var(--user-bg); border-left: 4px solid var(--user-border); }
+.message.assistant { background: var(--card-bg); border-left: 4px solid var(--assistant-border); }
+.message.tool-reply { background: #fff8e1; border-left: 4px solid #ff9800; }
+.tool-reply .role-label { color: #e65100; }
+.tool-reply .tool-result { background: transparent; padding: 0; margin: 0; }
+.tool-reply .tool-result .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff8e1); }
+.message-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 16px; background: rgba(0,0,0,0.03); font-size: 0.85rem; }
+.role-label { font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
+.user .role-label { color: var(--user-border); }
+time { color: var(--text-muted); font-size: 0.8rem; }
+.timestamp-link { color: inherit; text-decoration: none; }
+.timestamp-link:hover { text-decoration: underline; }
+.message:target { animation: highlight 2s ease-out; }
+@keyframes highlight { 0% { background-color: rgba(25, 118, 210, 0.2); } 100% { background-color: transparent; } }
+.message-content { padding: 16px; }
+.message-content p { margin: 0 0 12px 0; }
+.message-content p:last-child { margin-bottom: 0; }
+.thinking { background: var(--thinking-bg); border: 1px solid var(--thinking-border); border-radius: 8px; padding: 12px; margin: 12px 0; font-size: 0.9rem; color: var(--thinking-text); }
+.thinking-label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: #f57c00; margin-bottom: 8px; }
+.thinking p { margin: 8px 0; }
+.assistant-text { margin: 8px 0; }
+.tool-use { background: var(--tool-bg); border: 1px solid var(--tool-border); border-radius: 8px; padding: 12px; margin: 12px 0; }
+.tool-header { font-weight: 600; color: var(--tool-border); margin-bottom: 8px; display: flex; align-items: center; gap: 8px; }
+.tool-icon { font-size: 1.1rem; }
+.tool-description { font-size: 0.9rem; color: var(--text-muted); margin-bottom: 8px; font-style: italic; }
+.tool-result { background: var(--tool-result-bg); border-radius: 8px; padding: 12px; margin: 12px 0; }
+.tool-result.tool-error { background: var(--tool-error-bg); }
+.file-tool { border-radius: 8px; padding: 12px; margin: 12px 0; }
+.write-tool { background: linear-gradient(135deg, #e3f2fd 0%, #e8f5e9 100%); border: 1px solid #4caf50; }
+.edit-tool { background: linear-gradient(135deg, #fff3e0 0%, #fce4ec 100%); border: 1px solid #ff9800; }
+.file-tool-header { font-weight: 600; margin-bottom: 4px; display: flex; align-items: center; gap: 8px; font-size: 0.95rem; }
+.write-header { color: #2e7d32; }
+.edit-header { color: #e65100; }
+.file-tool-icon { font-size: 1rem; }
+.file-tool-path { font-family: monospace; background: rgba(0,0,0,0.08); padding: 2px 8px; border-radius: 4px; }
+.file-tool-fullpath { font-family: monospace; font-size: 0.8rem; color: var(--text-muted); margin-bottom: 8px; word-break: break-all; }
+.file-content { margin: 0; }
+.edit-section { display: flex; margin: 4px 0; border-radius: 4px; overflow: hidden; }
+.edit-label { padding: 8px 12px; font-weight: bold; font-family: monospace; display: flex; align-items: flex-start; }
+.edit-old { background: #fce4ec; }
+.edit-old .edit-label { color: #b71c1c; background: #f8bbd9; }
+.edit-old .edit-content { color: #880e4f; }
+.edit-new { background: #e8f5e9; }
+.edit-new .edit-label { color: #1b5e20; background: #a5d6a7; }
+.edit-new .edit-content { color: #1b5e20; }
+.edit-content { margin: 0; flex: 1; background: transparent; font-size: 0.85rem; }
+.edit-replace-all { font-size: 0.75rem; font-weight: normal; color: var(--text-muted); }
+.write-tool .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #e6f4ea); }
+.edit-tool .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff0e5); }
+.todo-list { background: linear-gradient(135deg, #e8f5e9 0%, #f1f8e9 100%); border: 1px solid #81c784; border-radius: 8px; padding: 12px; margin: 12px 0; }
+.todo-header { font-weight: 600; color: #2e7d32; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; font-size: 0.95rem; }
+.todo-items { list-style: none; margin: 0; padding: 0; }
+.todo-item { display: flex; align-items: flex-start; gap: 10px; padding: 6px 0; border-bottom: 1px solid rgba(0,0,0,0.06); font-size: 0.9rem; }
+.todo-item:last-child { border-bottom: none; }
+.todo-icon { flex-shrink: 0; width: 20px; height: 20px; display: flex; align-items: center; justify-content: center; font-weight: bold; border-radius: 50%; }
+.todo-completed .todo-icon { color: #2e7d32; background: rgba(46, 125, 50, 0.15); }
+.todo-completed .todo-content { color: #558b2f; text-decoration: line-through; }
+.todo-in-progress .todo-icon { color: #f57c00; background: rgba(245, 124, 0, 0.15); }
+.todo-in-progress .todo-content { color: #e65100; font-weight: 500; }
+.todo-pending .todo-icon { color: #757575; background: rgba(0,0,0,0.05); }
+.todo-pending .todo-content { color: #616161; }
+pre { background: var(--code-bg); color: var(--code-text); padding: 12px; border-radius: 6px; overflow-x: auto; font-size: 0.85rem; line-height: 1.5; margin: 8px 0; white-space: pre-wrap; word-wrap: break-word; }
+pre.json { color: #e0e0e0; }
+code { background: rgba(0,0,0,0.08); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+pre code { background: none; padding: 0; }
+.user-content { margin: 0; }
+.truncatable { position: relative; }
+.truncatable.truncated .truncatable-content { max-height: 200px; overflow: hidden; }
+.truncatable.truncated::after { content: ''; position: absolute; bottom: 32px; left: 0; right: 0; height: 60px; background: linear-gradient(to bottom, transparent, var(--card-bg)); pointer-events: none; }
+.message.user .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--user-bg)); }
+.message.tool-reply .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff8e1); }
+.tool-use .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--tool-bg)); }
+.tool-result .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--tool-result-bg)); }
+.expand-btn { display: none; width: 100%; padding: 8px 16px; margin-top: 4px; background: rgba(0,0,0,0.05); border: 1px solid rgba(0,0,0,0.1); border-radius: 6px; cursor: pointer; font-size: 0.85rem; color: var(--text-muted); }
+.expand-btn:hover { background: rgba(0,0,0,0.1); }
+.truncatable.truncated .expand-btn, .truncatable.expanded .expand-btn { display: block; }
+.pagination { display: flex; justify-content: center; gap: 8px; margin: 24px 0; flex-wrap: wrap; }
+.pagination a, .pagination span { padding: 5px 10px; border-radius: 6px; text-decoration: none; font-size: 0.85rem; }
+.pagination a { background: var(--card-bg); color: var(--user-border); border: 1px solid var(--user-border); }
+.pagination a:hover { background: var(--user-bg); }
+.pagination .current { background: var(--user-border); color: white; }
+.pagination .disabled { color: var(--text-muted); border: 1px solid #ddd; }
+.pagination .index-link { background: var(--user-border); color: white; }
+details.continuation { margin-bottom: 16px; }
+details.continuation summary { cursor: pointer; padding: 12px 16px; background: var(--user-bg); border-left: 4px solid var(--user-border); border-radius: 12px; font-weight: 500; color: var(--text-muted); }
+details.continuation summary:hover { background: rgba(25, 118, 210, 0.15); }
+details.continuation[open] summary { border-radius: 12px 12px 0 0; margin-bottom: 0; }
+.index-item { margin-bottom: 16px; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); background: var(--user-bg); border-left: 4px solid var(--user-border); }
+.index-item a { display: block; text-decoration: none; color: inherit; }
+.index-item a:hover { background: rgba(25, 118, 210, 0.1); }
+.index-item-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 16px; background: rgba(0,0,0,0.03); font-size: 0.85rem; }
+.index-item-number { font-weight: 600; color: var(--user-border); }
+.index-item-content { padding: 16px; }
+.index-item-stats { padding: 8px 16px 12px 32px; font-size: 0.85rem; color: var(--text-muted); border-top: 1px solid rgba(0,0,0,0.06); }
+.index-item-commit { margin-top: 6px; padding: 4px 8px; background: #fff3e0; border-radius: 4px; font-size: 0.85rem; color: #e65100; }
+.index-item-commit code { background: rgba(0,0,0,0.08); padding: 1px 4px; border-radius: 3px; font-size: 0.8rem; margin-right: 6px; }
+.commit-card { margin: 8px 0; padding: 10px 14px; background: #fff3e0; border-left: 4px solid #ff9800; border-radius: 6px; }
+.commit-card a { text-decoration: none; color: #5d4037; display: block; }
+.commit-card a:hover { color: #e65100; }
+.commit-card-hash { font-family: monospace; color: #e65100; font-weight: 600; margin-right: 8px; }
+.index-commit { margin-bottom: 12px; padding: 10px 16px; background: #fff3e0; border-left: 4px solid #ff9800; border-radius: 8px; box-shadow: 0 1px 2px rgba(0,0,0,0.05); }
+.index-commit a { display: block; text-decoration: none; color: inherit; }
+.index-commit a:hover { background: rgba(255, 152, 0, 0.1); margin: -10px -16px; padding: 10px 16px; border-radius: 8px; }
+.index-commit-header { display: flex; justify-content: space-between; align-items: center; font-size: 0.85rem; margin-bottom: 4px; }
+.index-commit-hash { font-family: monospace; color: #e65100; font-weight: 600; }
+.index-commit-msg { color: #5d4037; }
+.index-item-long-text { margin-top: 8px; padding: 12px; background: var(--card-bg); border-radius: 8px; border-left: 3px solid var(--assistant-border); }
+.index-item-long-text .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--card-bg)); }
+.index-item-long-text-content { color: var(--text-color); }
+#search-box { display: none; align-items: center; gap: 8px; }
+#search-box input { padding: 6px 12px; border: 1px solid var(--assistant-border); border-radius: 6px; font-size: 16px; width: 180px; }
+#search-box button, #modal-search-btn, #modal-close-btn { background: var(--user-border); color: white; border: none; border-radius: 6px; padding: 6px 10px; cursor: pointer; display: flex; align-items: center; justify-content: center; }
+#search-box button:hover, #modal-search-btn:hover { background: #1565c0; }
+#modal-close-btn { background: var(--text-muted); margin-left: 8px; }
+#modal-close-btn:hover { background: #616161; }
+#search-modal[open] { border: none; border-radius: 12px; box-shadow: 0 4px 24px rgba(0,0,0,0.2); padding: 0; width: 90vw; max-width: 900px; height: 80vh; max-height: 80vh; display: flex; flex-direction: column; }
+#search-modal::backdrop { background: rgba(0,0,0,0.5); }
+.search-modal-header { display: flex; align-items: center; gap: 8px; padding: 16px; border-bottom: 1px solid var(--assistant-border); background: var(--bg-color); border-radius: 12px 12px 0 0; }
+.search-modal-header input { flex: 1; padding: 8px 12px; border: 1px solid var(--assistant-border); border-radius: 6px; font-size: 16px; }
+#search-status { padding: 8px 16px; font-size: 0.85rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
+#search-results { flex: 1; overflow-y: auto; padding: 16px; }
+.search-result { margin-bottom: 16px; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.search-result a { display: block; text-decoration: none; color: inherit; }
+.search-result a:hover { background: rgba(25, 118, 210, 0.05); }
+.search-result-page { padding: 6px 12px; background: rgba(0,0,0,0.03); font-size: 0.8rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
+.search-result-content { padding: 12px; }
+.search-result mark { background: #fff59d; padding: 1px 2px; border-radius: 2px; }
+@media (max-width: 600px) { body { padding: 8px; } .message, .index-item { border-radius: 8px; } .message-content, .index-item-content { padding: 12px; } pre { font-size: 0.8rem; padding: 8px; } #search-box input { width: 120px; } #search-modal[open] { width: 95vw; height: 90vh; } }
+</style>
+</head>
+<body>
+    <div class="container">
+        <div class="header-row">
+            <h1>Claude Code transcript</h1>
+            <div id="search-box">
+                <input type="text" id="search-input" placeholder="Search..." aria-label="Search transcripts">
+                <button id="search-btn" type="button" aria-label="Search">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.35-4.35"></path></svg>
+                </button>
+            </div>
+        </div>
+        
+
+<div class="pagination">
+<span class="current">Index</span>
+<span class="disabled">&larr; Prev</span>
+<a href="page-001.html">1</a>
+<a href="page-002.html">2</a>
+<a href="page-003.html">3</a>
+<a href="page-004.html">4</a>
+<a href="page-005.html">5</a>
+<a href="page-001.html">Next &rarr;</a>
+</div>
+
+        <p style="color: var(--text-muted); margin-bottom: 24px;">24 prompts · 352 messages · 119 tool calls · 1 commits · 5 pages</p>
+        
+<div class="index-item"><a href="page-001.html#msg-2026-04-11T01-53-49-966Z"><div class="index-item-header"><span class="index-item-number">#1</span><time datetime="2026-04-11T01:53:49.966Z" data-timestamp="2026-04-11T01:53:49.966Z">2026-04-11T01:53:49.966Z</time></div><div class="index-item-content"><p><local-command-caveat>Caveat: The messages below were generated by the user while running local commands. DO NOT respond to these messages or otherwise consider them in your response unless the user explicitly asks you to.</local-command-caveat></p></div></a></div>
+<div class="index-item"><a href="page-001.html#msg-2026-04-11T01-53-49-966Z"><div class="index-item-header"><span class="index-item-number">#2</span><time datetime="2026-04-11T01:53:49.966Z" data-timestamp="2026-04-11T01:53:49.966Z">2026-04-11T01:53:49.966Z</time></div><div class="index-item-content"><p><command-name>/sandbox</command-name>
+            <command-message>sandbox</command-message>
+            <command-args></command-args></p></div></a></div>
+<div class="index-item"><a href="page-001.html#msg-2026-04-11T01-53-49-966Z"><div class="index-item-header"><span class="index-item-number">#3</span><time datetime="2026-04-11T01:53:49.966Z" data-timestamp="2026-04-11T01:53:49.966Z">2026-04-11T01:53:49.966Z</time></div><div class="index-item-content"><p><local-command-stdout>✓ Sandbox enabled with auto-allow for bash commands</local-command-stdout></p></div></a></div>
+<div class="index-item"><a href="page-001.html#msg-2026-04-11T01-54-16-928Z"><div class="index-item-header"><span class="index-item-number">#4</span><time datetime="2026-04-11T01:54:16.928Z" data-timestamp="2026-04-11T01:54:16.928Z">2026-04-11T01:54:16.928Z</time></div><div class="index-item-content"><p>read https://github.com/llimllib/git-ls/issues/44</p></div></a><div class="index-item-stats"><span>2 bash</span>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>Here's <strong>llimllib/git-ls#44</strong> — "feature: tree view" (OPEN):</p>
+<p>The issue proposes a <code>--tree</code> flag, especially useful with <code>--changed-only</code>, to display files in a tree structure. Two options are presented:</p>
+<p><strong>Option 1: Actual tree with box-drawing characters</strong></p>
+<pre><code>$ git ls --tree --changed-only
+M README.md ++++ a749399289 2026-04-08 Bill Mill docs: document the glooping
+src
+├─ network
+│  ├─ M server.go ++-- c14a93aa8b 2026-04-08 Bill Mill fix: de-glorp the glooper
+│  └─ M tork.go   ---- c14a93aa8b 2026-04-08 Bill Mill fix: de-glorp the glooper
+├─ trimble
+│  └─ M alpha.go  +++- d25b04bb9c 2026-04-08 Bill Mill feat: enable auto-glooping
+</code></pre>
+<p><strong>Option 2: Flat paths like <code>git status</code></strong></p>
+<pre><code>$ git ls --tree --changed-only
+M README.md             ++++ a749399289 2026-04-08 Bill Mill ...
+M src/network/server.go ++-- c14a93aa8b 2026-04-08 Bill Mill ...
+M src/network/tork.go   ---- c14a93aa8b 2026-04-08 Bill Mill ...
+M trimble/alpha.go      +++- d25b04bb9c 2026-04-08 Bill Mill ...
+</code></pre>
+<p><strong>Open questions raised:</strong>
+- Column alignment: per-level or per-branch?
+- Maximum depth? Deep branches would be hard to display, and adding a max-depth flag adds complexity.</p>
+<p>No comments or labels yet.</p></div></div><button class="expand-btn">Show more</button></div></div>
+</div></div>
+<div class="index-item"><a href="page-001.html#msg-2026-04-11T01-55-01-207Z"><div class="index-item-header"><span class="index-item-number">#5</span><time datetime="2026-04-11T01:55:01.207Z" data-timestamp="2026-04-11T01:55:01.207Z">2026-04-11T01:55:01.207Z</time></div><div class="index-item-content"><p>which option makes more sense to you?</p></div></a><div class="index-item-stats">
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>Option 1 (the actual tree with box-drawing characters) is more interesting but I think Option 2 (flat paths) makes more sense, for a few reasons:</p>
+<ol>
+<li>
+<p><strong>Column alignment is straightforward.</strong> With flat paths, all filenames are at the same indentation level, so you just pad to the longest path. With a tree, alignment gets tricky — do you align across siblings? across the whole tree? The issue raises this question and there's no clean answer.</p>
+</li>
+<li>
+<p><strong>No depth problem.</strong> Deep nesting just means a longer path string, not an ever-widening indent with box-drawing prefixes eating into your terminal width.</p>
+</li>
+<li>
+<p><strong>No new flags needed.</strong> No max-depth flag, no questions about collapsing directories, etc.</p>
+</li>
+<li>
+<p><strong>It's what <code>git status</code> does.</strong> Users already expect this mental model from git — showing paths relative to the repo root. Option 1 looks nice in the issue but is a format nobody's used to reading alongside git metadata columns.</p>
+</li>
+<li>
+<p><strong>Simpler to implement and maintain.</strong> The tree-drawing logic (tracking which branches are last children, nesting prefixes) is fiddly and would complicate the column-formatting code that already exists.</p>
+</li>
+</ol>
+<p>Really the only advantage of Option 1 is that it looks cool, but it trades a lot of complexity for that. Option 2 gives you the key benefit — seeing directory structure at a glance — without the downsides.</p>
+<p>Want me to look at the codebase and start thinking about implementation?</p></div></div><button class="expand-btn">Show more</button></div></div>
+</div></div>
+<div class="index-item"><a href="page-002.html#msg-2026-04-11T01-56-04-099Z"><div class="index-item-header"><span class="index-item-number">#6</span><time datetime="2026-04-11T01:56:04.099Z" data-timestamp="2026-04-11T01:56:04.099Z">2026-04-11T01:56:04.099Z</time></div><div class="index-item-content"><p>--tree doesn't make sense to me any longer with that, I wonder if it should be the default behavior for --changed-only</p></div></a><div class="index-item-stats">
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>That makes sense — if you're using <code>--changed-only</code>, you're already looking at a small subset of files, so showing full paths relative to the repo root is natural and arguably the <em>expected</em> behavior. The current behavior of just showing the filename without the path means you can't tell which <code>server.go</code> you're looking at if there are multiple.</p>
+<p>Making it the default for <code>--changed-only</code> is cleaner than adding a flag. No new flags, no decision fatigue, and the display is still compact since the file count is small.</p>
+<p>Want me to dig into the codebase and see how filenames are currently rendered so we can figure out what needs to change?</p></div></div><button class="expand-btn">Show more</button></div></div>
+</div></div>
+<div class="index-item"><a href="page-002.html#msg-2026-04-11T01-56-26-841Z"><div class="index-item-header"><span class="index-item-number">#7</span><time datetime="2026-04-11T01:56:26.841Z" data-timestamp="2026-04-11T01:56:26.841Z">2026-04-11T01:56:26.841Z</time></div><div class="index-item-content"><p>yeah let's take a look</p></div></a><div class="index-item-stats"><span>5 read · 1 agent</span>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>Here's the picture:</p>
+<p><strong>Current behavior:</strong> The tool runs <code>os.ReadDir(".")</code> on the current directory, so it only sees immediate entries (files and directories). <code>file.Name()</code> returns the basename only — you see <code>main.go</code>, not <code>src/network/main.go</code>.</p>
+<p><strong>The problem for <code>--changed-only</code>:</strong> <code>git status</code> reports changed files throughout the whole repo tree, but <code>os.ReadDir(".")</code> only lists the current directory. So <code>--changed-only</code> can only show changed files that happen to be in the current directory (or directories containing changed files). You can't see <code>src/network/server.go</code> as its own line — you'd just see <code>src/</code> as a directory.</p>
+<p>To make <code>--changed-only</code> show full relative paths, you'd need to:</p>
+<ol>
+<li>
+<p><strong>When <code>--changed-only</code> is active, build the file list from <code>git status</code> output</strong> instead of <code>os.ReadDir(".")</code>. The status data already has the full repo-relative paths — parse those into <code>File</code> structs with a <code>name</code> field containing the relative path (e.g. <code>src/network/server.go</code>).</p>
+</li>
+<li>
+<p><strong>Update <code>renderFilename</code></strong> to use the relative path for display and width calculation — which it already would if <code>file.Name()</code> returns the full relative path.</p>
+</li>
+<li>
+<p><strong>Fix the hyperlink URL</strong> in <code>renderFilename</code> — <code>filepath.Join(rctx.Dir, file.Name())</code> should still work since <code>rctx.Dir</code> is the abs path of the working directory.</p>
+</li>
+</ol>
+<p>The key insight is that <code>--changed-only</code> should switch from "list directory entries then filter" to "list changed files from git status directly." Want me to start on an implementation?</p></div></div><button class="expand-btn">Show more</button></div></div>
+</div></div>
+<div class="index-item"><a href="page-002.html#msg-2026-04-11T01-58-50-634Z"><div class="index-item-header"><span class="index-item-number">#8</span><time datetime="2026-04-11T01:58:50.634Z" data-timestamp="2026-04-11T01:58:50.634Z">2026-04-11T01:58:50.634Z</time></div><div class="index-item-content"><p>sure give it a shot</p></div></a><div class="index-item-stats"><span>11 read · 11 bash · 8 grep · 4 edit</span>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>Now let me check how <code>parseGitLog</code> handles paths — it uses <code>--relative</code> and <code>-- .</code> to scope to the current directory, and <code>first()</code> to get the first path component. For <code>--changed-only</code> with full paths, the git log approach needs to match full relative paths instead.</p>
+<p>Let me also check if there are tests I should look at.</p></div></div><button class="expand-btn">Show more</button></div></div>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>Now I have a solid understanding. Let me plan the implementation:</p>
+<ol>
+<li>When <code>--changed-only</code> is active, build <code>File</code> structs from git status output with full relative paths (instead of from <code>os.ReadDir(".")</code>)</li>
+<li>Adapt <code>parseGitLog</code> to work with full relative paths (not just first path components)</li>
+<li>Adapt <code>parseDiffStat</code> similarly</li>
+<li>The <code>renderFilename</code> and width calculation should just work since they use <code>file.Name()</code></li>
+</ol>
+<p>Let me look at the main flow one more time to see how <code>changedOnly</code> is threaded through.</p></div></div><button class="expand-btn">Show more</button></div></div>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>Now I have a clear picture. Here's the approach:</p>
+<p>For <code>--changed-only</code>, instead of reading the current directory and filtering, we'll build <code>File</code> structs directly from <code>git status</code> output with their full relative paths. The key changes:</p>
+<ol>
+<li><strong>New function <code>changedFilesFromStatus</code></strong> — parses git status to create <code>File</code> structs with relative paths</li>
+<li><strong>Adjust <code>parseGitLog</code></strong> — when files have paths with separators, look them up by full path not just <code>first()</code></li>
+<li><strong>Adjust <code>parseDiffStat</code></strong> — same, match on full path</li>
+<li><strong>Wire it up</strong> in the main flow, skipping <code>os.ReadDir</code> when <code>--changed-only</code></li>
+</ol>
+<p>Let me implement this.</p></div></div><button class="expand-btn">Show more</button></div></div>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>Now I understand the full picture. The tricky parts:</p>
+<ol>
+<li><code>parseGitLog</code> uses <code>--relative</code> and <code>-- .</code> which scopes to the current dir. For <code>--changed-only</code> with recursive files, we need it to search more broadly and match on full relative paths.</li>
+<li><code>parseDiffStat</code> uses <code>--relative</code> which gives paths relative to cwd — it also uses <code>first()</code> to collapse to directory level.</li>
+</ol>
+<p>Let me implement the change. I'll create a new function that builds file list from git status for <code>--changed-only</code>, and adjust the git log/diff matching.</p></div></div><button class="expand-btn">Show more</button></div></div>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>The current <code>parseGitLog</code> uses <code>first(filename)</code> to collapse <code>builtin/add.c</code> → <code>builtin</code> for directory-level matching. For <code>--changed-only</code> files, we need to match on the full path. The git log output with <code>--relative</code> already gives paths relative to cwd, so we just need to check both the full path and the <code>first()</code> component.</p>
+<p>Let me update <code>parseGitLog</code> to also check for full-path matches:</p></div></div><button class="expand-btn">Show more</button></div></div>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>Now I need to update the matching. The <code>filesNeeded</code> map is keyed by <code>file.Name()</code>. In the normal case, <code>Name()</code> returns a basename like <code>main.go</code> or directory name like <code>src</code>. In our <code>--changed-only</code> case, <code>Name()</code> returns a full relative path like <code>src/network/server.go</code>.</p>
+<p>The git log output with <code>--relative</code> gives paths like <code>src/network/server.go</code>. Currently <code>first("src/network/server.go")</code> → <code>"src"</code> which matches a directory entry. For our full-path files, we need to match the full filename.</p>
+<p>The simplest approach: check both the full filename AND <code>first(filename)</code> against <code>filesNeeded</code>:</p></div></div><button class="expand-btn">Show more</button></div></div>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>That's working nicely. Files show their full relative paths with proper column alignment:</p>
+<pre><code>M +- README.md              c5f36b1 2026-04-10 Test initial commit
+M +- src/network/server.go  c5f36b1 2026-04-10 Test initial commit
+M +- src/network/tork.go    c5f36b1 2026-04-10 Test initial commit
+M +- src/trimble/alpha.go   c5f36b1 2026-04-10 Test initial commit
+</code></pre>
+<p>Let me also verify the normal (non <code>--changed-only</code>) mode still works:</p></div></div><button class="expand-btn">Show more</button></div></div>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>All 15 tests pass. Here's a summary of the changes:</p>
+<p><strong>What changed in <code>main.go</code>:</strong></p>
+<ol>
+<li>
+<p><strong>Reordered the main flow</strong> (lines ~335-370): <code>fetchGitData()</code> and <code>curdir</code> calculation now happen before building the file list, since <code>--changed-only</code> needs the git status data to build files.</p>
+</li>
+<li>
+<p><strong>New function <code>changedFilesFromStatus</code></strong> (after line ~457): When <code>--changed-only</code> is active, builds <code>File</code> structs directly from <code>git status</code> output with full relative paths (e.g. <code>src/network/server.go</code>) instead of reading the current directory. Handles renames, deletes, ignores, and deduplication.</p>
+</li>
+<li>
+<p><strong>Updated <code>parseGitLog</code></strong> (line ~1019): Now tries to match git log filenames against the full relative path first, then falls back to <code>first()</code> for directory-level matching. This lets it find commit history for nested files.</p>
+</li>
+<li>
+<p><strong>Updated <code>parseDiffStat</code></strong> (line ~1137): Stores diff stats under both the full path and the first component, so both <code>--changed-only</code> (full path) and normal mode (directory aggregation) find their data.</p>
+</li>
+</ol></div></div><button class="expand-btn">Show more</button></div></div>
+</div></div>
+<div class="index-item"><a href="page-002.html#msg-2026-04-11T02-05-07-972Z"><div class="index-item-header"><span class="index-item-number">#9</span><time datetime="2026-04-11T02:05:07.972Z" data-timestamp="2026-04-11T02:05:07.972Z">2026-04-11T02:05:07.972Z</time></div><div class="index-item-content"><p>I'm having an internal debate on whether it's sensible to include this change in this tool. From one perspective, we're listing files with both regular "git ls" and "git ls -c", but in the second we're listing them by status rather than directory. From another perspective, that ought to be "git stat" or some different command name</p></div></a><div class="index-item-stats">
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>That's a fair tension. I think there's a reasonable argument that it still belongs in <code>git ls</code>:</p>
+<p>The tool's job is "list files with git annotations." <code>--changed-only</code> is already a filter on that list — it just says "only show files that have status." Showing their full paths is a natural consequence of the fact that they're no longer scoped to one directory. You're not changing <em>what</em> the tool does (list files with metadata), just <em>which</em> files and <em>how they're identified</em>.</p>
+<p>On the other hand, I see the <code>git stat</code> argument — once you're showing a flat list of changed files across the whole tree, you're basically in <code>git status</code> territory but with richer annotations. It starts feeling like a different verb.</p>
+<p>A middle-ground framing: <code>git ls</code> lists files in the current directory. <code>git ls -c</code> lists files in the current directory that have changed. The new behavior would be <code>git ls -c</code> lists changed files anywhere under the current directory — which is a subtle but real scope change from "filter the directory listing" to "search the tree for changes."</p>
+<p>I'd lean toward keeping it in <code>git ls</code> because:
+- It's a mode of the same tool, not a standalone workflow
+- Users who already reach for <code>git ls -c</code> would expect this, not a second command
+- Adding a whole new command for what amounts to "show paths instead of basenames" feels heavyweight</p>
+<p>But if it bugs you, you could also frame it as: the default <code>git ls -c</code> stays as-is (current directory), and a new flag like <code>--recursive</code> or <code>-r</code> opts into the tree-wide behavior. That way the scope change is explicit. Though that might be the flag creep you were trying to avoid.</p></div></div><button class="expand-btn">Show more</button></div></div>
+</div></div>
+<div class="index-item"><a href="page-002.html#msg-2026-04-11T02-06-29-329Z"><div class="index-item-header"><span class="index-item-number">#10</span><time datetime="2026-04-11T02:06:29.329Z" data-timestamp="2026-04-11T02:06:29.329Z">2026-04-11T02:06:29.329Z</time></div><div class="index-item-content"><p>yeah this is a good point - this PR as it stands would be a behavior change when in a subdirectory. Previously it would have listed the changed files in the current directory or below, but now it would list all changed files from the root</p></div></a><div class="index-item-stats">
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>Right, and that's probably not what someone running <code>git ls -c</code> from a subdirectory expects. They're in <code>src/network/</code> and want to see what changed <em>here</em>, not everything across the whole repo.</p>
+<p>The current behavior — list the current directory's entries, filtered to changed ones — is actually correct for subdirectories. The gap is just that when you're at the repo root, changed files in subdirectories get collapsed into directory names like <code>src/</code> instead of showing <code>src/network/server.go</code>.</p>
+<p>So maybe the right behavior for <code>--changed-only</code> is: show changed files <strong>at or below</strong> the current directory, with paths relative to the current directory. That way:</p>
+<ul>
+<li>From the repo root: you see <code>src/network/server.go</code> (the useful new behavior)</li>
+<li>From <code>src/network/</code>: you see <code>server.go</code>, <code>tork.go</code> (same as before, no regression)</li>
+<li>From <code>src/</code>: you see <code>network/server.go</code>, <code>trimble/alpha.go</code></li>
+</ul>
+<p>That's really just making <code>--changed-only</code> recursive from wherever you are, which feels like the natural expectation. Want me to adjust the implementation? The <code>changedFilesFromStatus</code> function already filters out <code>..</code> paths, so it should mostly be right — I just need to verify the path handling is relative to cwd, not the repo root.</p></div></div><button class="expand-btn">Show more</button></div></div>
+</div></div>
+<div class="index-item"><a href="page-003.html#msg-2026-04-11T02-07-05-425Z"><div class="index-item-header"><span class="index-item-number">#11</span><time datetime="2026-04-11T02:07:05.425Z" data-timestamp="2026-04-11T02:07:05.425Z">2026-04-11T02:07:05.425Z</time></div><div class="index-item-content"><p>yes please, I like that</p></div></a><div class="index-item-stats"><span>3 bash · 1 read</span>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>The path handling is already relative to <code>curdir</code> via <code>filepath.Rel(curdir, path)</code>, and it filters out <code>..</code> paths. So from <code>src/network/</code>, a file at <code>src/network/server.go</code> (in git status as repo-root-relative) would become <code>server.go</code>, and a file at <code>src/trimble/alpha.go</code> would become <code>../trimble/alpha.go</code> and get filtered out. That's correct.</p>
+<p>Let me test from a subdirectory to confirm:</p></div></div><button class="expand-btn">Show more</button></div></div>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>It's working exactly as intended:</p>
+<ul>
+<li><strong>From repo root</strong>: <code>README.md</code>, <code>src/network/server.go</code>, <code>src/network/tork.go</code>, <code>src/trimble/alpha.go</code></li>
+<li><strong>From <code>src/</code></strong>: <code>network/server.go</code>, <code>network/tork.go</code>, <code>trimble/alpha.go</code> (no <code>README.md</code> — it's outside)</li>
+<li><strong>From <code>src/network/</code></strong>: <code>server.go</code>, <code>tork.go</code> (just the two files here, basenames only)</li>
+</ul>
+<p>Paths are always relative to wherever you are, and files outside your current directory are excluded. Let me run the tests once more:</p></div></div><button class="expand-btn">Show more</button></div></div>
+</div></div>
+<div class="index-item"><a href="page-003.html#msg-2026-04-11T02-10-23-814Z"><div class="index-item-header"><span class="index-item-number">#12</span><time datetime="2026-04-11T02:10:23.814Z" data-timestamp="2026-04-11T02:10:23.814Z">2026-04-11T02:10:23.814Z</time></div><div class="index-item-content"><p>--nerdfont doesn't work properly with it:</p>
+<p>```</p></div></a></div>
+<div class="index-item"><a href="page-003.html#msg-2026-04-11T02-10-28-255Z"><div class="index-item-header"><span class="index-item-number">#13</span><time datetime="2026-04-11T02:10:28.255Z" data-timestamp="2026-04-11T02:10:28.255Z">2026-04-11T02:10:28.255Z</time></div><div class="index-item-content"><p>--nerdfont doesn't work properly with it:</p>
+<pre><code>$ ~/code/git-ls/tree-experiment/git-ls -c --nerdfont
+On branch main
+
+   M +   README.md             c5f36b1 2026-04-10 Test initial commit
+   M +   src/network/server.go c5f36b1 2026-04-10 Test initial commit
+   M +   src/network/tork.go   c5f36b1 2026-04-10 Test initial commit
+   ++- src/trimble/alpha.go  c5f36b1 2026-04-10 Test initial commit
+</code></pre></div></a><div class="index-item-stats"><span>2 read · 2 bash · 1 grep · 1 edit</span>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>I see the problem. The issue is with <code>statusCode</code> trimming. In <code>changedFilesFromStatus</code>, I have:</p>
+<pre><code class="language-go">status: strings.TrimSpace(statusCode),
+</code></pre>
+<p>The git status porcelain format for <code>src/trimble/alpha.go</code> is <code>MM</code> (modified in both index and worktree). But <code>statusCode</code> is <code>line[:2]</code> which is <code>"MM"</code> — that's fine. The <code>" M"</code> status has a leading space, and <code>TrimSpace</code> turns <code>" M"</code> into <code>"M"</code>.</p>
+<p>That's the bug — <code>" M"</code> (space + M, meaning unstaged modification) becomes <code>"M"</code> which is not a valid 2-char status code, so the nerd font renderer falls through to the fallback and just prints the raw text. The original <code>fileStatus</code> function stores statuses as-is without trimming.</p></div></div><button class="expand-btn">Show more</button></div></div>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>Now the <code>changedFilesFilter</code> also needs to handle the un-trimmed statuses. Let me check — it filters on <code>file.status != ""</code> and <code>!= "I"</code> and <code>!= "*"</code>. Since <code>changedFilesFromStatus</code> already skips <code>!!</code> (ignored) files, and there's no <code>.git</code> entry in git status output, the filter isn't even called in the <code>--changed-only</code> path anymore. Let me verify:</p></div></div><button class="expand-btn">Show more</button></div></div>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>Good — <code>changedFilesFilter</code> is not called in the <code>--changed-only</code> branch. But the <code>filesNeedingLog</code> logic below checks for <code>file.status == "I"</code>, <code>"??"</code>, <code>"*"</code>, and empty status. With the un-trimmed 2-char status codes like <code>" M"</code> and <code>"??"</code>, those checks still work. <code>"??"</code> matches exactly, and <code>" M"</code> won't match any of the skip conditions, which is correct.</p>
+<p>But wait — the <code>allNew</code> check looks at <code>status[0]</code>. For <code>" M"</code>, <code>status[0]</code> is a space, not <code>'A'</code>, so <code>allNew</code> would be false — that's correct, <code>" M"</code> has history.</p>
+<p>For <code>"A "</code> (staged addition), <code>status[0]</code> is <code>'A'</code>, so <code>allNew</code> stays true — correct, no history to look up.</p>
+<p>Let me build and test:</p></div></div><button class="expand-btn">Show more</button></div></div>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>The fix was removing <code>strings.TrimSpace(statusCode)</code> — git's porcelain status codes are exactly 2 characters where the position matters (index vs worktree). <code>" M"</code> means "unstaged modification" and <code>"M "</code> means "staged modification." Trimming destroyed that distinction, so the nerd font renderer couldn't match the 2-char pattern.</p></div></div><button class="expand-btn">Show more</button></div></div>
+</div></div>
+<div class="index-item"><a href="page-003.html#msg-2026-04-11T02-14-55-480Z"><div class="index-item-header"><span class="index-item-number">#14</span><time datetime="2026-04-11T02:14:55.480Z" data-timestamp="2026-04-11T02:14:55.480Z">2026-04-11T02:14:55.480Z</time></div><div class="index-item-content"><p>okay, I'm pretty happy with this. No tests fail with this change, which makes me suspect that our tests are not very good</p></div></a><div class="index-item-stats">
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>Yeah, there should be a test that exercises the new <code>changedFilesFromStatus</code> path — a real integration test that creates a repo with subdirectory changes and verifies <code>--changed-only</code> shows full relative paths. The unit test for <code>changedFilesFilter</code> still passes because that function is unchanged; it just doesn't get called in the <code>--changed-only</code> path anymore.</p>
+<p>Want me to write a test? I'm thinking something like:</p>
+<ol>
+<li>Create a repo with files in nested directories</li>
+<li>Modify files at different levels</li>
+<li>Run <code>--changed-only</code> from the repo root and verify files show full relative paths</li>
+<li>Run from a subdirectory and verify only files at/below that point appear, with correct relative paths</li>
+</ol></div></div><button class="expand-btn">Show more</button></div></div>
+</div></div>
+<div class="index-item"><a href="page-003.html#msg-2026-04-11T02-16-13-931Z"><div class="index-item-header"><span class="index-item-number">#15</span><time datetime="2026-04-11T02:16:13.931Z" data-timestamp="2026-04-11T02:16:13.931Z">2026-04-11T02:16:13.931Z</time></div><div class="index-item-content"><p>I tend to think that with this tool we should be leaning pretty heavily on integration tests. Doesn't the git repo have some sort of test script format that describes setting up a repo, making changes, and then expected output?</p></div></a><div class="index-item-stats"><span>1 agent</span>
+</div></div>
+<div class="index-item"><a href="page-004.html#msg-2026-04-11T02-16-48-359Z"><div class="index-item-header"><span class="index-item-number">#16</span><time datetime="2026-04-11T02:16:48.359Z" data-timestamp="2026-04-11T02:16:48.359Z">2026-04-11T02:16:48.359Z</time></div><div class="index-item-content"><p>[Request interrupted by user for tool use]</p></div></a></div>
+<div class="index-item"><a href="page-004.html#msg-2026-04-11T02-17-08-160Z"><div class="index-item-header"><span class="index-item-number">#17</span><time datetime="2026-04-11T02:17:08.160Z" data-timestamp="2026-04-11T02:17:08.160Z">2026-04-11T02:17:08.160Z</time></div><div class="index-item-content"><p>by "the git repo" I meant git/git, the source code for the git command line; not this git repo</p></div></a><div class="index-item-stats">
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>Ah, good call. I know git/git uses a test framework based on shell scripts with helper functions like <code>test_expect_success</code>, <code>test_expect_failure</code>, etc. in <code>t/</code> directory. There's also the <code>test_cmp</code> pattern where you write expected output to a file and compare.</p>
+<p>But I'm not sure that's exactly what you're after — are you thinking about adopting something like that for git-ls, or were you thinking of a simpler script-based test format? Something like <a href="https://pkg.go.dev/golang.org/x/tools/txtar">txtar</a> (Go's test archive format used by <code>testscript</code>) might be a closer fit — it lets you describe a sequence of commands and expected outputs in a single file, and there's a Go library for it.</p>
+<p>Want me to look into <code>testscript</code> / <code>txtar</code> as a test harness for this?</p></div></div><button class="expand-btn">Show more</button></div></div>
+</div></div>
+<div class="index-item"><a href="page-004.html#msg-2026-04-11T02-18-21-627Z"><div class="index-item-header"><span class="index-item-number">#18</span><time datetime="2026-04-11T02:18:21.627Z" data-timestamp="2026-04-11T02:18:21.627Z">2026-04-11T02:18:21.627Z</time></div><div class="index-item-content"><p>I think some sort of format along that line would be a nice fit; set up a repository and expect output from the CLI, but I don't care that much about the particular format or tools, just that we make a sensible choice that's reasonably easy to read and modify</p></div></a><div class="index-item-stats"><span>1 agent</span>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p><code>testscript</code> looks like a good fit. Here's what a test would look like:</p>
+<pre><code class="language-txtar"># Test that --changed-only shows full relative paths from repo root
+env NO_COLOR=1
+
+exec git init -b main
+exec git config user.email test@test.com
+exec git config user.name Test
+
+exec mkdir -p src/network src/trimble
+exec cp README.md README.md
+exec cp server.go src/network/server.go
+exec cp alpha.go src/trimble/alpha.go
+
+exec git add .
+exec git commit -m 'initial'
+
+exec cp modified-readme.txt README.md
+exec cp modified-server.go src/network/server.go
+
+exec git-ls --changed-only
+stdout 'README\.md'
+stdout 'src/network/server\.go'
+! stdout 'src/trimble'
+
+-- README.md --
+# readme
+-- modified-readme.txt --
+# updated readme
+-- server.go --
+package network
+-- modified-server.go --
+package network // modified
+-- alpha.go --
+package trimble
+</code></pre>
+<p>The format is easy to read, each test is a self-contained file, and you wire it up with a small <code>TestScript</code> function that registers your binary. <code>stdout</code> takes a regex so you can match partial output and ignore column padding. <code>env NO_COLOR=1</code> would let you skip ANSI codes (though you'd need to add <code>NO_COLOR</code> support to git-ls — it's a common convention).</p>
+<p>The main question is whether your <code>main()</code> calls <code>os.Exit()</code> directly or returns an int. <code>testscript</code> needs a <code>func() int</code> to register as a binary. If <code>main()</code> does <code>log.Fatal</code> / <code>os.Exit</code>, you'd need a small refactor to extract a <code>run() int</code> function.</p>
+<p>Want me to set this up?</p></div></div><button class="expand-btn">Show more</button></div></div>
+</div></div>
+<div class="index-item"><a href="page-004.html#msg-2026-04-11T02-20-48-353Z"><div class="index-item-header"><span class="index-item-number">#19</span><time datetime="2026-04-11T02:20:48.353Z" data-timestamp="2026-04-11T02:20:48.353Z">2026-04-11T02:20:48.353Z</time></div><div class="index-item-content"><p>it does a mixture, but ditching the fatalf's would be no great loss, the <code>log</code> package is not a great fit for a CLI anyway</p></div></a><div class="index-item-stats"><span>10 grep · 10 read</span>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>OK, the tests don't deal with stripping ANSI. Here's my plan:</p>
+<ol>
+<li>Refactor <code>main()</code> → extract a <code>run(args []string, stdout, stderr io.Writer) int</code> function</li>
+<li>Add <code>NO_COLOR</code> support (it's a widely-adopted convention, useful beyond testing)</li>
+<li>Add <code>testscript</code> dependency and wire it up</li>
+<li>Write integration tests for the <code>--changed-only</code> behavior</li>
+</ol>
+<p>Let me do this in steps. First, the <code>run()</code> refactor and <code>NO_COLOR</code>:</p></div></div><button class="expand-btn">Show more</button></div></div>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>OK, this is a substantial refactor. Let me do it in pieces:</p>
+<ol>
+<li>Add <code>NO_COLOR</code> support</li>
+<li>Extract <code>run()</code> from <code>main()</code></li>
+<li>Convert <code>log.Fatalf</code> → <code>fmt.Fprintf(stderr)</code> + return</li>
+<li>Add <code>testscript</code> and write tests</li>
+</ol>
+<p>Let me start with <code>NO_COLOR</code>. The convention (https://no-color.org) is: if <code>NO_COLOR</code> env var is set (to anything), disable colors.</p></div></div><button class="expand-btn">Show more</button></div></div>
+</div></div>
+<div class="index-item"><a href="page-004.html#msg-2026-04-11T02-22-31-954Z"><div class="index-item-header"><span class="index-item-number">#20</span><time datetime="2026-04-11T02:22:31.954Z" data-timestamp="2026-04-11T02:22:31.954Z">2026-04-11T02:22:31.954Z</time></div><div class="index-item-content"><p>[Request interrupted by user]</p></div></a></div>
+<div class="index-item"><a href="page-005.html#msg-2026-04-11T02-23-18-795Z"><div class="index-item-header"><span class="index-item-number">#21</span><time datetime="2026-04-11T02:23:18.795Z" data-timestamp="2026-04-11T02:23:18.795Z">2026-04-11T02:23:18.795Z</time></div><div class="index-item-content"><p>wait I don't like the idea of disabling hyperlinks when NO_COLOR is set, a user could plausibly be using NO_COLOR in their terminal and want hyperlinks.</p>
+<p>What about an undocumented NO_HYPERLINKS or NO_ANSI env var that's used only for testing</p></div></a><div class="index-item-stats"><span>15 bash · 9 write · 5 read · 4 edit · 2 grep</span>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>Good point. Let me keep <code>NO_COLOR</code> doing just what the spec says — disable colors — and add a separate <code>NO_HYPERLINKS</code> for the link escapes. For testing we'd set both.</p>
+<p>Actually, thinking about it more: <code>NO_COLOR</code> should disable color codes, and the <code>link()</code> function's escape sequences aren't color — they're OSC 8 hyperlinks. So <code>NO_COLOR</code> shouldn't touch them at all per the spec. For testing, we just need to strip or ignore them in our test assertions. <code>testscript</code>'s <code>stdout</code> takes a regex, so we can match the text content and skip the escapes.</p>
+<p>So the plan is:
+1. <code>NO_COLOR</code> — sets color vars to <code>""</code>, leaves hyperlinks alone
+2. In testscript tests, use regex matching to check text content (ignoring hyperlink escapes)</p>
+<p>Let me do it.</p></div></div><button class="expand-btn">Show more</button></div></div>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>OK, the helper functions (<code>gitRemotes</code>, <code>gitRoot</code>, <code>gitStatus</code>, <code>gitDiffStat</code>) use <code>log.Fatalf</code> but they're called inside <code>fetchGitData</code> via goroutines. Converting those to return errors would be a bigger refactor of the parallel fetch pattern. For now, let me convert just <code>main()</code> into <code>run()</code> with <code>fmt.Fprintf(os.Stderr, ...)</code> for the errors in the main flow, and leave the helper goroutine fatals as-is — they'll still terminate the process on git failures, which is reasonable behavior. We can clean those up later.</p></div></div><button class="expand-btn">Show more</button></div></div>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>Two failures to fix:</p>
+<ol>
+<li>
+<p><strong>basic.txtar</strong>: The txtar archive files (<code>server.go</code>) get placed in the work dir root, so <code>git add .</code> adds them too and they show up in the listing. I need to not have the source files overlap.</p>
+</li>
+<li>
+<p><strong>changed_only_paths.txtar</strong>: Same issue — the archive files (<code>server.go</code>, <code>tork.go</code>, etc.) are in the root and show up. Also, the <code>! stdout 'src'</code> check at line 45 fails because <code>server.go</code> in the hyperlink URL contains <code>src</code>. I need to match more carefully.</p>
+</li>
+</ol>
+<p>Let me fix both. The key insight is that txtar archive files all land in the work directory root, so I need to use distinct names for source files vs. what gets committed, or use a subdirectory for staging.</p></div></div><button class="expand-btn">Show more</button></div></div>
+<div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content"><p>All tests pass — both the existing unit/integration tests and the new testscript tests. Here's a summary of everything done:</p>
+<p><strong>Feature: <code>--changed-only</code> shows full relative paths</strong>
+- <code>changedFilesFromStatus()</code> builds file list from git status with relative paths
+- <code>parseGitLog</code> matches full paths, falling back to first-component matching
+- <code>parseDiffStat</code> stores stats under both full path and first component
+- Scoped to current directory — from <code>src/</code>, you see <code>network/server.go</code>, not files in parent dirs</p>
+<p><strong><code>NO_COLOR</code> support</strong>
+- Color vars changed from <code>const</code> to <code>var</code>
+- <code>init()</code> checks <code>NO_COLOR</code> env and blanks them all out
+- <code>hashToColor</code> returns empty string when colors are disabled</p>
+<p><strong><code>run()</code> refactor</strong>
+- <code>main()</code> → <code>os.Exit(run())</code>, with <code>run() int</code> doing all the work
+- <code>log.Fatalf</code> in main flow replaced with <code>fmt.Fprintf(os.Stderr, ...)</code> + <code>return 1</code>
+- Helper functions (<code>gitRemotes</code>, <code>gitRoot</code>, etc.) still use <code>log.Fatalf</code> for now</p>
+<p><strong>testscript integration</strong>
+- Added <code>github.com/rogpeppe/go-internal/testscript</code> dependency
+- <code>script_test.go</code> wires up <code>git-ls</code> as an in-process command
+- Three test scripts in <code>testdata/scripts/</code>:
+  - <code>basic.txtar</code> — normal mode lists directory entries
+  - <code>changed_only_filter.txtar</code> — only changed files appear
+  - <code>changed_only_paths.txtar</code> — full relative paths from root, scoped from subdirs</p></div></div><button class="expand-btn">Show more</button></div></div>
+</div></div>
+<div class="index-item"><a href="page-005.html#msg-2026-04-11T03-01-40-385Z"><div class="index-item-header"><span class="index-item-number">#22</span><time datetime="2026-04-11T03:01:40.385Z" data-timestamp="2026-04-11T03:01:40.385Z">2026-04-11T03:01:40.385Z</time></div><div class="index-item-content"><p>one thing I noticed is that uncommitted directories appear as the directory name, but when added appear as each file. That's the same behavior as "git status" right?</p></div></a><div class="index-item-stats"><span>2 bash</span>
+</div></div>
+<div class="index-item"><a href="page-005.html#msg-2026-04-11T03-06-22-554Z"><div class="index-item-header"><span class="index-item-number">#23</span><time datetime="2026-04-11T03:06:22.554Z" data-timestamp="2026-04-11T03:06:22.554Z">2026-04-11T03:06:22.554Z</time></div><div class="index-item-content"><p>alright, let's commit and file a PR</p></div></a><div class="index-item-stats"><span>5 bash</span>
+</div></div><div class="index-commit"><a href="https://github.com/llimllib/git-ls/commit/303a7fc"><div class="index-commit-header"><span class="index-commit-hash">303a7fc</span><time datetime="2026-04-11T03:06:42.525Z" data-timestamp="2026-04-11T03:06:42.525Z">2026-04-11T03:06:42.525Z</time></div><div class="index-commit-msg">feat: --changed-only shows full relative paths for subdirectory files</div></a></div>
+<div class="index-item"><a href="page-005.html#msg-2026-04-11T03-11-46-304Z"><div class="index-item-header"><span class="index-item-number">#24</span><time datetime="2026-04-11T03:11:46.304Z" data-timestamp="2026-04-11T03:11:46.304Z">2026-04-11T03:11:46.304Z</time></div><div class="index-item-content"><p>create a transcript in the transcripts dir with <code>uvx claude-code-transcripts --help</code></p></div></a><div class="index-item-stats"><span>3 bash</span>
+</div></div>
+        
+
+<div class="pagination">
+<span class="current">Index</span>
+<span class="disabled">&larr; Prev</span>
+<a href="page-001.html">1</a>
+<a href="page-002.html">2</a>
+<a href="page-003.html">3</a>
+<a href="page-004.html">4</a>
+<a href="page-005.html">5</a>
+<a href="page-001.html">Next &rarr;</a>
+</div>
+
+
+        <dialog id="search-modal">
+            <div class="search-modal-header">
+                <input type="text" id="modal-search-input" placeholder="Search..." aria-label="Search transcripts">
+                <button id="modal-search-btn" type="button" aria-label="Search">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.35-4.35"></path></svg>
+                </button>
+                <button id="modal-close-btn" type="button" aria-label="Close">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg>
+                </button>
+            </div>
+            <div id="search-status"></div>
+            <div id="search-results"></div>
+        </dialog>
+        <script>
+(function() {
+    var totalPages = 5;
+    var searchBox = document.getElementById('search-box');
+    var searchInput = document.getElementById('search-input');
+    var searchBtn = document.getElementById('search-btn');
+    var modal = document.getElementById('search-modal');
+    var modalInput = document.getElementById('modal-search-input');
+    var modalSearchBtn = document.getElementById('modal-search-btn');
+    var modalCloseBtn = document.getElementById('modal-close-btn');
+    var searchStatus = document.getElementById('search-status');
+    var searchResults = document.getElementById('search-results');
+
+    if (!searchBox || !modal) return;
+
+    // Hide search on file:// protocol (doesn't work due to CORS restrictions)
+    if (window.location.protocol === 'file:') return;
+
+    // Show search box (progressive enhancement)
+    searchBox.style.display = 'flex';
+
+    // Gist preview support - detect if we're on gisthost.github.io or gistpreview.github.io
+    var hostname = window.location.hostname;
+    var isGistPreview = hostname === 'gisthost.github.io' || hostname === 'gistpreview.github.io';
+    var gistId = null;
+    var gistOwner = null;
+    var gistInfoLoaded = false;
+
+    if (isGistPreview) {
+        // Extract gist ID from URL query string like ?78a436a8a9e7a2e603738b8193b95410/index.html
+        var queryMatch = window.location.search.match(/^\?([a-f0-9]+)/i);
+        if (queryMatch) {
+            gistId = queryMatch[1];
+        }
+    }
+
+    async function loadGistInfo() {
+        if (!isGistPreview || !gistId || gistInfoLoaded) return;
+        try {
+            var response = await fetch('https://api.github.com/gists/' + gistId);
+            if (response.ok) {
+                var info = await response.json();
+                gistOwner = info.owner.login;
+                gistInfoLoaded = true;
+            }
+        } catch (e) {
+            console.error('Failed to load gist info:', e);
+        }
+    }
+
+    function getPageFetchUrl(pageFile) {
+        if (isGistPreview && gistOwner && gistId) {
+            // Use raw gist URL for fetching content
+            return 'https://gist.githubusercontent.com/' + gistOwner + '/' + gistId + '/raw/' + pageFile;
+        }
+        return pageFile;
+    }
+
+    function getPageLinkUrl(pageFile) {
+        if (isGistPreview && gistId) {
+            // Use gistpreview URL format for navigation links
+            return '?' + gistId + '/' + pageFile;
+        }
+        return pageFile;
+    }
+
+    function escapeHtml(text) {
+        var div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    function escapeRegex(string) {
+        return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+
+    function openModal(query) {
+        modalInput.value = query || '';
+        searchResults.innerHTML = '';
+        searchStatus.textContent = '';
+        modal.showModal();
+        modalInput.focus();
+        if (query) {
+            performSearch(query);
+        }
+    }
+
+    function closeModal() {
+        modal.close();
+        // Update URL to remove search fragment, preserving path and query string
+        if (window.location.hash.startsWith('#search=')) {
+            history.replaceState(null, '', window.location.pathname + window.location.search);
+        }
+    }
+
+    function updateUrlHash(query) {
+        if (query) {
+            // Preserve path and query string when adding hash
+            history.replaceState(null, '', window.location.pathname + window.location.search + '#search=' + encodeURIComponent(query));
+        }
+    }
+
+    function highlightTextNodes(element, searchTerm) {
+        var walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT, null, false);
+        var nodesToReplace = [];
+
+        while (walker.nextNode()) {
+            var node = walker.currentNode;
+            if (node.nodeValue.toLowerCase().indexOf(searchTerm.toLowerCase()) !== -1) {
+                nodesToReplace.push(node);
+            }
+        }
+
+        nodesToReplace.forEach(function(node) {
+            var text = node.nodeValue;
+            var regex = new RegExp('(' + escapeRegex(searchTerm) + ')', 'gi');
+            var parts = text.split(regex);
+            if (parts.length > 1) {
+                var span = document.createElement('span');
+                parts.forEach(function(part) {
+                    if (part.toLowerCase() === searchTerm.toLowerCase()) {
+                        var mark = document.createElement('mark');
+                        mark.textContent = part;
+                        span.appendChild(mark);
+                    } else {
+                        span.appendChild(document.createTextNode(part));
+                    }
+                });
+                node.parentNode.replaceChild(span, node);
+            }
+        });
+    }
+
+    function fixInternalLinks(element, pageFile) {
+        // Update all internal anchor links to include the page file
+        var links = element.querySelectorAll('a[href^="#"]');
+        links.forEach(function(link) {
+            var href = link.getAttribute('href');
+            link.setAttribute('href', pageFile + href);
+        });
+    }
+
+    function processPage(pageFile, html, query) {
+        var parser = new DOMParser();
+        var doc = parser.parseFromString(html, 'text/html');
+        var resultsFromPage = 0;
+
+        // Find all message blocks
+        var messages = doc.querySelectorAll('.message');
+        messages.forEach(function(msg) {
+            var text = msg.textContent || '';
+            if (text.toLowerCase().indexOf(query.toLowerCase()) !== -1) {
+                resultsFromPage++;
+
+                // Get the message ID for linking
+                var msgId = msg.id || '';
+                var pageLinkUrl = getPageLinkUrl(pageFile);
+                var link = pageLinkUrl + (msgId ? '#' + msgId : '');
+
+                // Clone the message HTML and highlight matches
+                var clone = msg.cloneNode(true);
+                // Fix internal links to include the page file
+                fixInternalLinks(clone, pageLinkUrl);
+                highlightTextNodes(clone, query);
+
+                var resultDiv = document.createElement('div');
+                resultDiv.className = 'search-result';
+                resultDiv.innerHTML = '<a href="' + link + '">' +
+                    '<div class="search-result-page">' + escapeHtml(pageFile) + '</div>' +
+                    '<div class="search-result-content">' + clone.innerHTML + '</div>' +
+                    '</a>';
+                searchResults.appendChild(resultDiv);
+            }
+        });
+
+        return resultsFromPage;
+    }
+
+    async function performSearch(query) {
+        if (!query.trim()) {
+            searchStatus.textContent = 'Enter a search term';
+            return;
+        }
+
+        updateUrlHash(query);
+        searchResults.innerHTML = '';
+        searchStatus.textContent = 'Searching...';
+
+        // Load gist info if on gistpreview (needed for constructing URLs)
+        if (isGistPreview && !gistInfoLoaded) {
+            searchStatus.textContent = 'Loading gist info...';
+            await loadGistInfo();
+            if (!gistOwner) {
+                searchStatus.textContent = 'Failed to load gist info. Search unavailable.';
+                return;
+            }
+        }
+
+        var resultsFound = 0;
+        var pagesSearched = 0;
+
+        // Build list of pages to fetch
+        var pagesToFetch = [];
+        for (var i = 1; i <= totalPages; i++) {
+            pagesToFetch.push('page-' + String(i).padStart(3, '0') + '.html');
+        }
+
+        searchStatus.textContent = 'Searching...';
+
+        // Process pages in batches of 3, but show results immediately as each completes
+        var batchSize = 3;
+        for (var i = 0; i < pagesToFetch.length; i += batchSize) {
+            var batch = pagesToFetch.slice(i, i + batchSize);
+
+            // Create promises that process results immediately when each fetch completes
+            var promises = batch.map(function(pageFile) {
+                return fetch(getPageFetchUrl(pageFile))
+                    .then(function(response) {
+                        if (!response.ok) throw new Error('Failed to fetch');
+                        return response.text();
+                    })
+                    .then(function(html) {
+                        // Process and display results immediately
+                        var count = processPage(pageFile, html, query);
+                        resultsFound += count;
+                        pagesSearched++;
+                        searchStatus.textContent = 'Found ' + resultsFound + ' result(s) in ' + pagesSearched + '/' + totalPages + ' pages...';
+                    })
+                    .catch(function() {
+                        pagesSearched++;
+                        searchStatus.textContent = 'Found ' + resultsFound + ' result(s) in ' + pagesSearched + '/' + totalPages + ' pages...';
+                    });
+            });
+
+            // Wait for this batch to complete before starting the next
+            await Promise.all(promises);
+        }
+
+        searchStatus.textContent = 'Found ' + resultsFound + ' result(s) in ' + totalPages + ' pages';
+    }
+
+    // Event listeners
+    searchBtn.addEventListener('click', function() {
+        openModal(searchInput.value);
+    });
+
+    searchInput.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter') {
+            openModal(searchInput.value);
+        }
+    });
+
+    modalSearchBtn.addEventListener('click', function() {
+        performSearch(modalInput.value);
+    });
+
+    modalInput.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter') {
+            performSearch(modalInput.value);
+        }
+    });
+
+    modalCloseBtn.addEventListener('click', closeModal);
+
+    modal.addEventListener('click', function(e) {
+        if (e.target === modal) {
+            closeModal();
+        }
+    });
+
+    // Check for #search= in URL on page load
+    if (window.location.hash.startsWith('#search=')) {
+        var query = decodeURIComponent(window.location.hash.substring(8));
+        if (query) {
+            searchInput.value = query;
+            openModal(query);
+        }
+    }
+})();
+        </script>
+    </div>
+    <script>
+document.querySelectorAll('time[data-timestamp]').forEach(function(el) {
+    const timestamp = el.getAttribute('data-timestamp');
+    const date = new Date(timestamp);
+    const now = new Date();
+    const isToday = date.toDateString() === now.toDateString();
+    const timeStr = date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+    if (isToday) { el.textContent = timeStr; }
+    else { el.textContent = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' ' + timeStr; }
+});
+document.querySelectorAll('pre.json').forEach(function(el) {
+    let text = el.textContent;
+    text = text.replace(/"([^"]+)":/g, '<span style="color: #ce93d8">"$1"</span>:');
+    text = text.replace(/: "([^"]*)"/g, ': <span style="color: #81d4fa">"$1"</span>');
+    text = text.replace(/: (\d+)/g, ': <span style="color: #ffcc80">$1</span>');
+    text = text.replace(/: (true|false|null)/g, ': <span style="color: #f48fb1">$1</span>');
+    el.innerHTML = text;
+});
+document.querySelectorAll('.truncatable').forEach(function(wrapper) {
+    const content = wrapper.querySelector('.truncatable-content');
+    const btn = wrapper.querySelector('.expand-btn');
+    if (content.scrollHeight > 250) {
+        wrapper.classList.add('truncated');
+        btn.addEventListener('click', function() {
+            if (wrapper.classList.contains('truncated')) { wrapper.classList.remove('truncated'); wrapper.classList.add('expanded'); btn.textContent = 'Show less'; }
+            else { wrapper.classList.remove('expanded'); wrapper.classList.add('truncated'); btn.textContent = 'Show more'; }
+        });
+    }
+});
+</script>
+</body>
+</html>

--- a/transcripts/47-changed-relative-paths.html/page-001.html
+++ b/transcripts/47-changed-relative-paths.html/page-001.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Claude Code transcript - page 1</title>
+    <style>
+:root { --bg-color: #f5f5f5; --card-bg: #ffffff; --user-bg: #e3f2fd; --user-border: #1976d2; --assistant-bg: #f5f5f5; --assistant-border: #9e9e9e; --thinking-bg: #fff8e1; --thinking-border: #ffc107; --thinking-text: #666; --tool-bg: #f3e5f5; --tool-border: #9c27b0; --tool-result-bg: #e8f5e9; --tool-error-bg: #ffebee; --text-color: #212121; --text-muted: #757575; --code-bg: #263238; --code-text: #aed581; }
+* { box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg-color); color: var(--text-color); margin: 0; padding: 16px; line-height: 1.6; }
+.container { max-width: 800px; margin: 0 auto; }
+h1 { font-size: 1.5rem; margin-bottom: 24px; padding-bottom: 8px; border-bottom: 2px solid var(--user-border); }
+.header-row { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; border-bottom: 2px solid var(--user-border); padding-bottom: 8px; margin-bottom: 24px; }
+.header-row h1 { border-bottom: none; padding-bottom: 0; margin-bottom: 0; flex: 1; min-width: 200px; }
+.message { margin-bottom: 16px; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.message.user { background: var(--user-bg); border-left: 4px solid var(--user-border); }
+.message.assistant { background: var(--card-bg); border-left: 4px solid var(--assistant-border); }
+.message.tool-reply { background: #fff8e1; border-left: 4px solid #ff9800; }
+.tool-reply .role-label { color: #e65100; }
+.tool-reply .tool-result { background: transparent; padding: 0; margin: 0; }
+.tool-reply .tool-result .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff8e1); }
+.message-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 16px; background: rgba(0,0,0,0.03); font-size: 0.85rem; }
+.role-label { font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
+.user .role-label { color: var(--user-border); }
+time { color: var(--text-muted); font-size: 0.8rem; }
+.timestamp-link { color: inherit; text-decoration: none; }
+.timestamp-link:hover { text-decoration: underline; }
+.message:target { animation: highlight 2s ease-out; }
+@keyframes highlight { 0% { background-color: rgba(25, 118, 210, 0.2); } 100% { background-color: transparent; } }
+.message-content { padding: 16px; }
+.message-content p { margin: 0 0 12px 0; }
+.message-content p:last-child { margin-bottom: 0; }
+.thinking { background: var(--thinking-bg); border: 1px solid var(--thinking-border); border-radius: 8px; padding: 12px; margin: 12px 0; font-size: 0.9rem; color: var(--thinking-text); }
+.thinking-label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: #f57c00; margin-bottom: 8px; }
+.thinking p { margin: 8px 0; }
+.assistant-text { margin: 8px 0; }
+.tool-use { background: var(--tool-bg); border: 1px solid var(--tool-border); border-radius: 8px; padding: 12px; margin: 12px 0; }
+.tool-header { font-weight: 600; color: var(--tool-border); margin-bottom: 8px; display: flex; align-items: center; gap: 8px; }
+.tool-icon { font-size: 1.1rem; }
+.tool-description { font-size: 0.9rem; color: var(--text-muted); margin-bottom: 8px; font-style: italic; }
+.tool-result { background: var(--tool-result-bg); border-radius: 8px; padding: 12px; margin: 12px 0; }
+.tool-result.tool-error { background: var(--tool-error-bg); }
+.file-tool { border-radius: 8px; padding: 12px; margin: 12px 0; }
+.write-tool { background: linear-gradient(135deg, #e3f2fd 0%, #e8f5e9 100%); border: 1px solid #4caf50; }
+.edit-tool { background: linear-gradient(135deg, #fff3e0 0%, #fce4ec 100%); border: 1px solid #ff9800; }
+.file-tool-header { font-weight: 600; margin-bottom: 4px; display: flex; align-items: center; gap: 8px; font-size: 0.95rem; }
+.write-header { color: #2e7d32; }
+.edit-header { color: #e65100; }
+.file-tool-icon { font-size: 1rem; }
+.file-tool-path { font-family: monospace; background: rgba(0,0,0,0.08); padding: 2px 8px; border-radius: 4px; }
+.file-tool-fullpath { font-family: monospace; font-size: 0.8rem; color: var(--text-muted); margin-bottom: 8px; word-break: break-all; }
+.file-content { margin: 0; }
+.edit-section { display: flex; margin: 4px 0; border-radius: 4px; overflow: hidden; }
+.edit-label { padding: 8px 12px; font-weight: bold; font-family: monospace; display: flex; align-items: flex-start; }
+.edit-old { background: #fce4ec; }
+.edit-old .edit-label { color: #b71c1c; background: #f8bbd9; }
+.edit-old .edit-content { color: #880e4f; }
+.edit-new { background: #e8f5e9; }
+.edit-new .edit-label { color: #1b5e20; background: #a5d6a7; }
+.edit-new .edit-content { color: #1b5e20; }
+.edit-content { margin: 0; flex: 1; background: transparent; font-size: 0.85rem; }
+.edit-replace-all { font-size: 0.75rem; font-weight: normal; color: var(--text-muted); }
+.write-tool .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #e6f4ea); }
+.edit-tool .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff0e5); }
+.todo-list { background: linear-gradient(135deg, #e8f5e9 0%, #f1f8e9 100%); border: 1px solid #81c784; border-radius: 8px; padding: 12px; margin: 12px 0; }
+.todo-header { font-weight: 600; color: #2e7d32; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; font-size: 0.95rem; }
+.todo-items { list-style: none; margin: 0; padding: 0; }
+.todo-item { display: flex; align-items: flex-start; gap: 10px; padding: 6px 0; border-bottom: 1px solid rgba(0,0,0,0.06); font-size: 0.9rem; }
+.todo-item:last-child { border-bottom: none; }
+.todo-icon { flex-shrink: 0; width: 20px; height: 20px; display: flex; align-items: center; justify-content: center; font-weight: bold; border-radius: 50%; }
+.todo-completed .todo-icon { color: #2e7d32; background: rgba(46, 125, 50, 0.15); }
+.todo-completed .todo-content { color: #558b2f; text-decoration: line-through; }
+.todo-in-progress .todo-icon { color: #f57c00; background: rgba(245, 124, 0, 0.15); }
+.todo-in-progress .todo-content { color: #e65100; font-weight: 500; }
+.todo-pending .todo-icon { color: #757575; background: rgba(0,0,0,0.05); }
+.todo-pending .todo-content { color: #616161; }
+pre { background: var(--code-bg); color: var(--code-text); padding: 12px; border-radius: 6px; overflow-x: auto; font-size: 0.85rem; line-height: 1.5; margin: 8px 0; white-space: pre-wrap; word-wrap: break-word; }
+pre.json { color: #e0e0e0; }
+code { background: rgba(0,0,0,0.08); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+pre code { background: none; padding: 0; }
+.user-content { margin: 0; }
+.truncatable { position: relative; }
+.truncatable.truncated .truncatable-content { max-height: 200px; overflow: hidden; }
+.truncatable.truncated::after { content: ''; position: absolute; bottom: 32px; left: 0; right: 0; height: 60px; background: linear-gradient(to bottom, transparent, var(--card-bg)); pointer-events: none; }
+.message.user .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--user-bg)); }
+.message.tool-reply .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff8e1); }
+.tool-use .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--tool-bg)); }
+.tool-result .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--tool-result-bg)); }
+.expand-btn { display: none; width: 100%; padding: 8px 16px; margin-top: 4px; background: rgba(0,0,0,0.05); border: 1px solid rgba(0,0,0,0.1); border-radius: 6px; cursor: pointer; font-size: 0.85rem; color: var(--text-muted); }
+.expand-btn:hover { background: rgba(0,0,0,0.1); }
+.truncatable.truncated .expand-btn, .truncatable.expanded .expand-btn { display: block; }
+.pagination { display: flex; justify-content: center; gap: 8px; margin: 24px 0; flex-wrap: wrap; }
+.pagination a, .pagination span { padding: 5px 10px; border-radius: 6px; text-decoration: none; font-size: 0.85rem; }
+.pagination a { background: var(--card-bg); color: var(--user-border); border: 1px solid var(--user-border); }
+.pagination a:hover { background: var(--user-bg); }
+.pagination .current { background: var(--user-border); color: white; }
+.pagination .disabled { color: var(--text-muted); border: 1px solid #ddd; }
+.pagination .index-link { background: var(--user-border); color: white; }
+details.continuation { margin-bottom: 16px; }
+details.continuation summary { cursor: pointer; padding: 12px 16px; background: var(--user-bg); border-left: 4px solid var(--user-border); border-radius: 12px; font-weight: 500; color: var(--text-muted); }
+details.continuation summary:hover { background: rgba(25, 118, 210, 0.15); }
+details.continuation[open] summary { border-radius: 12px 12px 0 0; margin-bottom: 0; }
+.index-item { margin-bottom: 16px; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); background: var(--user-bg); border-left: 4px solid var(--user-border); }
+.index-item a { display: block; text-decoration: none; color: inherit; }
+.index-item a:hover { background: rgba(25, 118, 210, 0.1); }
+.index-item-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 16px; background: rgba(0,0,0,0.03); font-size: 0.85rem; }
+.index-item-number { font-weight: 600; color: var(--user-border); }
+.index-item-content { padding: 16px; }
+.index-item-stats { padding: 8px 16px 12px 32px; font-size: 0.85rem; color: var(--text-muted); border-top: 1px solid rgba(0,0,0,0.06); }
+.index-item-commit { margin-top: 6px; padding: 4px 8px; background: #fff3e0; border-radius: 4px; font-size: 0.85rem; color: #e65100; }
+.index-item-commit code { background: rgba(0,0,0,0.08); padding: 1px 4px; border-radius: 3px; font-size: 0.8rem; margin-right: 6px; }
+.commit-card { margin: 8px 0; padding: 10px 14px; background: #fff3e0; border-left: 4px solid #ff9800; border-radius: 6px; }
+.commit-card a { text-decoration: none; color: #5d4037; display: block; }
+.commit-card a:hover { color: #e65100; }
+.commit-card-hash { font-family: monospace; color: #e65100; font-weight: 600; margin-right: 8px; }
+.index-commit { margin-bottom: 12px; padding: 10px 16px; background: #fff3e0; border-left: 4px solid #ff9800; border-radius: 8px; box-shadow: 0 1px 2px rgba(0,0,0,0.05); }
+.index-commit a { display: block; text-decoration: none; color: inherit; }
+.index-commit a:hover { background: rgba(255, 152, 0, 0.1); margin: -10px -16px; padding: 10px 16px; border-radius: 8px; }
+.index-commit-header { display: flex; justify-content: space-between; align-items: center; font-size: 0.85rem; margin-bottom: 4px; }
+.index-commit-hash { font-family: monospace; color: #e65100; font-weight: 600; }
+.index-commit-msg { color: #5d4037; }
+.index-item-long-text { margin-top: 8px; padding: 12px; background: var(--card-bg); border-radius: 8px; border-left: 3px solid var(--assistant-border); }
+.index-item-long-text .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--card-bg)); }
+.index-item-long-text-content { color: var(--text-color); }
+#search-box { display: none; align-items: center; gap: 8px; }
+#search-box input { padding: 6px 12px; border: 1px solid var(--assistant-border); border-radius: 6px; font-size: 16px; width: 180px; }
+#search-box button, #modal-search-btn, #modal-close-btn { background: var(--user-border); color: white; border: none; border-radius: 6px; padding: 6px 10px; cursor: pointer; display: flex; align-items: center; justify-content: center; }
+#search-box button:hover, #modal-search-btn:hover { background: #1565c0; }
+#modal-close-btn { background: var(--text-muted); margin-left: 8px; }
+#modal-close-btn:hover { background: #616161; }
+#search-modal[open] { border: none; border-radius: 12px; box-shadow: 0 4px 24px rgba(0,0,0,0.2); padding: 0; width: 90vw; max-width: 900px; height: 80vh; max-height: 80vh; display: flex; flex-direction: column; }
+#search-modal::backdrop { background: rgba(0,0,0,0.5); }
+.search-modal-header { display: flex; align-items: center; gap: 8px; padding: 16px; border-bottom: 1px solid var(--assistant-border); background: var(--bg-color); border-radius: 12px 12px 0 0; }
+.search-modal-header input { flex: 1; padding: 8px 12px; border: 1px solid var(--assistant-border); border-radius: 6px; font-size: 16px; }
+#search-status { padding: 8px 16px; font-size: 0.85rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
+#search-results { flex: 1; overflow-y: auto; padding: 16px; }
+.search-result { margin-bottom: 16px; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.search-result a { display: block; text-decoration: none; color: inherit; }
+.search-result a:hover { background: rgba(25, 118, 210, 0.05); }
+.search-result-page { padding: 6px 12px; background: rgba(0,0,0,0.03); font-size: 0.8rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
+.search-result-content { padding: 12px; }
+.search-result mark { background: #fff59d; padding: 1px 2px; border-radius: 2px; }
+@media (max-width: 600px) { body { padding: 8px; } .message, .index-item { border-radius: 8px; } .message-content, .index-item-content { padding: 12px; } pre { font-size: 0.8rem; padding: 8px; } #search-box input { width: 120px; } #search-modal[open] { width: 95vw; height: 90vh; } }
+</style>
+</head>
+<body>
+    <div class="container">
+        <h1><a href="index.html" style="color: inherit; text-decoration: none;">Claude Code transcript</a> - page 1/5</h1>
+        
+
+<div class="pagination">
+<a href="index.html" class="index-link">Index</a>
+<span class="disabled">&larr; Prev</span>
+<span class="current">1</span>
+<a href="page-002.html">2</a>
+<a href="page-003.html">3</a>
+<a href="page-004.html">4</a>
+<a href="page-005.html">5</a>
+<a href="page-002.html">Next &rarr;</a>
+</div>
+
+        
+<div class="message user" id="msg-2026-04-11T01-53-49-966Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T01-53-49-966Z" class="timestamp-link"><time datetime="2026-04-11T01:53:49.966Z" data-timestamp="2026-04-11T01:53:49.966Z">2026-04-11T01:53:49.966Z</time></a></div><div class="message-content">
+<div class="user-content"><p><local-command-caveat>Caveat: The messages below were generated by the user while running local commands. DO NOT respond to these messages or otherwise consider them in your response unless the user explicitly asks you to.</local-command-caveat></p></div></div></div>
+<div class="message user" id="msg-2026-04-11T01-53-49-966Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T01-53-49-966Z" class="timestamp-link"><time datetime="2026-04-11T01:53:49.966Z" data-timestamp="2026-04-11T01:53:49.966Z">2026-04-11T01:53:49.966Z</time></a></div><div class="message-content">
+<div class="user-content"><p><command-name>/sandbox</command-name>
+            <command-message>sandbox</command-message>
+            <command-args></command-args></p></div></div></div>
+<div class="message user" id="msg-2026-04-11T01-53-49-966Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T01-53-49-966Z" class="timestamp-link"><time datetime="2026-04-11T01:53:49.966Z" data-timestamp="2026-04-11T01:53:49.966Z">2026-04-11T01:53:49.966Z</time></a></div><div class="message-content">
+<div class="user-content"><p><local-command-stdout>✓ Sandbox enabled with auto-allow for bash commands</local-command-stdout></p></div></div></div>
+<div class="message user" id="msg-2026-04-11T01-54-16-928Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T01-54-16-928Z" class="timestamp-link"><time datetime="2026-04-11T01:54:16.928Z" data-timestamp="2026-04-11T01:54:16.928Z">2026-04-11T01:54:16.928Z</time></a></div><div class="message-content">
+<div class="user-content"><p>read https://github.com/llimllib/git-ls/issues/44</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-54-20-833Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-54-20-833Z" class="timestamp-link"><time datetime="2026-04-11T01:54:20.833Z" data-timestamp="2026-04-11T01:54:20.833Z">2026-04-11T01:54:20.833Z</time></a></div><div class="message-content">
+<div class="thinking"><div class="thinking-label">Thinking</div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-54-21-584Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-54-21-584Z" class="timestamp-link"><time datetime="2026-04-11T01:54:21.584Z" data-timestamp="2026-04-11T01:54:21.584Z">2026-04-11T01:54:21.584Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_014CNoNdBsPkNQToHsLpue8M">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Fetch GitHub issue #44</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">gh issue view 44 --json title,body,comments,labels,state</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-54-21-935Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-54-21-935Z" class="timestamp-link"><time datetime="2026-04-11T01:54:21.935Z" data-timestamp="2026-04-11T01:54:21.935Z">2026-04-11T01:54:21.935Z</time></a></div><div class="message-content"><div class="tool-result tool-error"><div class="truncatable"><div class="truncatable-content"><pre>Exit code 1
+Post &quot;https://api.github.com/graphql&quot;: tls: failed to verify certificate: x509: OSStatus -26276
+[rerun: b1]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-54-26-728Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-54-26-728Z" class="timestamp-link"><time datetime="2026-04-11T01:54:26.728Z" data-timestamp="2026-04-11T01:54:26.728Z">2026-04-11T01:54:26.728Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01V63dHQAL1FgQ5mnDXqNATp">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Fetch GitHub issue #44 with SSL workaround</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">GIT_SSL_NO_VERIFY=1 gh issue view 44 --repo llimllib/git-ls --json title,body,comments,labels,state 2&gt;&amp;1 || curl -s &#34;https://api.github.com/repos/llimllib/git-ls/issues/44&#34; 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-54-27-088Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-54-27-088Z" class="timestamp-link"><time datetime="2026-04-11T01:54:27.088Z" data-timestamp="2026-04-11T01:54:27.088Z">2026-04-11T01:54:27.088Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>{&quot;body&quot;:&quot;Especially when using `--changed-only`, I often want to see a tree view of the files I&#x27;ve changed.\n\nIt would be neat if there were a `--tree` flag that would display a tree view, like:\n\n```\n$ git ls --tree --changed-only\nM README.md ++++ a749399289 2026-04-08 Bill Mill docs: document the glooping\nsrc\n├─ network\n│  ├─ M server.go ++-- c14a93aa8b 2026-04-08 Bill Mill fix: de-glorp the glooper\n│  └─ M tork.go   ---- c14a93aa8b 2026-04-08 Bill Mill fix: de-glorp the glooper\n├─ trimble\n│  └─ M alpha.go  +++- d25b04bb9c 2026-04-08 Bill Mill feat: enable auto-glooping\n```\n\n- how would column alignment work? Should `network` and `trimble` have the same column alignment since they&#x27;re at the same level, or should it be per-branch?\n- would there be a maximum depth?\n    - our display is pretty wide, deep branches would be difficult to display well\n    - would we have to add a max depth flag? starts to seem like a lot of flags to add\n\nOr would it be better if it displayed them just as paths, like `git status` does?\n\n```\n$ git ls --tree --changed-only\nM README.md             ++++ a749399289 2026-04-08 Bill Mill docs: document the glooping\nM src/network/server.go ++-- c14a93aa8b 2026-04-08 Bill Mill fix: de-glorp the glooper\nM src/network/tork.go   ---- c14a93aa8b 2026-04-08 Bill Mill fix: de-glorp the glooper\nM trimble/alpha.go      +++- d25b04bb9c 2026-04-08 Bill Mill feat: enable auto-glooping\n```&quot;,&quot;comments&quot;:[],&quot;labels&quot;:[],&quot;state&quot;:&quot;OPEN&quot;,&quot;title&quot;:&quot;feature: tree view&quot;}
+[rerun: b2]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-54-36-434Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-54-36-434Z" class="timestamp-link"><time datetime="2026-04-11T01:54:36.434Z" data-timestamp="2026-04-11T01:54:36.434Z">2026-04-11T01:54:36.434Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Here's <strong>llimllib/git-ls#44</strong> — "feature: tree view" (OPEN):</p>
+<p>The issue proposes a <code>--tree</code> flag, especially useful with <code>--changed-only</code>, to display files in a tree structure. Two options are presented:</p>
+<p><strong>Option 1: Actual tree with box-drawing characters</strong></p>
+<pre><code>$ git ls --tree --changed-only
+M README.md ++++ a749399289 2026-04-08 Bill Mill docs: document the glooping
+src
+├─ network
+│  ├─ M server.go ++-- c14a93aa8b 2026-04-08 Bill Mill fix: de-glorp the glooper
+│  └─ M tork.go   ---- c14a93aa8b 2026-04-08 Bill Mill fix: de-glorp the glooper
+├─ trimble
+│  └─ M alpha.go  +++- d25b04bb9c 2026-04-08 Bill Mill feat: enable auto-glooping
+</code></pre>
+<p><strong>Option 2: Flat paths like <code>git status</code></strong></p>
+<pre><code>$ git ls --tree --changed-only
+M README.md             ++++ a749399289 2026-04-08 Bill Mill ...
+M src/network/server.go ++-- c14a93aa8b 2026-04-08 Bill Mill ...
+M src/network/tork.go   ---- c14a93aa8b 2026-04-08 Bill Mill ...
+M trimble/alpha.go      +++- d25b04bb9c 2026-04-08 Bill Mill ...
+</code></pre>
+<p><strong>Open questions raised:</strong>
+- Column alignment: per-level or per-branch?
+- Maximum depth? Deep branches would be hard to display, and adding a max-depth flag adds complexity.</p>
+<p>No comments or labels yet.</p></div></div></div>
+<div class="message user" id="msg-2026-04-11T01-55-01-207Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T01-55-01-207Z" class="timestamp-link"><time datetime="2026-04-11T01:55:01.207Z" data-timestamp="2026-04-11T01:55:01.207Z">2026-04-11T01:55:01.207Z</time></a></div><div class="message-content">
+<div class="user-content"><p>which option makes more sense to you?</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-55-06-409Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-55-06-409Z" class="timestamp-link"><time datetime="2026-04-11T01:55:06.409Z" data-timestamp="2026-04-11T01:55:06.409Z">2026-04-11T01:55:06.409Z</time></a></div><div class="message-content">
+<div class="thinking"><div class="thinking-label">Thinking</div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-55-15-359Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-55-15-359Z" class="timestamp-link"><time datetime="2026-04-11T01:55:15.359Z" data-timestamp="2026-04-11T01:55:15.359Z">2026-04-11T01:55:15.359Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Option 1 (the actual tree with box-drawing characters) is more interesting but I think Option 2 (flat paths) makes more sense, for a few reasons:</p>
+<ol>
+<li>
+<p><strong>Column alignment is straightforward.</strong> With flat paths, all filenames are at the same indentation level, so you just pad to the longest path. With a tree, alignment gets tricky — do you align across siblings? across the whole tree? The issue raises this question and there's no clean answer.</p>
+</li>
+<li>
+<p><strong>No depth problem.</strong> Deep nesting just means a longer path string, not an ever-widening indent with box-drawing prefixes eating into your terminal width.</p>
+</li>
+<li>
+<p><strong>No new flags needed.</strong> No max-depth flag, no questions about collapsing directories, etc.</p>
+</li>
+<li>
+<p><strong>It's what <code>git status</code> does.</strong> Users already expect this mental model from git — showing paths relative to the repo root. Option 1 looks nice in the issue but is a format nobody's used to reading alongside git metadata columns.</p>
+</li>
+<li>
+<p><strong>Simpler to implement and maintain.</strong> The tree-drawing logic (tracking which branches are last children, nesting prefixes) is fiddly and would complicate the column-formatting code that already exists.</p>
+</li>
+</ol>
+<p>Really the only advantage of Option 1 is that it looks cool, but it trades a lot of complexity for that. Option 2 gives you the key benefit — seeing directory structure at a glance — without the downsides.</p>
+<p>Want me to look at the codebase and start thinking about implementation?</p></div></div></div>
+        
+
+<div class="pagination">
+<a href="index.html" class="index-link">Index</a>
+<span class="disabled">&larr; Prev</span>
+<span class="current">1</span>
+<a href="page-002.html">2</a>
+<a href="page-003.html">3</a>
+<a href="page-004.html">4</a>
+<a href="page-005.html">5</a>
+<a href="page-002.html">Next &rarr;</a>
+</div>
+
+    </div>
+    <script>
+document.querySelectorAll('time[data-timestamp]').forEach(function(el) {
+    const timestamp = el.getAttribute('data-timestamp');
+    const date = new Date(timestamp);
+    const now = new Date();
+    const isToday = date.toDateString() === now.toDateString();
+    const timeStr = date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+    if (isToday) { el.textContent = timeStr; }
+    else { el.textContent = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' ' + timeStr; }
+});
+document.querySelectorAll('pre.json').forEach(function(el) {
+    let text = el.textContent;
+    text = text.replace(/"([^"]+)":/g, '<span style="color: #ce93d8">"$1"</span>:');
+    text = text.replace(/: "([^"]*)"/g, ': <span style="color: #81d4fa">"$1"</span>');
+    text = text.replace(/: (\d+)/g, ': <span style="color: #ffcc80">$1</span>');
+    text = text.replace(/: (true|false|null)/g, ': <span style="color: #f48fb1">$1</span>');
+    el.innerHTML = text;
+});
+document.querySelectorAll('.truncatable').forEach(function(wrapper) {
+    const content = wrapper.querySelector('.truncatable-content');
+    const btn = wrapper.querySelector('.expand-btn');
+    if (content.scrollHeight > 250) {
+        wrapper.classList.add('truncated');
+        btn.addEventListener('click', function() {
+            if (wrapper.classList.contains('truncated')) { wrapper.classList.remove('truncated'); wrapper.classList.add('expanded'); btn.textContent = 'Show less'; }
+            else { wrapper.classList.remove('expanded'); wrapper.classList.add('truncated'); btn.textContent = 'Show more'; }
+        });
+    }
+});
+</script>
+</body>
+</html>

--- a/transcripts/47-changed-relative-paths.html/page-002.html
+++ b/transcripts/47-changed-relative-paths.html/page-002.html
@@ -1,0 +1,2183 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Claude Code transcript - page 2</title>
+    <style>
+:root { --bg-color: #f5f5f5; --card-bg: #ffffff; --user-bg: #e3f2fd; --user-border: #1976d2; --assistant-bg: #f5f5f5; --assistant-border: #9e9e9e; --thinking-bg: #fff8e1; --thinking-border: #ffc107; --thinking-text: #666; --tool-bg: #f3e5f5; --tool-border: #9c27b0; --tool-result-bg: #e8f5e9; --tool-error-bg: #ffebee; --text-color: #212121; --text-muted: #757575; --code-bg: #263238; --code-text: #aed581; }
+* { box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg-color); color: var(--text-color); margin: 0; padding: 16px; line-height: 1.6; }
+.container { max-width: 800px; margin: 0 auto; }
+h1 { font-size: 1.5rem; margin-bottom: 24px; padding-bottom: 8px; border-bottom: 2px solid var(--user-border); }
+.header-row { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; border-bottom: 2px solid var(--user-border); padding-bottom: 8px; margin-bottom: 24px; }
+.header-row h1 { border-bottom: none; padding-bottom: 0; margin-bottom: 0; flex: 1; min-width: 200px; }
+.message { margin-bottom: 16px; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.message.user { background: var(--user-bg); border-left: 4px solid var(--user-border); }
+.message.assistant { background: var(--card-bg); border-left: 4px solid var(--assistant-border); }
+.message.tool-reply { background: #fff8e1; border-left: 4px solid #ff9800; }
+.tool-reply .role-label { color: #e65100; }
+.tool-reply .tool-result { background: transparent; padding: 0; margin: 0; }
+.tool-reply .tool-result .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff8e1); }
+.message-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 16px; background: rgba(0,0,0,0.03); font-size: 0.85rem; }
+.role-label { font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
+.user .role-label { color: var(--user-border); }
+time { color: var(--text-muted); font-size: 0.8rem; }
+.timestamp-link { color: inherit; text-decoration: none; }
+.timestamp-link:hover { text-decoration: underline; }
+.message:target { animation: highlight 2s ease-out; }
+@keyframes highlight { 0% { background-color: rgba(25, 118, 210, 0.2); } 100% { background-color: transparent; } }
+.message-content { padding: 16px; }
+.message-content p { margin: 0 0 12px 0; }
+.message-content p:last-child { margin-bottom: 0; }
+.thinking { background: var(--thinking-bg); border: 1px solid var(--thinking-border); border-radius: 8px; padding: 12px; margin: 12px 0; font-size: 0.9rem; color: var(--thinking-text); }
+.thinking-label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: #f57c00; margin-bottom: 8px; }
+.thinking p { margin: 8px 0; }
+.assistant-text { margin: 8px 0; }
+.tool-use { background: var(--tool-bg); border: 1px solid var(--tool-border); border-radius: 8px; padding: 12px; margin: 12px 0; }
+.tool-header { font-weight: 600; color: var(--tool-border); margin-bottom: 8px; display: flex; align-items: center; gap: 8px; }
+.tool-icon { font-size: 1.1rem; }
+.tool-description { font-size: 0.9rem; color: var(--text-muted); margin-bottom: 8px; font-style: italic; }
+.tool-result { background: var(--tool-result-bg); border-radius: 8px; padding: 12px; margin: 12px 0; }
+.tool-result.tool-error { background: var(--tool-error-bg); }
+.file-tool { border-radius: 8px; padding: 12px; margin: 12px 0; }
+.write-tool { background: linear-gradient(135deg, #e3f2fd 0%, #e8f5e9 100%); border: 1px solid #4caf50; }
+.edit-tool { background: linear-gradient(135deg, #fff3e0 0%, #fce4ec 100%); border: 1px solid #ff9800; }
+.file-tool-header { font-weight: 600; margin-bottom: 4px; display: flex; align-items: center; gap: 8px; font-size: 0.95rem; }
+.write-header { color: #2e7d32; }
+.edit-header { color: #e65100; }
+.file-tool-icon { font-size: 1rem; }
+.file-tool-path { font-family: monospace; background: rgba(0,0,0,0.08); padding: 2px 8px; border-radius: 4px; }
+.file-tool-fullpath { font-family: monospace; font-size: 0.8rem; color: var(--text-muted); margin-bottom: 8px; word-break: break-all; }
+.file-content { margin: 0; }
+.edit-section { display: flex; margin: 4px 0; border-radius: 4px; overflow: hidden; }
+.edit-label { padding: 8px 12px; font-weight: bold; font-family: monospace; display: flex; align-items: flex-start; }
+.edit-old { background: #fce4ec; }
+.edit-old .edit-label { color: #b71c1c; background: #f8bbd9; }
+.edit-old .edit-content { color: #880e4f; }
+.edit-new { background: #e8f5e9; }
+.edit-new .edit-label { color: #1b5e20; background: #a5d6a7; }
+.edit-new .edit-content { color: #1b5e20; }
+.edit-content { margin: 0; flex: 1; background: transparent; font-size: 0.85rem; }
+.edit-replace-all { font-size: 0.75rem; font-weight: normal; color: var(--text-muted); }
+.write-tool .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #e6f4ea); }
+.edit-tool .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff0e5); }
+.todo-list { background: linear-gradient(135deg, #e8f5e9 0%, #f1f8e9 100%); border: 1px solid #81c784; border-radius: 8px; padding: 12px; margin: 12px 0; }
+.todo-header { font-weight: 600; color: #2e7d32; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; font-size: 0.95rem; }
+.todo-items { list-style: none; margin: 0; padding: 0; }
+.todo-item { display: flex; align-items: flex-start; gap: 10px; padding: 6px 0; border-bottom: 1px solid rgba(0,0,0,0.06); font-size: 0.9rem; }
+.todo-item:last-child { border-bottom: none; }
+.todo-icon { flex-shrink: 0; width: 20px; height: 20px; display: flex; align-items: center; justify-content: center; font-weight: bold; border-radius: 50%; }
+.todo-completed .todo-icon { color: #2e7d32; background: rgba(46, 125, 50, 0.15); }
+.todo-completed .todo-content { color: #558b2f; text-decoration: line-through; }
+.todo-in-progress .todo-icon { color: #f57c00; background: rgba(245, 124, 0, 0.15); }
+.todo-in-progress .todo-content { color: #e65100; font-weight: 500; }
+.todo-pending .todo-icon { color: #757575; background: rgba(0,0,0,0.05); }
+.todo-pending .todo-content { color: #616161; }
+pre { background: var(--code-bg); color: var(--code-text); padding: 12px; border-radius: 6px; overflow-x: auto; font-size: 0.85rem; line-height: 1.5; margin: 8px 0; white-space: pre-wrap; word-wrap: break-word; }
+pre.json { color: #e0e0e0; }
+code { background: rgba(0,0,0,0.08); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+pre code { background: none; padding: 0; }
+.user-content { margin: 0; }
+.truncatable { position: relative; }
+.truncatable.truncated .truncatable-content { max-height: 200px; overflow: hidden; }
+.truncatable.truncated::after { content: ''; position: absolute; bottom: 32px; left: 0; right: 0; height: 60px; background: linear-gradient(to bottom, transparent, var(--card-bg)); pointer-events: none; }
+.message.user .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--user-bg)); }
+.message.tool-reply .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff8e1); }
+.tool-use .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--tool-bg)); }
+.tool-result .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--tool-result-bg)); }
+.expand-btn { display: none; width: 100%; padding: 8px 16px; margin-top: 4px; background: rgba(0,0,0,0.05); border: 1px solid rgba(0,0,0,0.1); border-radius: 6px; cursor: pointer; font-size: 0.85rem; color: var(--text-muted); }
+.expand-btn:hover { background: rgba(0,0,0,0.1); }
+.truncatable.truncated .expand-btn, .truncatable.expanded .expand-btn { display: block; }
+.pagination { display: flex; justify-content: center; gap: 8px; margin: 24px 0; flex-wrap: wrap; }
+.pagination a, .pagination span { padding: 5px 10px; border-radius: 6px; text-decoration: none; font-size: 0.85rem; }
+.pagination a { background: var(--card-bg); color: var(--user-border); border: 1px solid var(--user-border); }
+.pagination a:hover { background: var(--user-bg); }
+.pagination .current { background: var(--user-border); color: white; }
+.pagination .disabled { color: var(--text-muted); border: 1px solid #ddd; }
+.pagination .index-link { background: var(--user-border); color: white; }
+details.continuation { margin-bottom: 16px; }
+details.continuation summary { cursor: pointer; padding: 12px 16px; background: var(--user-bg); border-left: 4px solid var(--user-border); border-radius: 12px; font-weight: 500; color: var(--text-muted); }
+details.continuation summary:hover { background: rgba(25, 118, 210, 0.15); }
+details.continuation[open] summary { border-radius: 12px 12px 0 0; margin-bottom: 0; }
+.index-item { margin-bottom: 16px; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); background: var(--user-bg); border-left: 4px solid var(--user-border); }
+.index-item a { display: block; text-decoration: none; color: inherit; }
+.index-item a:hover { background: rgba(25, 118, 210, 0.1); }
+.index-item-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 16px; background: rgba(0,0,0,0.03); font-size: 0.85rem; }
+.index-item-number { font-weight: 600; color: var(--user-border); }
+.index-item-content { padding: 16px; }
+.index-item-stats { padding: 8px 16px 12px 32px; font-size: 0.85rem; color: var(--text-muted); border-top: 1px solid rgba(0,0,0,0.06); }
+.index-item-commit { margin-top: 6px; padding: 4px 8px; background: #fff3e0; border-radius: 4px; font-size: 0.85rem; color: #e65100; }
+.index-item-commit code { background: rgba(0,0,0,0.08); padding: 1px 4px; border-radius: 3px; font-size: 0.8rem; margin-right: 6px; }
+.commit-card { margin: 8px 0; padding: 10px 14px; background: #fff3e0; border-left: 4px solid #ff9800; border-radius: 6px; }
+.commit-card a { text-decoration: none; color: #5d4037; display: block; }
+.commit-card a:hover { color: #e65100; }
+.commit-card-hash { font-family: monospace; color: #e65100; font-weight: 600; margin-right: 8px; }
+.index-commit { margin-bottom: 12px; padding: 10px 16px; background: #fff3e0; border-left: 4px solid #ff9800; border-radius: 8px; box-shadow: 0 1px 2px rgba(0,0,0,0.05); }
+.index-commit a { display: block; text-decoration: none; color: inherit; }
+.index-commit a:hover { background: rgba(255, 152, 0, 0.1); margin: -10px -16px; padding: 10px 16px; border-radius: 8px; }
+.index-commit-header { display: flex; justify-content: space-between; align-items: center; font-size: 0.85rem; margin-bottom: 4px; }
+.index-commit-hash { font-family: monospace; color: #e65100; font-weight: 600; }
+.index-commit-msg { color: #5d4037; }
+.index-item-long-text { margin-top: 8px; padding: 12px; background: var(--card-bg); border-radius: 8px; border-left: 3px solid var(--assistant-border); }
+.index-item-long-text .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--card-bg)); }
+.index-item-long-text-content { color: var(--text-color); }
+#search-box { display: none; align-items: center; gap: 8px; }
+#search-box input { padding: 6px 12px; border: 1px solid var(--assistant-border); border-radius: 6px; font-size: 16px; width: 180px; }
+#search-box button, #modal-search-btn, #modal-close-btn { background: var(--user-border); color: white; border: none; border-radius: 6px; padding: 6px 10px; cursor: pointer; display: flex; align-items: center; justify-content: center; }
+#search-box button:hover, #modal-search-btn:hover { background: #1565c0; }
+#modal-close-btn { background: var(--text-muted); margin-left: 8px; }
+#modal-close-btn:hover { background: #616161; }
+#search-modal[open] { border: none; border-radius: 12px; box-shadow: 0 4px 24px rgba(0,0,0,0.2); padding: 0; width: 90vw; max-width: 900px; height: 80vh; max-height: 80vh; display: flex; flex-direction: column; }
+#search-modal::backdrop { background: rgba(0,0,0,0.5); }
+.search-modal-header { display: flex; align-items: center; gap: 8px; padding: 16px; border-bottom: 1px solid var(--assistant-border); background: var(--bg-color); border-radius: 12px 12px 0 0; }
+.search-modal-header input { flex: 1; padding: 8px 12px; border: 1px solid var(--assistant-border); border-radius: 6px; font-size: 16px; }
+#search-status { padding: 8px 16px; font-size: 0.85rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
+#search-results { flex: 1; overflow-y: auto; padding: 16px; }
+.search-result { margin-bottom: 16px; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.search-result a { display: block; text-decoration: none; color: inherit; }
+.search-result a:hover { background: rgba(25, 118, 210, 0.05); }
+.search-result-page { padding: 6px 12px; background: rgba(0,0,0,0.03); font-size: 0.8rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
+.search-result-content { padding: 12px; }
+.search-result mark { background: #fff59d; padding: 1px 2px; border-radius: 2px; }
+@media (max-width: 600px) { body { padding: 8px; } .message, .index-item { border-radius: 8px; } .message-content, .index-item-content { padding: 12px; } pre { font-size: 0.8rem; padding: 8px; } #search-box input { width: 120px; } #search-modal[open] { width: 95vw; height: 90vh; } }
+</style>
+</head>
+<body>
+    <div class="container">
+        <h1><a href="index.html" style="color: inherit; text-decoration: none;">Claude Code transcript</a> - page 2/5</h1>
+        
+
+<div class="pagination">
+<a href="index.html" class="index-link">Index</a>
+<a href="page-001.html">&larr; Prev</a>
+<a href="page-001.html">1</a>
+<span class="current">2</span>
+<a href="page-003.html">3</a>
+<a href="page-004.html">4</a>
+<a href="page-005.html">5</a>
+<a href="page-003.html">Next &rarr;</a>
+</div>
+
+        
+<div class="message user" id="msg-2026-04-11T01-56-04-099Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T01-56-04-099Z" class="timestamp-link"><time datetime="2026-04-11T01:56:04.099Z" data-timestamp="2026-04-11T01:56:04.099Z">2026-04-11T01:56:04.099Z</time></a></div><div class="message-content">
+<div class="user-content"><p>--tree doesn't make sense to me any longer with that, I wonder if it should be the default behavior for --changed-only</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-56-12-149Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-56-12-149Z" class="timestamp-link"><time datetime="2026-04-11T01:56:12.149Z" data-timestamp="2026-04-11T01:56:12.149Z">2026-04-11T01:56:12.149Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>That makes sense — if you're using <code>--changed-only</code>, you're already looking at a small subset of files, so showing full paths relative to the repo root is natural and arguably the <em>expected</em> behavior. The current behavior of just showing the filename without the path means you can't tell which <code>server.go</code> you're looking at if there are multiple.</p>
+<p>Making it the default for <code>--changed-only</code> is cleaner than adding a flag. No new flags, no decision fatigue, and the display is still compact since the file count is small.</p>
+<p>Want me to dig into the codebase and see how filenames are currently rendered so we can figure out what needs to change?</p></div></div></div>
+<div class="message user" id="msg-2026-04-11T01-56-26-841Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T01-56-26-841Z" class="timestamp-link"><time datetime="2026-04-11T01:56:26.841Z" data-timestamp="2026-04-11T01:56:26.841Z">2026-04-11T01:56:26.841Z</time></a></div><div class="message-content">
+<div class="user-content"><p>yeah let's take a look</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-56-34-486Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-56-34-486Z" class="timestamp-link"><time datetime="2026-04-11T01:56:34.486Z" data-timestamp="2026-04-11T01:56:34.486Z">2026-04-11T01:56:34.486Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01L6jhsEoCSyNTmyFnqXTED4"><div class="tool-header"><span class="tool-icon">⚙</span> Agent</div><div class="tool-description">Explore git-ls codebase</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;subagent_type&#34;: &#34;Explore&#34;,
+  &#34;prompt&#34;: &#34;Explore the git-ls codebase at /Users/llimllib/code/git-ls/tree-experiment. I need to understand:\n\n1. The overall project structure (what language, key files)\n2. How filenames are displayed in the output — find the code that formats and prints file entries\n3. How --changed-only works — how it filters files and what it passes to the display/formatting code\n4. Whether filenames currently include directory paths or just basenames\n\nBe thorough — look at the main entry point, the display/formatting code, and the changed-only filtering logic. Report file paths and line numbers for key locations.&#34;
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-57-34-991Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-57-34-991Z" class="timestamp-link"><time datetime="2026-04-11T01:57:34.991Z" data-timestamp="2026-04-11T01:57:34.991Z">2026-04-11T01:57:34.991Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Perfect! Now I have all the information I need to provide a comprehensive answer.
+
+## Comprehensive Analysis of git-ls Codebase
+
+### 1. Overall Project Structure
+
+**Language:** Go (golang)
+**Key Files:**
+- `/Users/llimllib/code/git-ls/tree-experiment/main.go` - Main entry point and core logic (31,665 lines)
+- `/Users/llimllib/code/git-ls/tree-experiment/columns.go` - Display/formatting code (13,180 lines)
+- `/Users/llimllib/code/git-ls/tree-experiment/main_test.go` - Tests (35,621 lines)
+
+This is a command-line tool that displays files in a git repository annotated with git status, commit history, authors, and hyperlinks.
+
+---
+
+### 2. How Filenames Are Displayed
+
+**Key Location:** `/Users/llimllib/code/git-ls/tree-experiment/columns.go:243-270`
+
+The `renderFilename()` function handles filename display:
+```go
+func renderFilename(out io.Writer, file *File, maxWidth int, rctx *RenderContext) {
+    // Line 257-258: Creates file URL and renders it
+    fileURL := fmt.Sprintf(&quot;file://%s%s&quot;, must(os.Hostname()), filepath.Join(rctx.Dir, file.Name()))
+    must(fmt.Fprintf(out, &quot;%s&quot;, link(fileURL, file.Name())))
+}
+```
+
+**Critical Finding:** The filename displayed uses `file.Name()` which returns **just the basename**, not the full directory path. This is confirmed by:
+- `/Users/llimllib/code/git-ls/tree-experiment/main.go:62-67` - The `Name()` method returns either `f.entry.Name()` (from `os.DirEntry`) or `f.name` field
+- `os.DirEntry.Name()` in Go returns only the base name without the directory path
+- Line 257 constructs the full URL path by using `filepath.Join(rctx.Dir, file.Name())` where `rctx.Dir` is the absolute directory path
+
+The hyperlink is clickable and points to the full path, but the **displayed text is just the basename**.
+
+---
+
+### 3. How --changed-only Works
+
+**Flag Parsing:** `/Users/llimllib/code/git-ls/tree-experiment/main.go:286-288`
+```go
+} else if argv[0] == &quot;--changed-only&quot; || argv[0] == &quot;-c&quot; {
+    changedOnly = true
+    argv = argv[1:]
+```
+
+**Filtering Logic:** `/Users/llimllib/code/git-ls/tree-experiment/main.go:365-366`
+```go
+if changedOnly {
+    files = changedFilesFilter(files)
+}
+```
+
+**Filter Implementation:** `/Users/llimllib/code/git-ls/tree-experiment/main.go:444-453`
+```go
+func changedFilesFilter(files []*File) []*File {
+    var changedFiles []*File
+    for _, file := range files {
+        if file.status != &quot;&quot; &amp;&amp; file.status != &quot;I&quot; &amp;&amp; file.status != &quot;*&quot; {
+            changedFiles = append(changedFiles, file)
+        }
+    }
+    return changedFiles
+}
+```
+
+**What It Filters:**
+- **Keeps:** Files with non-empty status (modified, added, deleted, renamed, etc.)
+- **Removes:**
+  - Files with empty status (`&quot;&quot;`) — unmodified tracked files
+  - Ignored files (`&quot;I&quot;`)
+  - The `.git` directory (`&quot;*&quot;`)
+
+**Data Flow:**
+1. `fileStatus()` is called first (line 359) to populate the `status` field on each file from git status output
+2. `parseDeletedFiles()` adds deleted files to the list (line 362)
+3. Then `changedFilesFilter()` removes files with empty/ignored status (line 366)
+4. The filtered file list is passed to `showColumns()` for rendering (line 441)
+
+---
+
+### 4. Filename Path Display Summary
+
+**Current Behavior: Basenames Only**
+
+- **What&#x27;s displayed:** Just the filename basename (e.g., `main.go`, `README.md`)
+- **What&#x27;s NOT displayed:** Directory paths or relative paths
+- **Why:** Files are read from `os.ReadDir(&quot;.&quot;)` which returns only the names of entries in the current directory
+- **Hyperlink:** The clickable file URL includes the full absolute path, but the visible text is just the basename
+
+**Evidence:**
+- `/Users/llimllib/code/git-ls/tree-experiment/main.go:335-348` - Files are read from current directory with `os.ReadDir(&quot;.&quot;)`
+- `/Users/llimllib/code/git-ls/tree-experiment/columns.go:187` - Width calculation uses `width(file.Name())` (basename only)
+- `/Users/llimllib/code/git-ls/tree-experiment/main.go:421-423` - Files are sorted by `a.Name()` (basename)
+- `/Users/llimllib/code/git-ls/tree-experiment/columns.go:257` - Display uses `file.Name()` directly
+
+---
+
+### 5. Display/Formatting Code Architecture
+
+**Main Display Loop:** `/Users/llimllib/code/git-ls/tree-experiment/main.go:595-632`
+
+The `showColumns()` function:
+1. Calculates max widths for each column (line 597)
+2. Iterates through each file (line 600)
+3. For each file, iterates through requested columns (line 604)
+4. Gets the appropriate renderer function for each column (line 621)
+5. Calls the renderer with the file data (line 622)
+
+**Column Renderers** (in `/Users/llimllib/code/git-ls/tree-experiment/columns.go`):
+- `renderStatus()` - Line 215-231
+- `renderDiff()` - Line 233-241
+- `renderFilename()` - Line 243-270
+- `renderShorthash()` - Line 272-296
+- `renderHash()` - Line 298-319
+- `renderDate()` - Line 321-328
+- `renderAuthor()` - Line 330-356
+- `renderEmail()` - Line 358-371
+- `renderNumstat()` - Line 373-392
+- `renderCommitMessage()` - Line 394-418
+
+Each renderer handles:
+- Coloring (using ANSI codes)
+- Hyperlink generation
+- Width padding for column alignment</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-57-40-631Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-57-40-631Z" class="timestamp-link"><time datetime="2026-04-11T01:57:40.631Z" data-timestamp="2026-04-11T01:57:40.631Z">2026-04-11T01:57:40.631Z</time></a></div><div class="message-content">
+<div class="thinking"><div class="thinking-label">Thinking</div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-57-41-150Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-57-41-150Z" class="timestamp-link"><time datetime="2026-04-11T01:57:41.150Z" data-timestamp="2026-04-11T01:57:41.150Z">2026-04-11T01:57:41.150Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Let me look at the key sections more closely.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-57-41-505Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-57-41-505Z" class="timestamp-link"><time datetime="2026-04-11T01:57:41.505Z" data-timestamp="2026-04-11T01:57:41.505Z">2026-04-11T01:57:41.505Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01Vcu66VaHy9f9C3h6hzzERF"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;limit&#34;: 70
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-57-41-511Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-57-41-511Z" class="timestamp-link"><time datetime="2026-04-11T01:57:41.511Z" data-timestamp="2026-04-11T01:57:41.511Z">2026-04-11T01:57:41.511Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>1	package main
+2	
+3	import (
+4		&quot;bufio&quot;
+5		&quot;fmt&quot;
+6		&quot;io&quot;
+7		&quot;log&quot;
+8		&quot;os&quot;
+9		&quot;os/exec&quot;
+10		&quot;path/filepath&quot;
+11		&quot;regexp&quot;
+12		&quot;runtime/debug&quot;
+13		&quot;slices&quot;
+14		&quot;strconv&quot;
+15		&quot;strings&quot;
+16		&quot;sync&quot;
+17		&quot;syscall&quot;
+18		&quot;unsafe&quot;
+19	
+20		&quot;github.com/mattn/go-runewidth&quot;
+21	)
+22	
+23	const VERSION = &quot;5.9.0&quot;
+24	
+25	// HistoryLimit is the maximum number of commits to review; we&#x27;ll exit if we
+26	// find all files before it; if a file was more than this many commits ago we
+27	// won&#x27;t print its info
+28	const HistoryLimit = &quot;50000&quot;
+29	
+30	type Diff struct {
+31		plus  int
+32		minus int
+33	}
+34	
+35	type File struct {
+36		entry        os.DirEntry
+37		name         string // used for deleted files that don&#x27;t have a DirEntry
+38		oldName      string // pre-rename path for R/C status (relative to current directory)
+39		status       string
+40		diffSum      *Diff
+41		diffStat     string
+42		author       string
+43		authorEmail  string
+44		hash         string // full hash
+45		shortHash    string // Git&#x27;s abbreviated hash (length varies by repo size)
+46		lastModified string
+47		message      string
+48		isDir        bool
+49		isExe        bool
+50		isDeleted    bool
+51	}
+52	
+53	// RenderContext holds settings that affect how output is rendered
+54	type RenderContext struct {
+55		GithubURL string
+56		Dir       string
+57		MonoHash  bool
+58		NerdFont  bool
+59	}
+60	
+61	// Name returns the file name, either from the DirEntry or the name field
+62	func (f *File) Name() string {
+63		if f.entry != nil {
+64			return f.entry.Name()
+65		}
+66		return f.name
+67	}
+68	
+69	const (
+70		BLUE      = &quot;\x1b[34m&quot;</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-57-45-048Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-57-45-048Z" class="timestamp-link"><time datetime="2026-04-11T01:57:45.048Z" data-timestamp="2026-04-11T01:57:45.048Z">2026-04-11T01:57:45.048Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01PUYkQmtaJaXn4jPLay12GW"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 325,
+  &#34;limit&#34;: 130
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-57-45-054Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-57-45-054Z" class="timestamp-link"><time datetime="2026-04-11T01:57:45.054Z" data-timestamp="2026-04-11T01:57:45.054Z">2026-04-11T01:57:45.054Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>325		if len(argv) &gt; 0 {
+326			dir = argv[0]
+327	
+328			if err := os.Chdir(dir); err != nil {
+329				log.Fatalf(&quot;Failed to change directory to %s: %v&quot;, dir, err)
+330			}
+331		} else {
+332			dir = &quot;.&quot;
+333		}
+334	
+335		osfiles, err := os.ReadDir(&quot;.&quot;)
+336		if err != nil {
+337			log.Fatalf(&quot;Failed to read directory %s: %v&quot;, dir, err)
+338		}
+339	
+340		var files []*File
+341		for _, file := range osfiles {
+342			stat, _ := os.Stat(file.Name())
+343			files = append(files, &amp;File{
+344				entry: file,
+345				isDir: file.IsDir(),
+346				isExe: !file.IsDir() &amp;&amp; stat.Mode()&amp;0o111 != 0,
+347			})
+348		}
+349	
+350		// Fetch all git data in parallel
+351		gitData := fetchGitData()
+352	
+353		// Resolve symlinks to match git&#x27;s perspective. Git internally resolves
+354		// symlinks when working with worktrees, so we need to do the same to
+355		// ensure filepath.Rel() works correctly in fileStatus().
+356		// https://github.com/llimllib/git-ls/issues/34
+357		resolved := must(filepath.EvalSymlinks(must(filepath.Abs(&quot;.&quot;))))
+358		curdir := must(filepath.Rel(gitData.root, resolved))
+359		fileStatus(gitData.status, files, curdir)
+360	
+361		// Parse deleted files from git status and merge into file list
+362		deletedFiles := parseDeletedFiles(gitData.status, curdir)
+363		files = append(files, deletedFiles...)
+364	
+365		if changedOnly {
+366			files = changedFilesFilter(files)
+367		}
+368	
+369		// Now run git log on the files we&#x27;ll show
+370		// Skip git log for files that won&#x27;t have history:
+371		// - I: Ignored files - not tracked by git
+372		// - ??: Untracked files - not in git yet
+373		// - *: .git directory - git metadata, not file history
+374		// - A: Newly added files
+375		//   Examples: &quot;A &quot;, &quot;AM&quot;, &quot;AD&quot; - staged additions not yet committed
+376		//   But &quot;M &quot;, &quot;MM&quot;, or mixed dirs like &quot;A ,M &quot; have history
+377		var filesNeedingLog []*File
+378		for _, file := range files {
+379			if file.status == &quot;I&quot; || file.status == &quot;??&quot; || file.status == &quot;*&quot; {
+380				continue
+381			}
+382			// Empty status means unmodified tracked file — it has history
+383			if file.status == &quot;&quot; {
+384				filesNeedingLog = append(filesNeedingLog, file)
+385				continue
+386			}
+387			// Check if ALL statuses in a comma-separated list are new additions
+388			// For directories, status might be &quot;A ,M &quot; if it has both new and modified files
+389			allNew := true
+390			for status := range strings.SplitSeq(file.status, &quot;,&quot;) {
+391				status = strings.TrimSpace(status)
+392				// Check if this individual status represents a file with history
+393				// If first char (index) is not &#x27;A&#x27; and not untracked, it has history
+394				if len(status) &gt; 0 &amp;&amp; status[0] != &#x27;A&#x27; &amp;&amp; status != &quot;??&quot; {
+395					allNew = false
+396					break
+397				}
+398			}
+399			if !allNew {
+400				filesNeedingLog = append(filesNeedingLog, file)
+401			}
+402		}
+403	
+404		if debug {
+405			for _, file := range filesNeedingLog {
+406				log.Printf(&quot;%s,&quot;, file.Name())
+407			}
+408			fmt.Printf(&quot;\n&quot;)
+409		}
+410		if err := parseGitLog(filesNeedingLog); err != nil {
+411			log.Fatalf(&quot;Error: git log streaming failed: %v&quot;, err)
+412		}
+413		parseDiffStat(gitData.diffStat, files)
+414	
+415		// generate a diffStat graph for every file
+416		for _, file := range files {
+417			file.diffStat = makeDiffGraph(file, diffWidth)
+418		}
+419	
+420		// Sort files by name
+421		slices.SortFunc(files, func(a, b *File) int {
+422			return strings.Compare(strings.ToLower(a.Name()), strings.ToLower(b.Name()))
+423		})
+424	
+425		// Use default columns if not specified
+426		if len(formatColumns) == 0 {
+427			formatColumns = AllColumns()
+428		}
+429	
+430		maxWidth := columns(os.Stdout.Fd())
+431		if maxWidth == 0 {
+432			maxWidth = 80 // default when not a TTY
+433		}
+434		fmt.Printf(&quot;%s%s%s\n\n&quot;, RED, gitData.currentBranch, RESET)
+435		rctx := &amp;RenderContext{
+436			GithubURL: isGithub(gitData.remotes),
+437			Dir:       must(filepath.Abs(&quot;.&quot;)),
+438			MonoHash:  monoHash,
+439			NerdFont:  nerdFont,
+440		}
+441		showColumns(os.Stdout, maxWidth, files, rctx, formatColumns)
+442	}
+443	
+444	// changedFilesFilter strips unchanged files from the files to display
+445	func changedFilesFilter(files []*File) []*File {
+446		var changedFiles []*File
+447		for _, file := range files {
+448			if file.status != &quot;&quot; &amp;&amp; file.status != &quot;I&quot; &amp;&amp; file.status != &quot;*&quot; {
+449				changedFiles = append(changedFiles, file)
+450			}
+451		}
+452		return changedFiles
+453	}
+454	</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-57-45-793Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-57-45-793Z" class="timestamp-link"><time datetime="2026-04-11T01:57:45.793Z" data-timestamp="2026-04-11T01:57:45.793Z">2026-04-11T01:57:45.793Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01G4br17EmZKbrbCqY28y1qT"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 440,
+  &#34;limit&#34;: 30
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-57-45-797Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-57-45-797Z" class="timestamp-link"><time datetime="2026-04-11T01:57:45.797Z" data-timestamp="2026-04-11T01:57:45.797Z">2026-04-11T01:57:45.797Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>440		}
+441		showColumns(os.Stdout, maxWidth, files, rctx, formatColumns)
+442	}
+443	
+444	// changedFilesFilter strips unchanged files from the files to display
+445	func changedFilesFilter(files []*File) []*File {
+446		var changedFiles []*File
+447		for _, file := range files {
+448			if file.status != &quot;&quot; &amp;&amp; file.status != &quot;I&quot; &amp;&amp; file.status != &quot;*&quot; {
+449				changedFiles = append(changedFiles, file)
+450			}
+451		}
+452		return changedFiles
+453	}
+454	
+455	func parseFormat(formatStr string) []Column {
+456		validCols := ValidColumns()
+457		colNames := strings.Split(formatStr, &quot;,&quot;)
+458		var columns []Column
+459	
+460		for _, name := range colNames {
+461			name = strings.TrimSpace(name)
+462			if col, ok := validCols[name]; ok {
+463				columns = append(columns, col)
+464			} else {
+465				fmt.Fprintf(os.Stderr, &quot;Error: Invalid column name &#x27;%s&#x27;\n&quot;, name)
+466				fmt.Fprintf(os.Stderr, &quot;Valid columns: status, diff, filename, shorthash, hash, date, author, email, numstat, commitmessage\n&quot;)
+467				os.Exit(1)
+468			}
+469		}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-57-49-123Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-57-49-123Z" class="timestamp-link"><time datetime="2026-04-11T01:57:49.123Z" data-timestamp="2026-04-11T01:57:49.123Z">2026-04-11T01:57:49.123Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now let me look at <code>renderFilename</code> and how <code>fileStatus</code> works with paths.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-57-49-643Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-57-49-643Z" class="timestamp-link"><time datetime="2026-04-11T01:57:49.643Z" data-timestamp="2026-04-11T01:57:49.643Z">2026-04-11T01:57:49.643Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_017Z8T2VWx9ahu4vqz1kGKJc"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/columns.go&#34;,
+  &#34;offset&#34;: 243,
+  &#34;limit&#34;: 30
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-57-49-660Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-57-49-660Z" class="timestamp-link"><time datetime="2026-04-11T01:57:49.660Z" data-timestamp="2026-04-11T01:57:49.660Z">2026-04-11T01:57:49.660Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>243	// renderFilename renders the filename column with colors and hyperlinks
+244	func renderFilename(out io.Writer, file *File, maxWidth int, rctx *RenderContext) {
+245		if file.isDeleted {
+246			must(fmt.Fprintf(out, &quot;%s%s&quot;, RED, STRIKEOUT))
+247		} else if file.isDir {
+248			must(fmt.Fprintf(out, &quot;%s&quot;, BLUE))
+249		} else if file.isExe {
+250			must(fmt.Fprintf(out, &quot;%s&quot;, GREEN))
+251		}
+252	
+253		// link the file name to the file&#x27;s location (but not for deleted files)
+254		if file.isDeleted {
+255			must(fmt.Fprintf(out, &quot;%s&quot;, file.Name()))
+256		} else {
+257			fileURL := fmt.Sprintf(&quot;file://%s%s&quot;, must(os.Hostname()), filepath.Join(rctx.Dir, file.Name()))
+258			must(fmt.Fprintf(out, &quot;%s&quot;, link(fileURL, file.Name())))
+259		}
+260	
+261		// pad spaces to the right up to maxWidth
+262		for i := 0; i &lt; maxWidth-width(file.Name()); i++ {
+263			must(fmt.Fprintf(out, &quot; &quot;))
+264		}
+265	
+266		// reset color for dir/exe but not deleted (strikethrough continues)
+267		if file.isDir || file.isExe {
+268			must(fmt.Fprintf(out, &quot;%s&quot;, RESET))
+269		}
+270	}
+271	
+272	// renderShorthash renders the short commit hash</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-57-50-270Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-57-50-270Z" class="timestamp-link"><time datetime="2026-04-11T01:57:50.270Z" data-timestamp="2026-04-11T01:57:50.270Z">2026-04-11T01:57:50.270Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01Lpvv3XLfYV8wECzWfo1fe8"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/columns.go&#34;,
+  &#34;offset&#34;: 175,
+  &#34;limit&#34;: 20
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-57-50-278Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-57-50-278Z" class="timestamp-link"><time datetime="2026-04-11T01:57:50.278Z" data-timestamp="2026-04-11T01:57:50.278Z">2026-04-11T01:57:50.278Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>175			for _, file := range files {
+176				var w int
+177				switch col {
+178				case ColStatus:
+179					if rctx.NerdFont {
+180						w = nerdFontStatusWidth(file.status)
+181					} else {
+182						w = width(file.status)
+183					}
+184				case ColDiff:
+185					w = width(file.diffStat)
+186				case ColFilename:
+187					w = width(file.Name())
+188				case ColShorthash:
+189					w = width(file.shortHash)
+190				case ColHash:
+191					w = width(file.hash)
+192				case ColDate:
+193					w = width(file.lastModified)
+194				case ColAuthor:</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-58-03-257Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-58-03-257Z" class="timestamp-link"><time datetime="2026-04-11T01:58:03.257Z" data-timestamp="2026-04-11T01:58:03.257Z">2026-04-11T01:58:03.257Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Here's the picture:</p>
+<p><strong>Current behavior:</strong> The tool runs <code>os.ReadDir(".")</code> on the current directory, so it only sees immediate entries (files and directories). <code>file.Name()</code> returns the basename only — you see <code>main.go</code>, not <code>src/network/main.go</code>.</p>
+<p><strong>The problem for <code>--changed-only</code>:</strong> <code>git status</code> reports changed files throughout the whole repo tree, but <code>os.ReadDir(".")</code> only lists the current directory. So <code>--changed-only</code> can only show changed files that happen to be in the current directory (or directories containing changed files). You can't see <code>src/network/server.go</code> as its own line — you'd just see <code>src/</code> as a directory.</p>
+<p>To make <code>--changed-only</code> show full relative paths, you'd need to:</p>
+<ol>
+<li>
+<p><strong>When <code>--changed-only</code> is active, build the file list from <code>git status</code> output</strong> instead of <code>os.ReadDir(".")</code>. The status data already has the full repo-relative paths — parse those into <code>File</code> structs with a <code>name</code> field containing the relative path (e.g. <code>src/network/server.go</code>).</p>
+</li>
+<li>
+<p><strong>Update <code>renderFilename</code></strong> to use the relative path for display and width calculation — which it already would if <code>file.Name()</code> returns the full relative path.</p>
+</li>
+<li>
+<p><strong>Fix the hyperlink URL</strong> in <code>renderFilename</code> — <code>filepath.Join(rctx.Dir, file.Name())</code> should still work since <code>rctx.Dir</code> is the abs path of the working directory.</p>
+</li>
+</ol>
+<p>The key insight is that <code>--changed-only</code> should switch from "list directory entries then filter" to "list changed files from git status directly." Want me to start on an implementation?</p></div></div></div>
+<div class="message user" id="msg-2026-04-11T01-58-50-634Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T01-58-50-634Z" class="timestamp-link"><time datetime="2026-04-11T01:58:50.634Z" data-timestamp="2026-04-11T01:58:50.634Z">2026-04-11T01:58:50.634Z</time></a></div><div class="message-content">
+<div class="user-content"><p>sure give it a shot</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-58-55-178Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-58-55-178Z" class="timestamp-link"><time datetime="2026-04-11T01:58:55.178Z" data-timestamp="2026-04-11T01:58:55.178Z">2026-04-11T01:58:55.178Z</time></a></div><div class="message-content">
+<div class="thinking"><div class="thinking-label">Thinking</div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-58-55-737Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-58-55-737Z" class="timestamp-link"><time datetime="2026-04-11T01:58:55.737Z" data-timestamp="2026-04-11T01:58:55.737Z">2026-04-11T01:58:55.737Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Let me first understand how git status is parsed and the full flow.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-58-56-823Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-58-56-823Z" class="timestamp-link"><time datetime="2026-04-11T01:58:56.823Z" data-timestamp="2026-04-11T01:58:56.823Z">2026-04-11T01:58:56.823Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_014Lu6oCKRLTgyYaNhrTEMxS"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;func fileStatus&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-58-56-846Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-58-56-846Z" class="timestamp-link"><time datetime="2026-04-11T01:58:56.846Z" data-timestamp="2026-04-11T01:58:56.846Z">2026-04-11T01:58:56.846Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>main.go:803:func fileStatus(status []byte, files []*File, curdir string) {</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-58-57-314Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-58-57-314Z" class="timestamp-link"><time datetime="2026-04-11T01:58:57.314Z" data-timestamp="2026-04-11T01:58:57.314Z">2026-04-11T01:58:57.314Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01EfP6P2kBWppxNeyTFC5dsL"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;func parseDeletedFiles&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-58-57-331Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-58-57-331Z" class="timestamp-link"><time datetime="2026-04-11T01:58:57.331Z" data-timestamp="2026-04-11T01:58:57.331Z">2026-04-11T01:58:57.331Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>main.go:854:func parseDeletedFiles(status []byte, curdir string) []*File {</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-58-58-042Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-58-58-042Z" class="timestamp-link"><time datetime="2026-04-11T01:58:58.042Z" data-timestamp="2026-04-11T01:58:58.042Z">2026-04-11T01:58:58.042Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_014hzinD8ox9KszQTQfPACgR"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;func fetchGitData&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-58-58-064Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-58-58-064Z" class="timestamp-link"><time datetime="2026-04-11T01:58:58.064Z" data-timestamp="2026-04-11T01:58:58.064Z">2026-04-11T01:58:58.064Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>main.go:160:func fetchGitData() *gitResults {
+transcripts/45-handle-detached-head/page-002.html:1102:@@ -171,7 +171,7 @@ func fetchGitData() *gitResults {</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-59-02-649Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-59-02-649Z" class="timestamp-link"><time datetime="2026-04-11T01:59:02.649Z" data-timestamp="2026-04-11T01:59:02.649Z">2026-04-11T01:59:02.649Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01XrnZQRCGwRs5aSfPcMrrJv"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 160,
+  &#34;limit&#34;: 50
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-59-02-654Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-59-02-654Z" class="timestamp-link"><time datetime="2026-04-11T01:59:02.654Z" data-timestamp="2026-04-11T01:59:02.654Z">2026-04-11T01:59:02.654Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>160	func fetchGitData() *gitResults {
+161		results := &amp;gitResults{}
+162	
+163		var wg sync.WaitGroup
+164	
+165		wg.Go(func() {
+166			results.root = gitRoot()
+167		})
+168	
+169		wg.Go(func() {
+170			results.status = gitStatus()
+171		})
+172	
+173		wg.Go(func() {
+174			results.currentBranch = headDescription()
+175		})
+176	
+177		wg.Go(func() {
+178			results.remotes = gitRemotes()
+179		})
+180	
+181		// No diff stats in empty repo
+182		if isEmptyRepo() {
+183			results.isEmpty = true
+184			results.diffStat = []byte{}
+185		} else {
+186			wg.Go(func() {
+187				results.diffStat = gitDiffStat()
+188			})
+189		}
+190	
+191		wg.Wait()
+192		return results
+193	}
+194	
+195	// printVersion prints version info including the commit hash if available
+196	func printVersion() {
+197		commit := &quot;&quot;
+198		if info, ok := debug.ReadBuildInfo(); ok {
+199			for _, setting := range info.Settings {
+200				if setting.Key == &quot;vcs.revision&quot; {
+201					commit = setting.Value
+202					if len(commit) &gt; 7 {
+203						commit = commit[:7]
+204					}
+205					break
+206				}
+207			}
+208		}
+209		if commit != &quot;&quot; {</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-59-03-128Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-59-03-128Z" class="timestamp-link"><time datetime="2026-04-11T01:59:03.128Z" data-timestamp="2026-04-11T01:59:03.128Z">2026-04-11T01:59:03.128Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01Jcyq7VLusmPWu2tj8jBXx9"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 803,
+  &#34;limit&#34;: 100
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-59-03-133Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-59-03-133Z" class="timestamp-link"><time datetime="2026-04-11T01:59:03.133Z" data-timestamp="2026-04-11T01:59:03.133Z">2026-04-11T01:59:03.133Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>803	func fileStatus(status []byte, files []*File, curdir string) {
+804		gitStatusMap := make(map[string][]string)
+805		// oldNameMap tracks the old (pre-rename) path for renamed/copied files,
+806		// keyed by the new filename. This is needed so git log can look up
+807		// the file&#x27;s history under its previous name.
+808		oldNameMap := make(map[string]string)
+809		for line := range strings.SplitSeq(string(status), &quot;\n&quot;) {
+810			if len(line) &gt;= 3 {
+811				status := line[:2]
+812				// TODO: reject filenames that aren&#x27;t in the current directory. Can
+813				// we just ignore &quot;..&quot; entries? Right now, if you&#x27;re in /subdir,
+814				// and there&#x27;s changes in /otherdir/whatever , this will create
+815				// gitStatusMap entries of &quot;..&quot;, which doesn&#x27;t seem to mess stuff
+816				// up but isn&#x27;t ideal either
+817				path := line[3:]
+818				// For renames and copies, git&#x27;s porcelain output looks like:
+819				//   R  old-name.txt -&gt; new-name.txt
+820				//   C  source.txt -&gt; copy.txt
+821				// We need the new filename (after &quot; -&gt; &quot;) since that&#x27;s what
+822				// exists on disk, and we record the old name so we can look up
+823				// the file&#x27;s commit history.
+824				if (status[0] == &#x27;R&#x27; || status[0] == &#x27;C&#x27;) &amp;&amp; strings.Contains(path, &quot; -&gt; &quot;) {
+825					parts := strings.SplitN(path, &quot; -&gt; &quot;, 2)
+826					oldNameMap[first(must(filepath.Rel(curdir, parts[1])))] = must(filepath.Rel(curdir, parts[0]))
+827					path = parts[1]
+828				}
+829				fileName := first(must(filepath.Rel(curdir, path)))
+830				if status == &quot;!!&quot; {
+831					status = &quot;I&quot;
+832				}
+833				gitStatusMap[fileName] = append(gitStatusMap[fileName], status)
+834			}
+835		}
+836	
+837		for _, file := range files {
+838			if fileStatus, ok := gitStatusMap[file.Name()]; ok {
+839				slices.Sort(fileStatus)
+840				file.status = strings.Join(slices.Compact(fileStatus), &quot;,&quot;)
+841			}
+842			if oldName, ok := oldNameMap[file.Name()]; ok {
+843				file.oldName = oldName
+844			}
+845			if file.Name() == &quot;.git&quot; {
+846				file.status = &quot;*&quot;
+847			}
+848		}
+849	}
+850	
+851	// parseDeletedFiles extracts deleted files from git status output and returns
+852	// them as File structs. Deleted files have status &quot; D&quot; (deleted in worktree)
+853	// or &quot;D &quot; (staged deletion).
+854	func parseDeletedFiles(status []byte, curdir string) []*File {
+855		var deletedFiles []*File
+856		for line := range strings.SplitSeq(string(status), &quot;\n&quot;) {
+857			if len(line) &gt;= 3 {
+858				statusCode := line[:2]
+859				// &quot; D&quot; means deleted in worktree, &quot;D &quot; means staged deletion
+860				if statusCode == &quot; D&quot; || statusCode == &quot;D &quot; {
+861					fileName := first(must(filepath.Rel(curdir, line[3:])))
+862					// Only include files in current directory (not &quot;..&quot; for parent dirs)
+863					if fileName != &quot;..&quot; &amp;&amp; !strings.Contains(fileName, string(os.PathSeparator)) {
+864						deletedFiles = append(deletedFiles, &amp;File{
+865							name:      fileName,
+866							status:    statusCode,
+867							isDeleted: true,
+868						})
+869					}
+870				}
+871			}
+872		}
+873		return deletedFiles
+874	}
+875	
+876	// parseGitLog runs a single git log command and streams the output,
+877	// stopping as soon as all files are found. This is much faster than spawning
+878	// N processes because:
+879	// 1. Single process (no spawn overhead)
+880	// 2. Early exit (stops when all files found)
+881	// 3. Walks history once (all files benefit from git&#x27;s caching)
+882	// 4. Directory scoped (only checks current directory)
+883	func parseGitLog(files []*File) error {
+884		if len(files) == 0 {
+885			return nil
+886		}
+887	
+888		// Build map of files we need to find
+889		filesNeeded := make(map[string]*File)
+890		for _, f := range files {
+891			filesNeeded[f.Name()] = f
+892			// For renamed/copied files, also look for the old name so the
+893			// streaming log can match the file under its previous path.
+894			if f.oldName != &quot;&quot; {
+895				filesNeeded[first(f.oldName)] = f
+896			}
+897		}
+898	
+899		// Start git log with streaming output
+900		// -- .: limit to current directory (faster)
+901		// --relative: make paths relative to current directory
+902		cmd := exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;log&quot;,</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-59-06-955Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-59-06-955Z" class="timestamp-link"><time datetime="2026-04-11T01:59:06.955Z" data-timestamp="2026-04-11T01:59:06.955Z">2026-04-11T01:59:06.955Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01Rw6Xh5gJgxHXsDm1ZpuHYB"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 900,
+  &#34;limit&#34;: 80
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-59-06-961Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-59-06-961Z" class="timestamp-link"><time datetime="2026-04-11T01:59:06.961Z" data-timestamp="2026-04-11T01:59:06.961Z">2026-04-11T01:59:06.961Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>900		// -- .: limit to current directory (faster)
+901		// --relative: make paths relative to current directory
+902		cmd := exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;log&quot;,
+903			&quot;--name-only&quot;,
+904			&quot;--relative&quot;,
+905			&quot;--date=format:%Y-%m-%d&quot;,
+906			&quot;--format=%H%x00%h%x00%ad%x00%aN%x00%aE%x00%s%x00&quot;,
+907			&quot;-n&quot;, HistoryLimit,
+908			&quot;HEAD&quot;, &quot;--&quot;, &quot;.&quot;)
+909	
+910		stdout, err := cmd.StdoutPipe()
+911		if err != nil {
+912			return err
+913		}
+914	
+915		if err := cmd.Start(); err != nil {
+916			return err
+917		}
+918	
+919		scanner := bufio.NewScanner(stdout)
+920		var currentCommit struct {
+921			hash        string
+922			shortHash   string
+923			date        string
+924			author      string
+925			authorEmail string
+926			message     string
+927		}
+928	
+929		// Track lines since last find for early exit. This counts lines of output
+930		// (both commit metadata and filenames), not commits. In active monorepos
+931		// a single root-level file might not appear for 100k+ lines if
+932		// subdirectories see heavy churn.
+933		linesSinceLastFind := 0
+934		const giveUpAfter = 150000
+935	
+936		for scanner.Scan() {
+937			linesSinceLastFind++
+938			line := scanner.Text()
+939	
+940			if len(line) == 0 {
+941				continue // Skip blank lines
+942			}
+943	
+944			// Check if this is a commit metadata line (contains null bytes)
+945			if strings.Contains(line, &quot;\x00&quot;) {
+946				parts := strings.Split(line, &quot;\x00&quot;)
+947				if len(parts) &gt;= 6 {
+948					currentCommit.hash = parts[0]
+949					currentCommit.shortHash = parts[1]
+950					currentCommit.date = parts[2]
+951					currentCommit.author = parts[3]
+952					currentCommit.authorEmail = parts[4]
+953					currentCommit.message = parts[5]
+954				}
+955			} else if currentCommit.hash != &quot;&quot; {
+956				// This is a filename line
+957				filename := strings.TrimSpace(line)
+958	
+959				// Extract the first component (for directories)
+960				// e.g., &quot;builtin/add.c&quot; -&gt; &quot;builtin&quot;, &quot;main.go&quot; -&gt; &quot;main.go&quot;
+961				firstPart := first(filename)
+962	
+963				// Check if this is a file/dir we&#x27;re looking for
+964				if file, needed := filesNeeded[firstPart]; needed {
+965					// Found it! Populate the file info
+966					file.hash = currentCommit.hash
+967					file.shortHash = currentCommit.shortHash
+968					file.lastModified = currentCommit.date
+969					file.author = currentCommit.author
+970					file.authorEmail = currentCommit.authorEmail
+971					file.message = currentCommit.message
+972	
+973					// Remove from needed set. For renamed/copied files we
+974					// may have two keys (old name + new name) pointing to
+975					// the same File, so delete both.
+976					delete(filesNeeded, firstPart)
+977					if file.oldName != &quot;&quot; {
+978						delete(filesNeeded, first(file.oldName))
+979						delete(filesNeeded, file.Name())</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-59-13-451Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-59-13-451Z" class="timestamp-link"><time datetime="2026-04-11T01:59:13.451Z" data-timestamp="2026-04-11T01:59:13.451Z">2026-04-11T01:59:13.451Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_0185CR9GJ2Ko38Xe7fzqGsKq"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;func first\\(&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;-A&#34;: 5
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-59-13-463Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-59-13-463Z" class="timestamp-link"><time datetime="2026-04-11T01:59:13.463Z" data-timestamp="2026-04-11T01:59:13.463Z">2026-04-11T01:59:13.463Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>1028:func first(path string) string {
+1029-	i := 0
+1030-	for i &lt; len(path) &amp;&amp; !os.IsPathSeparator(path[i]) {
+1031-		i++
+1032-	}
+1033-	return path[:i]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-59-13-969Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-59-13-969Z" class="timestamp-link"><time datetime="2026-04-11T01:59:13.969Z" data-timestamp="2026-04-11T01:59:13.969Z">2026-04-11T01:59:13.969Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01FbK5uDGGFjqSMJY36ywc6n"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;func parseDiffStat&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;-A&#34;: 30
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-59-13-987Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-59-13-987Z" class="timestamp-link"><time datetime="2026-04-11T01:59:13.987Z" data-timestamp="2026-04-11T01:59:13.987Z">2026-04-11T01:59:13.987Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>1061:func parseDiffStat(diffStat []byte, files []*File) {
+1062-	diffStats := make(map[string][]Diff)
+1063-	for line := range strings.SplitSeq(strings.TrimSpace(string(diffStat)), &quot;\n&quot;) {
+1064-		parts := strings.Split(line, &quot;\t&quot;)
+1065-		if len(parts) &lt; 3 {
+1066-			continue
+1067-		}
+1068-
+1069-		plus := diffInt(parts[0])
+1070-		minus := diffInt(parts[1])
+1071-		path := first(strings.TrimSpace(parts[2]))
+1072-		diffStats[path] = append(diffStats[path], Diff{plus, minus})
+1073-	}
+1074-
+1075-	for _, file := range files {
+1076-		// if the file has any diffs, sum them up. This way we aggregate a
+1077-		// directory&#x27;s diffs
+1078-		if stats, ok := diffStats[file.Name()]; ok {
+1079-			plus := 0
+1080-			minus := 0
+1081-			for _, stat := range stats {
+1082-				plus += stat.plus
+1083-				minus += stat.minus
+1084-			}
+1085-
+1086-			file.diffSum = &amp;Diff{plus, minus}
+1087-		}
+1088-	}
+1089-}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-59-18-110Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-59-18-110Z" class="timestamp-link"><time datetime="2026-04-11T01:59:18.110Z" data-timestamp="2026-04-11T01:59:18.110Z">2026-04-11T01:59:18.110Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now I have a good understanding of the codebase. Let me look at the <code>gitStatus()</code> function to see the raw format, then implement the change.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-59-19-055Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-59-19-055Z" class="timestamp-link"><time datetime="2026-04-11T01:59:19.055Z" data-timestamp="2026-04-11T01:59:19.055Z">2026-04-11T01:59:19.055Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01VoSRteo2bZvpx4UV7a8Awf"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;func gitStatus\\(\\)&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;-A&#34;: 10
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-59-19-072Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-59-19-072Z" class="timestamp-link"><time datetime="2026-04-11T01:59:19.072Z" data-timestamp="2026-04-11T01:59:19.072Z">2026-04-11T01:59:19.072Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>794:func gitStatus() []byte {
+795-	cmd := exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;status&quot;, &quot;--porcelain&quot;, &quot;--ignored&quot;)
+796-	out, err := cmd.Output()
+797-	if err != nil {
+798-		log.Fatalf(&quot;Failed to get git status: %v&quot;, err)
+799-	}
+800-	return out
+801-}
+802-
+803-func fileStatus(status []byte, files []*File, curdir string) {
+804-	gitStatusMap := make(map[string][]string)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-59-19-696Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-59-19-696Z" class="timestamp-link"><time datetime="2026-04-11T01:59:19.696Z" data-timestamp="2026-04-11T01:59:19.696Z">2026-04-11T01:59:19.696Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01D38NCsy5SPR42be6n7gppm"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;func gitDiffStat\\(\\)&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;-A&#34;: 10
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-59-19-713Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-59-19-713Z" class="timestamp-link"><time datetime="2026-04-11T01:59:19.713Z" data-timestamp="2026-04-11T01:59:19.713Z">2026-04-11T01:59:19.713Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>1047:func gitDiffStat() []byte {
+1048-	cmd := exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;diff&quot;, &quot;--numstat&quot;, &quot;--relative&quot;, &quot;HEAD&quot;)
+1049-	output, err := cmd.Output()
+1050-	if err != nil {
+1051-		// If HEAD doesn&#x27;t exist (empty repo with no commits), return empty result
+1052-		// rather than crashing. Exit code 128 is git&#x27;s &quot;fatal error&quot; code.
+1053-		if exitErr, ok := err.(*exec.ExitError); ok &amp;&amp; exitErr.ExitCode() == 128 {
+1054-			return []byte{}
+1055-		}
+1056-		log.Fatalf(&quot;Diffstat error: %v&quot;, err)
+1057-	}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-59-26-510Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-59-26-510Z" class="timestamp-link"><time datetime="2026-04-11T01:59:26.510Z" data-timestamp="2026-04-11T01:59:26.510Z">2026-04-11T01:59:26.510Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now let me check how <code>parseGitLog</code> handles paths — it uses <code>--relative</code> and <code>-- .</code> to scope to the current directory, and <code>first()</code> to get the first path component. For <code>--changed-only</code> with full paths, the git log approach needs to match full relative paths instead.</p>
+<p>Let me also check if there are tests I should look at.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-59-27-289Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-59-27-289Z" class="timestamp-link"><time datetime="2026-04-11T01:59:27.289Z" data-timestamp="2026-04-11T01:59:27.289Z">2026-04-11T01:59:27.289Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_018oDJxmBwVdd3QQpc3ZbrxL"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;changedOnly|changed.only|changed_only&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main_test.go&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;-n&#34;: true
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-59-27-304Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-59-27-304Z" class="timestamp-link"><time datetime="2026-04-11T01:59:27.304Z" data-timestamp="2026-04-11T01:59:27.304Z">2026-04-11T01:59:27.304Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>819:// TestChangedOnly verifies that the --changed-only flag filters files
+867:// introduced with --changed-only where the filesNeedingLog filter excluded files</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-59-30-964Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-59-30-964Z" class="timestamp-link"><time datetime="2026-04-11T01:59:30.964Z" data-timestamp="2026-04-11T01:59:30.964Z">2026-04-11T01:59:30.964Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01EdCZpgCSFaME4DBFhnW5Ue"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main_test.go&#34;,
+  &#34;offset&#34;: 819,
+  &#34;limit&#34;: 100
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-59-30-969Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-59-30-969Z" class="timestamp-link"><time datetime="2026-04-11T01:59:30.969Z" data-timestamp="2026-04-11T01:59:30.969Z">2026-04-11T01:59:30.969Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>819	// TestChangedOnly verifies that the --changed-only flag filters files
+820	// to only show those with git status.
+821	func TestChangedOnly(t *testing.T) {
+822		// Create test files with different statuses
+823		files := []*File{
+824			{entry: &amp;mockDirEntry{name: &quot;modified.go&quot;}, status: &quot;M &quot;},
+825			{entry: &amp;mockDirEntry{name: &quot;untracked.go&quot;}, status: &quot;??&quot;},
+826			{entry: &amp;mockDirEntry{name: &quot;clean.go&quot;}, status: &quot;&quot;},
+827			{entry: &amp;mockDirEntry{name: &quot;added.go&quot;}, status: &quot;A &quot;},
+828			{entry: &amp;mockDirEntry{name: &quot;another-clean.go&quot;}, status: &quot;&quot;},
+829			{name: &quot;deleted.go&quot;, status: &quot;D &quot;, isDeleted: true},
+830			{entry: &amp;mockDirEntry{name: &quot;ignored.log&quot;}, status: &quot;I&quot;},
+831			{entry: &amp;mockDirEntry{name: &quot;.git&quot;}, status: &quot;*&quot;},
+832		}
+833	
+834		// Filter to only changed files
+835		changedFiles := changedFilesFilter(files)
+836	
+837		// Verify we got only the files with status (ignored files excluded)
+838		if len(changedFiles) != 4 {
+839			t.Errorf(&quot;Expected 4 changed files, got %d&quot;, len(changedFiles))
+840		}
+841	
+842		// Verify the correct files were kept
+843		expectedNames := map[string]bool{
+844			&quot;modified.go&quot;:  true,
+845			&quot;untracked.go&quot;: true,
+846			&quot;added.go&quot;:     true,
+847			&quot;deleted.go&quot;:   true,
+848		}
+849	
+850		for _, f := range changedFiles {
+851			name := f.Name()
+852			if !expectedNames[name] {
+853				t.Errorf(&quot;Unexpected file in changed list: %s&quot;, name)
+854			}
+855			delete(expectedNames, name)
+856		}
+857	
+858		if len(expectedNames) &gt; 0 {
+859			for name := range expectedNames {
+860				t.Errorf(&quot;Expected file %s was not in changed list&quot;, name)
+861			}
+862		}
+863	}
+864	
+865	// TestUnmodifiedFileGetsGitInfo verifies that clean tracked files (empty status)
+866	// get their commit information populated. This is a regression test for a bug
+867	// introduced with --changed-only where the filesNeedingLog filter excluded files
+868	// with empty status, causing unmodified files to show no commit info.
+869	func TestUnmodifiedFileGetsGitInfo(t *testing.T) {
+870		tmpDir := t.TempDir()
+871	
+872		repoDir := tmpDir + &quot;/repo&quot;
+873		if err := os.Mkdir(repoDir, 0o755); err != nil {
+874			t.Fatalf(&quot;Failed to create repo dir: %v&quot;, err)
+875		}
+876	
+877		if err := runCmd(repoDir, &quot;git&quot;, &quot;init&quot;, &quot;-b&quot;, &quot;main&quot;); err != nil {
+878			t.Fatalf(&quot;Failed to init repo: %v&quot;, err)
+879		}
+880		if err := runCmd(repoDir, &quot;git&quot;, &quot;config&quot;, &quot;user.email&quot;, &quot;test@example.com&quot;); err != nil {
+881			t.Fatalf(&quot;Failed to set git email: %v&quot;, err)
+882		}
+883		if err := runCmd(repoDir, &quot;git&quot;, &quot;config&quot;, &quot;user.name&quot;, &quot;Test User&quot;); err != nil {
+884			t.Fatalf(&quot;Failed to set git name: %v&quot;, err)
+885		}
+886	
+887		if err := os.WriteFile(repoDir+&quot;/clean.go&quot;, []byte(&quot;package main\n&quot;), 0o644); err != nil {
+888			t.Fatalf(&quot;Failed to write file: %v&quot;, err)
+889		}
+890		if err := runCmd(repoDir, &quot;git&quot;, &quot;add&quot;, &quot;clean.go&quot;); err != nil {
+891			t.Fatalf(&quot;Failed to add file: %v&quot;, err)
+892		}
+893		if err := runCmd(repoDir, &quot;git&quot;, &quot;commit&quot;, &quot;-m&quot;, &quot;add clean file&quot;); err != nil {
+894			t.Fatalf(&quot;Failed to commit: %v&quot;, err)
+895		}
+896	
+897		oldDir, _ := os.Getwd()
+898		defer func() {
+899			if err := os.Chdir(oldDir); err != nil {
+900				t.Logf(&quot;Failed to restore directory: %v&quot;, err)
+901			}
+902		}()
+903	
+904		if err := os.Chdir(repoDir); err != nil {
+905			t.Fatalf(&quot;Failed to chdir: %v&quot;, err)
+906		}
+907	
+908		osfiles, err := os.ReadDir(&quot;.&quot;)
+909		if err != nil {
+910			t.Fatalf(&quot;Failed to read directory: %v&quot;, err)
+911		}
+912	
+913		var files []*File
+914		for _, file := range osfiles {
+915			stat, _ := os.Stat(file.Name())
+916			files = append(files, &amp;File{
+917				entry: file,
+918				isDir: file.IsDir(),</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-59-38-411Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-59-38-411Z" class="timestamp-link"><time datetime="2026-04-11T01:59:38.411Z" data-timestamp="2026-04-11T01:59:38.411Z">2026-04-11T01:59:38.411Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now I have a solid understanding. Let me plan the implementation:</p>
+<ol>
+<li>When <code>--changed-only</code> is active, build <code>File</code> structs from git status output with full relative paths (instead of from <code>os.ReadDir(".")</code>)</li>
+<li>Adapt <code>parseGitLog</code> to work with full relative paths (not just first path components)</li>
+<li>Adapt <code>parseDiffStat</code> similarly</li>
+<li>The <code>renderFilename</code> and width calculation should just work since they use <code>file.Name()</code></li>
+</ol>
+<p>Let me look at the main flow one more time to see how <code>changedOnly</code> is threaded through.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-59-38-972Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-59-38-972Z" class="timestamp-link"><time datetime="2026-04-11T01:59:38.972Z" data-timestamp="2026-04-11T01:59:38.972Z">2026-04-11T01:59:38.972Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01GfjsuziqKBLMgpmhLNuppe"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 270,
+  &#34;limit&#34;: 60
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-59-38-982Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-59-38-982Z" class="timestamp-link"><time datetime="2026-04-11T01:59:38.982Z" data-timestamp="2026-04-11T01:59:38.982Z">2026-04-11T01:59:38.982Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>270		var formatColumns []Column
+271		for len(argv) &gt; 0 {
+272			if argv[0] == &quot;--version&quot; {
+273				printVersion()
+274				os.Exit(0)
+275			}
+276			if argv[0] == &quot;--help&quot; || argv[0] == &quot;-h&quot; {
+277				usage()
+278				os.Exit(0)
+279			}
+280			if argv[0] == &quot;--mono-hash&quot; {
+281				monoHash = true
+282				argv = argv[1:]
+283			} else if argv[0] == &quot;--nerdfont&quot; {
+284				nerdFont = true
+285				argv = argv[1:]
+286			} else if argv[0] == &quot;--changed-only&quot; || argv[0] == &quot;-c&quot; {
+287				changedOnly = true
+288				argv = argv[1:]
+289			} else if strings.HasPrefix(argv[0], &quot;--diffWidth&quot;) {
+290				if len(argv) == 1 {
+291					if strings.Contains(argv[0], &quot;=&quot;) {
+292						parts := strings.SplitN(argv[0], &quot;=&quot;, 2)
+293						diffWidth = must(strconv.Atoi(parts[1]))
+294					} else {
+295						log.Fatalf(&quot;--diffWidth requires an argument&quot;)
+296					}
+297					argv = argv[1:]
+298				} else {
+299					diffWidth = must(strconv.Atoi(argv[1]))
+300					argv = argv[2:]
+301				}
+302			} else if strings.HasPrefix(argv[0], &quot;--format&quot;) {
+303				if len(argv) == 1 {
+304					if strings.Contains(argv[0], &quot;=&quot;) {
+305						parts := strings.SplitN(argv[0], &quot;=&quot;, 2)
+306						formatColumns = parseFormat(parts[1])
+307					} else {
+308						log.Fatalf(&quot;--format requires an argument&quot;)
+309					}
+310					argv = argv[1:]
+311				} else {
+312					formatColumns = parseFormat(argv[1])
+313					argv = argv[2:]
+314				}
+315			} else if strings.HasPrefix(argv[0], &quot;--debug&quot;) {
+316				debug = true
+317				argv = argv[1:]
+318			} else {
+319				// Non-flag argument (directory), stop parsing flags
+320				break
+321			}
+322		}
+323	
+324		var dir string
+325		if len(argv) &gt; 0 {
+326			dir = argv[0]
+327	
+328			if err := os.Chdir(dir); err != nil {
+329				log.Fatalf(&quot;Failed to change directory to %s: %v&quot;, dir, err)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-59-44-701Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-59-44-701Z" class="timestamp-link"><time datetime="2026-04-11T01:59:44.701Z" data-timestamp="2026-04-11T01:59:44.701Z">2026-04-11T01:59:44.701Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now let me look at what <code>parseGitLog</code> does with <code>-- .</code> and <code>--relative</code> since we'll need to adjust that for full paths.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-59-45-120Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-59-45-120Z" class="timestamp-link"><time datetime="2026-04-11T01:59:45.120Z" data-timestamp="2026-04-11T01:59:45.120Z">2026-04-11T01:59:45.120Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01Pm3Vdn3okshUdrwfj48xDu"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 980,
+  &#34;limit&#34;: 50
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-59-45-135Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-59-45-135Z" class="timestamp-link"><time datetime="2026-04-11T01:59:45.135Z" data-timestamp="2026-04-11T01:59:45.135Z">2026-04-11T01:59:45.135Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>980					}
+981					linesSinceLastFind = 0 // Reset counter
+982	
+983					// If we found all files, we can stop!
+984					if len(filesNeeded) == 0 {
+985						// Kill the git process - we&#x27;re done
+986						_ = cmd.Process.Kill()
+987						// Drain remaining output to avoid broken pipe errors
+988						go func() {
+989							for scanner.Scan() {
+990							}
+991						}()
+992						return nil
+993					}
+994				}
+995	
+996				// Early exit if we haven&#x27;t found new files in a while
+997				if linesSinceLastFind &gt; giveUpAfter {
+998					_ = cmd.Process.Kill()
+999					go func() {
+1000						for scanner.Scan() {
+1001						}
+1002					}()
+1003					return nil
+1004				}
+1005			}
+1006		}
+1007	
+1008		if err := scanner.Err(); err != nil {
+1009			// If we killed the process, we might get an error - that&#x27;s fine if we found everything
+1010			if len(filesNeeded) == 0 {
+1011				return nil
+1012			}
+1013			return err
+1014		}
+1015	
+1016		// Wait for process to finish
+1017		_ = cmd.Wait()
+1018	
+1019		// If some files weren&#x27;t found, that&#x27;s okay - they might be very old
+1020		// or not in git history. They&#x27;ll just have empty commit info.
+1021	
+1022		return nil
+1023	}
+1024	
+1025	// first returns the first part of a filepath. Given &quot;some/file/path&quot;, it will
+1026	// return &quot;some&quot;. Modified from golang&#x27;s built-in Split function:
+1027	// https://github.com/golang/go/blob/c5698e315/src/internal/filepathlite/path.go#L204-L212
+1028	func first(path string) string {
+1029		i := 0</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-59-54-738Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-59-54-738Z" class="timestamp-link"><time datetime="2026-04-11T01:59:54.738Z" data-timestamp="2026-04-11T01:59:54.738Z">2026-04-11T01:59:54.738Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now I have a clear picture. Here's the approach:</p>
+<p>For <code>--changed-only</code>, instead of reading the current directory and filtering, we'll build <code>File</code> structs directly from <code>git status</code> output with their full relative paths. The key changes:</p>
+<ol>
+<li><strong>New function <code>changedFilesFromStatus</code></strong> — parses git status to create <code>File</code> structs with relative paths</li>
+<li><strong>Adjust <code>parseGitLog</code></strong> — when files have paths with separators, look them up by full path not just <code>first()</code></li>
+<li><strong>Adjust <code>parseDiffStat</code></strong> — same, match on full path</li>
+<li><strong>Wire it up</strong> in the main flow, skipping <code>os.ReadDir</code> when <code>--changed-only</code></li>
+</ol>
+<p>Let me implement this.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T01-59-54-779Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T01-59-54-779Z" class="timestamp-link"><time datetime="2026-04-11T01:59:54.779Z" data-timestamp="2026-04-11T01:59:54.779Z">2026-04-11T01:59:54.779Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01JSGSwe13BbHPmjsDCX4fQP"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 335,
+  &#34;limit&#34;: 110
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T01-59-54-787Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T01-59-54-787Z" class="timestamp-link"><time datetime="2026-04-11T01:59:54.787Z" data-timestamp="2026-04-11T01:59:54.787Z">2026-04-11T01:59:54.787Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>335		osfiles, err := os.ReadDir(&quot;.&quot;)
+336		if err != nil {
+337			log.Fatalf(&quot;Failed to read directory %s: %v&quot;, dir, err)
+338		}
+339	
+340		var files []*File
+341		for _, file := range osfiles {
+342			stat, _ := os.Stat(file.Name())
+343			files = append(files, &amp;File{
+344				entry: file,
+345				isDir: file.IsDir(),
+346				isExe: !file.IsDir() &amp;&amp; stat.Mode()&amp;0o111 != 0,
+347			})
+348		}
+349	
+350		// Fetch all git data in parallel
+351		gitData := fetchGitData()
+352	
+353		// Resolve symlinks to match git&#x27;s perspective. Git internally resolves
+354		// symlinks when working with worktrees, so we need to do the same to
+355		// ensure filepath.Rel() works correctly in fileStatus().
+356		// https://github.com/llimllib/git-ls/issues/34
+357		resolved := must(filepath.EvalSymlinks(must(filepath.Abs(&quot;.&quot;))))
+358		curdir := must(filepath.Rel(gitData.root, resolved))
+359		fileStatus(gitData.status, files, curdir)
+360	
+361		// Parse deleted files from git status and merge into file list
+362		deletedFiles := parseDeletedFiles(gitData.status, curdir)
+363		files = append(files, deletedFiles...)
+364	
+365		if changedOnly {
+366			files = changedFilesFilter(files)
+367		}
+368	
+369		// Now run git log on the files we&#x27;ll show
+370		// Skip git log for files that won&#x27;t have history:
+371		// - I: Ignored files - not tracked by git
+372		// - ??: Untracked files - not in git yet
+373		// - *: .git directory - git metadata, not file history
+374		// - A: Newly added files
+375		//   Examples: &quot;A &quot;, &quot;AM&quot;, &quot;AD&quot; - staged additions not yet committed
+376		//   But &quot;M &quot;, &quot;MM&quot;, or mixed dirs like &quot;A ,M &quot; have history
+377		var filesNeedingLog []*File
+378		for _, file := range files {
+379			if file.status == &quot;I&quot; || file.status == &quot;??&quot; || file.status == &quot;*&quot; {
+380				continue
+381			}
+382			// Empty status means unmodified tracked file — it has history
+383			if file.status == &quot;&quot; {
+384				filesNeedingLog = append(filesNeedingLog, file)
+385				continue
+386			}
+387			// Check if ALL statuses in a comma-separated list are new additions
+388			// For directories, status might be &quot;A ,M &quot; if it has both new and modified files
+389			allNew := true
+390			for status := range strings.SplitSeq(file.status, &quot;,&quot;) {
+391				status = strings.TrimSpace(status)
+392				// Check if this individual status represents a file with history
+393				// If first char (index) is not &#x27;A&#x27; and not untracked, it has history
+394				if len(status) &gt; 0 &amp;&amp; status[0] != &#x27;A&#x27; &amp;&amp; status != &quot;??&quot; {
+395					allNew = false
+396					break
+397				}
+398			}
+399			if !allNew {
+400				filesNeedingLog = append(filesNeedingLog, file)
+401			}
+402		}
+403	
+404		if debug {
+405			for _, file := range filesNeedingLog {
+406				log.Printf(&quot;%s,&quot;, file.Name())
+407			}
+408			fmt.Printf(&quot;\n&quot;)
+409		}
+410		if err := parseGitLog(filesNeedingLog); err != nil {
+411			log.Fatalf(&quot;Error: git log streaming failed: %v&quot;, err)
+412		}
+413		parseDiffStat(gitData.diffStat, files)
+414	
+415		// generate a diffStat graph for every file
+416		for _, file := range files {
+417			file.diffStat = makeDiffGraph(file, diffWidth)
+418		}
+419	
+420		// Sort files by name
+421		slices.SortFunc(files, func(a, b *File) int {
+422			return strings.Compare(strings.ToLower(a.Name()), strings.ToLower(b.Name()))
+423		})
+424	
+425		// Use default columns if not specified
+426		if len(formatColumns) == 0 {
+427			formatColumns = AllColumns()
+428		}
+429	
+430		maxWidth := columns(os.Stdout.Fd())
+431		if maxWidth == 0 {
+432			maxWidth = 80 // default when not a TTY
+433		}
+434		fmt.Printf(&quot;%s%s%s\n\n&quot;, RED, gitData.currentBranch, RESET)
+435		rctx := &amp;RenderContext{
+436			GithubURL: isGithub(gitData.remotes),
+437			Dir:       must(filepath.Abs(&quot;.&quot;)),
+438			MonoHash:  monoHash,
+439			NerdFont:  nerdFont,
+440		}
+441		showColumns(os.Stdout, maxWidth, files, rctx, formatColumns)
+442	}
+443	
+444	// changedFilesFilter strips unchanged files from the files to display</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-00-01-529Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-00-01-529Z" class="timestamp-link"><time datetime="2026-04-11T02:00:01.529Z" data-timestamp="2026-04-11T02:00:01.529Z">2026-04-11T02:00:01.529Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now I understand the full picture. The tricky parts:</p>
+<ol>
+<li><code>parseGitLog</code> uses <code>--relative</code> and <code>-- .</code> which scopes to the current dir. For <code>--changed-only</code> with recursive files, we need it to search more broadly and match on full relative paths.</li>
+<li><code>parseDiffStat</code> uses <code>--relative</code> which gives paths relative to cwd — it also uses <code>first()</code> to collapse to directory level.</li>
+</ol>
+<p>Let me implement the change. I'll create a new function that builds file list from git status for <code>--changed-only</code>, and adjust the git log/diff matching.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-00-10-521Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-00-10-521Z" class="timestamp-link"><time datetime="2026-04-11T02:00:10.521Z" data-timestamp="2026-04-11T02:00:10.521Z">2026-04-11T02:00:10.521Z</time></a></div><div class="message-content"><div class="file-tool edit-tool" data-tool-id="toolu_017GPX6oLVZ7ETQTiELUVej8">
+<div class="file-tool-header edit-header"><span class="file-tool-icon">✏️</span> Edit <span class="file-tool-path">main.go</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/tree-experiment/main.go</div>
+<div class="truncatable"><div class="truncatable-content">
+<div class="edit-section edit-old"><div class="edit-label">−</div><pre class="edit-content">	osfiles, err := os.ReadDir(&#34;.&#34;)
+	if err != nil {
+		log.Fatalf(&#34;Failed to read directory %s: %v&#34;, dir, err)
+	}
+
+	var files []*File
+	for _, file := range osfiles {
+		stat, _ := os.Stat(file.Name())
+		files = append(files, &amp;File{
+			entry: file,
+			isDir: file.IsDir(),
+			isExe: !file.IsDir() &amp;&amp; stat.Mode()&amp;0o111 != 0,
+		})
+	}
+
+	// Fetch all git data in parallel
+	gitData := fetchGitData()
+
+	// Resolve symlinks to match git&#39;s perspective. Git internally resolves
+	// symlinks when working with worktrees, so we need to do the same to
+	// ensure filepath.Rel() works correctly in fileStatus().
+	// https://github.com/llimllib/git-ls/issues/34
+	resolved := must(filepath.EvalSymlinks(must(filepath.Abs(&#34;.&#34;))))
+	curdir := must(filepath.Rel(gitData.root, resolved))
+	fileStatus(gitData.status, files, curdir)
+
+	// Parse deleted files from git status and merge into file list
+	deletedFiles := parseDeletedFiles(gitData.status, curdir)
+	files = append(files, deletedFiles...)
+
+	if changedOnly {
+		files = changedFilesFilter(files)
+	}</pre></div>
+<div class="edit-section edit-new"><div class="edit-label">+</div><pre class="edit-content">	// Fetch all git data in parallel
+	gitData := fetchGitData()
+
+	// Resolve symlinks to match git&#39;s perspective. Git internally resolves
+	// symlinks when working with worktrees, so we need to do the same to
+	// ensure filepath.Rel() works correctly in fileStatus().
+	// https://github.com/llimllib/git-ls/issues/34
+	resolved := must(filepath.EvalSymlinks(must(filepath.Abs(&#34;.&#34;))))
+	curdir := must(filepath.Rel(gitData.root, resolved))
+
+	var files []*File
+	if changedOnly {
+		// In --changed-only mode, build the file list directly from git
+		// status so we can show files from subdirectories with their full
+		// relative paths (e.g. &#34;src/network/server.go&#34; not just &#34;src/&#34;)
+		files = changedFilesFromStatus(gitData.status, curdir)
+	} else {
+		osfiles, err := os.ReadDir(&#34;.&#34;)
+		if err != nil {
+			log.Fatalf(&#34;Failed to read directory %s: %v&#34;, dir, err)
+		}
+
+		for _, file := range osfiles {
+			stat, _ := os.Stat(file.Name())
+			files = append(files, &amp;File{
+				entry: file,
+				isDir: file.IsDir(),
+				isExe: !file.IsDir() &amp;&amp; stat.Mode()&amp;0o111 != 0,
+			})
+		}
+
+		fileStatus(gitData.status, files, curdir)
+
+		// Parse deleted files from git status and merge into file list
+		deletedFiles := parseDeletedFiles(gitData.status, curdir)
+		files = append(files, deletedFiles...)
+	}</pre></div>
+</div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-00-10-547Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-00-10-547Z" class="timestamp-link"><time datetime="2026-04-11T02:00:10.547Z" data-timestamp="2026-04-11T02:00:10.547Z">2026-04-11T02:00:10.547Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/tree-experiment/main.go has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-00-14-692Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-00-14-692Z" class="timestamp-link"><time datetime="2026-04-11T02:00:14.692Z" data-timestamp="2026-04-11T02:00:14.692Z">2026-04-11T02:00:14.692Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now I need to add the <code>changedFilesFromStatus</code> function. Let me add it after <code>changedFilesFilter</code>:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-00-15-371Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-00-15-371Z" class="timestamp-link"><time datetime="2026-04-11T02:00:15.371Z" data-timestamp="2026-04-11T02:00:15.371Z">2026-04-11T02:00:15.371Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01MBNF4gfW6Ws6CJn98csYxT"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 448,
+  &#34;limit&#34;: 10
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-00-15-382Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-00-15-382Z" class="timestamp-link"><time datetime="2026-04-11T02:00:15.382Z" data-timestamp="2026-04-11T02:00:15.382Z">2026-04-11T02:00:15.382Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>448	// changedFilesFilter strips unchanged files from the files to display
+449	func changedFilesFilter(files []*File) []*File {
+450		var changedFiles []*File
+451		for _, file := range files {
+452			if file.status != &quot;&quot; &amp;&amp; file.status != &quot;I&quot; &amp;&amp; file.status != &quot;*&quot; {
+453				changedFiles = append(changedFiles, file)
+454			}
+455		}
+456		return changedFiles
+457	}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-00-28-289Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-00-28-289Z" class="timestamp-link"><time datetime="2026-04-11T02:00:28.289Z" data-timestamp="2026-04-11T02:00:28.289Z">2026-04-11T02:00:28.289Z</time></a></div><div class="message-content"><div class="file-tool edit-tool" data-tool-id="toolu_01SjMUH157jzKvMRyw8wenhe">
+<div class="file-tool-header edit-header"><span class="file-tool-icon">✏️</span> Edit <span class="file-tool-path">main.go</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/tree-experiment/main.go</div>
+<div class="truncatable"><div class="truncatable-content">
+<div class="edit-section edit-old"><div class="edit-label">−</div><pre class="edit-content">// changedFilesFilter strips unchanged files from the files to display
+func changedFilesFilter(files []*File) []*File {
+	var changedFiles []*File
+	for _, file := range files {
+		if file.status != &#34;&#34; &amp;&amp; file.status != &#34;I&#34; &amp;&amp; file.status != &#34;*&#34; {
+			changedFiles = append(changedFiles, file)
+		}
+	}
+	return changedFiles
+}</pre></div>
+<div class="edit-section edit-new"><div class="edit-label">+</div><pre class="edit-content">// changedFilesFilter strips unchanged files from the files to display
+func changedFilesFilter(files []*File) []*File {
+	var changedFiles []*File
+	for _, file := range files {
+		if file.status != &#34;&#34; &amp;&amp; file.status != &#34;I&#34; &amp;&amp; file.status != &#34;*&#34; {
+			changedFiles = append(changedFiles, file)
+		}
+	}
+	return changedFiles
+}
+
+// changedFilesFromStatus builds a list of changed File structs directly from
+// git status output. Unlike the normal flow (which reads the current directory
+// and then filters), this produces files with full relative paths so that
+// --changed-only can show files from subdirectories.
+func changedFilesFromStatus(status []byte, curdir string) []*File {
+	var files []*File
+	seen := make(map[string]bool)
+	for line := range strings.SplitSeq(string(status), &#34;\n&#34;) {
+		if len(line) &lt; 3 {
+			continue
+		}
+		statusCode := line[:2]
+		path := line[3:]
+
+		// Skip ignored files
+		if statusCode == &#34;!!&#34; {
+			continue
+		}
+
+		// For renames/copies, use the new name and record the old name
+		var oldName string
+		if (statusCode[0] == &#39;R&#39; || statusCode[0] == &#39;C&#39;) &amp;&amp; strings.Contains(path, &#34; -&gt; &#34;) {
+			parts := strings.SplitN(path, &#34; -&gt; &#34;, 2)
+			oldName = must(filepath.Rel(curdir, parts[0]))
+			path = parts[1]
+		}
+
+		relPath := must(filepath.Rel(curdir, path))
+
+		// Skip files outside the current directory (would start with &#34;..&#34;)
+		if strings.HasPrefix(relPath, &#34;..&#34;) {
+			continue
+		}
+
+		// Deduplicate (a file can appear in status with different codes)
+		if seen[relPath] {
+			continue
+		}
+		seen[relPath] = true
+
+		isDeleted := statusCode == &#34; D&#34; || statusCode == &#34;D &#34;
+		isExe := false
+		if !isDeleted {
+			if stat, err := os.Stat(relPath); err == nil {
+				isExe = !stat.IsDir() &amp;&amp; stat.Mode()&amp;0o111 != 0
+			}
+		}
+
+		file := &amp;File{
+			name:      relPath,
+			status:    strings.TrimSpace(statusCode),
+			oldName:   oldName,
+			isDeleted: isDeleted,
+			isExe:     isExe,
+		}
+		files = append(files, file)
+	}
+	return files
+}</pre></div>
+</div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-00-28-309Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-00-28-309Z" class="timestamp-link"><time datetime="2026-04-11T02:00:28.309Z" data-timestamp="2026-04-11T02:00:28.309Z">2026-04-11T02:00:28.309Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/tree-experiment/main.go has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-00-32-473Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-00-32-473Z" class="timestamp-link"><time datetime="2026-04-11T02:00:32.473Z" data-timestamp="2026-04-11T02:00:32.473Z">2026-04-11T02:00:32.473Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now I need to update <code>parseGitLog</code> to handle full relative paths. Currently it uses <code>first()</code> to collapse paths to first component. For <code>--changed-only</code> files with nested paths, we need to match the full path.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-00-32-943Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-00-32-943Z" class="timestamp-link"><time datetime="2026-04-11T02:00:32.943Z" data-timestamp="2026-04-11T02:00:32.943Z">2026-04-11T02:00:32.943Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_014etuaCpGKwgSF3HMYpfjEv"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 883,
+  &#34;limit&#34;: 130
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-00-32-953Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-00-32-953Z" class="timestamp-link"><time datetime="2026-04-11T02:00:32.953Z" data-timestamp="2026-04-11T02:00:32.953Z">2026-04-11T02:00:32.953Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>883				//   R  old-name.txt -&gt; new-name.txt
+884				//   C  source.txt -&gt; copy.txt
+885				// We need the new filename (after &quot; -&gt; &quot;) since that&#x27;s what
+886				// exists on disk, and we record the old name so we can look up
+887				// the file&#x27;s commit history.
+888				if (status[0] == &#x27;R&#x27; || status[0] == &#x27;C&#x27;) &amp;&amp; strings.Contains(path, &quot; -&gt; &quot;) {
+889					parts := strings.SplitN(path, &quot; -&gt; &quot;, 2)
+890					oldNameMap[first(must(filepath.Rel(curdir, parts[1])))] = must(filepath.Rel(curdir, parts[0]))
+891					path = parts[1]
+892				}
+893				fileName := first(must(filepath.Rel(curdir, path)))
+894				if status == &quot;!!&quot; {
+895					status = &quot;I&quot;
+896				}
+897				gitStatusMap[fileName] = append(gitStatusMap[fileName], status)
+898			}
+899		}
+900	
+901		for _, file := range files {
+902			if fileStatus, ok := gitStatusMap[file.Name()]; ok {
+903				slices.Sort(fileStatus)
+904				file.status = strings.Join(slices.Compact(fileStatus), &quot;,&quot;)
+905			}
+906			if oldName, ok := oldNameMap[file.Name()]; ok {
+907				file.oldName = oldName
+908			}
+909			if file.Name() == &quot;.git&quot; {
+910				file.status = &quot;*&quot;
+911			}
+912		}
+913	}
+914	
+915	// parseDeletedFiles extracts deleted files from git status output and returns
+916	// them as File structs. Deleted files have status &quot; D&quot; (deleted in worktree)
+917	// or &quot;D &quot; (staged deletion).
+918	func parseDeletedFiles(status []byte, curdir string) []*File {
+919		var deletedFiles []*File
+920		for line := range strings.SplitSeq(string(status), &quot;\n&quot;) {
+921			if len(line) &gt;= 3 {
+922				statusCode := line[:2]
+923				// &quot; D&quot; means deleted in worktree, &quot;D &quot; means staged deletion
+924				if statusCode == &quot; D&quot; || statusCode == &quot;D &quot; {
+925					fileName := first(must(filepath.Rel(curdir, line[3:])))
+926					// Only include files in current directory (not &quot;..&quot; for parent dirs)
+927					if fileName != &quot;..&quot; &amp;&amp; !strings.Contains(fileName, string(os.PathSeparator)) {
+928						deletedFiles = append(deletedFiles, &amp;File{
+929							name:      fileName,
+930							status:    statusCode,
+931							isDeleted: true,
+932						})
+933					}
+934				}
+935			}
+936		}
+937		return deletedFiles
+938	}
+939	
+940	// parseGitLog runs a single git log command and streams the output,
+941	// stopping as soon as all files are found. This is much faster than spawning
+942	// N processes because:
+943	// 1. Single process (no spawn overhead)
+944	// 2. Early exit (stops when all files found)
+945	// 3. Walks history once (all files benefit from git&#x27;s caching)
+946	// 4. Directory scoped (only checks current directory)
+947	func parseGitLog(files []*File) error {
+948		if len(files) == 0 {
+949			return nil
+950		}
+951	
+952		// Build map of files we need to find
+953		filesNeeded := make(map[string]*File)
+954		for _, f := range files {
+955			filesNeeded[f.Name()] = f
+956			// For renamed/copied files, also look for the old name so the
+957			// streaming log can match the file under its previous path.
+958			if f.oldName != &quot;&quot; {
+959				filesNeeded[first(f.oldName)] = f
+960			}
+961		}
+962	
+963		// Start git log with streaming output
+964		// -- .: limit to current directory (faster)
+965		// --relative: make paths relative to current directory
+966		cmd := exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;log&quot;,
+967			&quot;--name-only&quot;,
+968			&quot;--relative&quot;,
+969			&quot;--date=format:%Y-%m-%d&quot;,
+970			&quot;--format=%H%x00%h%x00%ad%x00%aN%x00%aE%x00%s%x00&quot;,
+971			&quot;-n&quot;, HistoryLimit,
+972			&quot;HEAD&quot;, &quot;--&quot;, &quot;.&quot;)
+973	
+974		stdout, err := cmd.StdoutPipe()
+975		if err != nil {
+976			return err
+977		}
+978	
+979		if err := cmd.Start(); err != nil {
+980			return err
+981		}
+982	
+983		scanner := bufio.NewScanner(stdout)
+984		var currentCommit struct {
+985			hash        string
+986			shortHash   string
+987			date        string
+988			author      string
+989			authorEmail string
+990			message     string
+991		}
+992	
+993		// Track lines since last find for early exit. This counts lines of output
+994		// (both commit metadata and filenames), not commits. In active monorepos
+995		// a single root-level file might not appear for 100k+ lines if
+996		// subdirectories see heavy churn.
+997		linesSinceLastFind := 0
+998		const giveUpAfter = 150000
+999	
+1000		for scanner.Scan() {
+1001			linesSinceLastFind++
+1002			line := scanner.Text()
+1003	
+1004			if len(line) == 0 {
+1005				continue // Skip blank lines
+1006			}
+1007	
+1008			// Check if this is a commit metadata line (contains null bytes)
+1009			if strings.Contains(line, &quot;\x00&quot;) {
+1010				parts := strings.Split(line, &quot;\x00&quot;)
+1011				if len(parts) &gt;= 6 {
+1012					currentCommit.hash = parts[0]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-00-39-272Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-00-39-272Z" class="timestamp-link"><time datetime="2026-04-11T02:00:39.272Z" data-timestamp="2026-04-11T02:00:39.272Z">2026-04-11T02:00:39.272Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>The current <code>parseGitLog</code> uses <code>first(filename)</code> to collapse <code>builtin/add.c</code> → <code>builtin</code> for directory-level matching. For <code>--changed-only</code> files, we need to match on the full path. The git log output with <code>--relative</code> already gives paths relative to cwd, so we just need to check both the full path and the <code>first()</code> component.</p>
+<p>Let me update <code>parseGitLog</code> to also check for full-path matches:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-00-39-800Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-00-39-800Z" class="timestamp-link"><time datetime="2026-04-11T02:00:39.800Z" data-timestamp="2026-04-11T02:00:39.800Z">2026-04-11T02:00:39.800Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_012eYwKXWKtdKMJYwwPyMM9N"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 1013,
+  &#34;limit&#34;: 60
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-00-39-805Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-00-39-805Z" class="timestamp-link"><time datetime="2026-04-11T02:00:39.805Z" data-timestamp="2026-04-11T02:00:39.805Z">2026-04-11T02:00:39.805Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>1013					currentCommit.shortHash = parts[1]
+1014					currentCommit.date = parts[2]
+1015					currentCommit.author = parts[3]
+1016					currentCommit.authorEmail = parts[4]
+1017					currentCommit.message = parts[5]
+1018				}
+1019			} else if currentCommit.hash != &quot;&quot; {
+1020				// This is a filename line
+1021				filename := strings.TrimSpace(line)
+1022	
+1023				// Extract the first component (for directories)
+1024				// e.g., &quot;builtin/add.c&quot; -&gt; &quot;builtin&quot;, &quot;main.go&quot; -&gt; &quot;main.go&quot;
+1025				firstPart := first(filename)
+1026	
+1027				// Check if this is a file/dir we&#x27;re looking for
+1028				if file, needed := filesNeeded[firstPart]; needed {
+1029					// Found it! Populate the file info
+1030					file.hash = currentCommit.hash
+1031					file.shortHash = currentCommit.shortHash
+1032					file.lastModified = currentCommit.date
+1033					file.author = currentCommit.author
+1034					file.authorEmail = currentCommit.authorEmail
+1035					file.message = currentCommit.message
+1036	
+1037					// Remove from needed set. For renamed/copied files we
+1038					// may have two keys (old name + new name) pointing to
+1039					// the same File, so delete both.
+1040					delete(filesNeeded, firstPart)
+1041					if file.oldName != &quot;&quot; {
+1042						delete(filesNeeded, first(file.oldName))
+1043						delete(filesNeeded, file.Name())
+1044					}
+1045					linesSinceLastFind = 0 // Reset counter
+1046	
+1047					// If we found all files, we can stop!
+1048					if len(filesNeeded) == 0 {
+1049						// Kill the git process - we&#x27;re done
+1050						_ = cmd.Process.Kill()
+1051						// Drain remaining output to avoid broken pipe errors
+1052						go func() {
+1053							for scanner.Scan() {
+1054							}
+1055						}()
+1056						return nil
+1057					}
+1058				}
+1059	
+1060				// Early exit if we haven&#x27;t found new files in a while
+1061				if linesSinceLastFind &gt; giveUpAfter {
+1062					_ = cmd.Process.Kill()
+1063					go func() {
+1064						for scanner.Scan() {
+1065						}
+1066					}()
+1067					return nil
+1068				}
+1069			}
+1070		}
+1071	
+1072		if err := scanner.Err(); err != nil {</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-00-47-295Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-00-47-295Z" class="timestamp-link"><time datetime="2026-04-11T02:00:47.295Z" data-timestamp="2026-04-11T02:00:47.295Z">2026-04-11T02:00:47.295Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now I need to update the matching. The <code>filesNeeded</code> map is keyed by <code>file.Name()</code>. In the normal case, <code>Name()</code> returns a basename like <code>main.go</code> or directory name like <code>src</code>. In our <code>--changed-only</code> case, <code>Name()</code> returns a full relative path like <code>src/network/server.go</code>.</p>
+<p>The git log output with <code>--relative</code> gives paths like <code>src/network/server.go</code>. Currently <code>first("src/network/server.go")</code> → <code>"src"</code> which matches a directory entry. For our full-path files, we need to match the full filename.</p>
+<p>The simplest approach: check both the full filename AND <code>first(filename)</code> against <code>filesNeeded</code>:</p></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-00-54-463Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-00-54-463Z" class="timestamp-link"><time datetime="2026-04-11T02:00:54.463Z" data-timestamp="2026-04-11T02:00:54.463Z">2026-04-11T02:00:54.463Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/tree-experiment/main.go has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-00-54-440Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-00-54-440Z" class="timestamp-link"><time datetime="2026-04-11T02:00:54.440Z" data-timestamp="2026-04-11T02:00:54.440Z">2026-04-11T02:00:54.440Z</time></a></div><div class="message-content"><div class="file-tool edit-tool" data-tool-id="toolu_01WSGVTyTuFyYXKPuduoEkHW">
+<div class="file-tool-header edit-header"><span class="file-tool-icon">✏️</span> Edit <span class="file-tool-path">main.go</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/tree-experiment/main.go</div>
+<div class="truncatable"><div class="truncatable-content">
+<div class="edit-section edit-old"><div class="edit-label">−</div><pre class="edit-content">		} else if currentCommit.hash != &#34;&#34; {
+			// This is a filename line
+			filename := strings.TrimSpace(line)
+
+			// Extract the first component (for directories)
+			// e.g., &#34;builtin/add.c&#34; -&gt; &#34;builtin&#34;, &#34;main.go&#34; -&gt; &#34;main.go&#34;
+			firstPart := first(filename)
+
+			// Check if this is a file/dir we&#39;re looking for
+			if file, needed := filesNeeded[firstPart]; needed {
+				// Found it! Populate the file info
+				file.hash = currentCommit.hash
+				file.shortHash = currentCommit.shortHash
+				file.lastModified = currentCommit.date
+				file.author = currentCommit.author
+				file.authorEmail = currentCommit.authorEmail
+				file.message = currentCommit.message
+
+				// Remove from needed set. For renamed/copied files we
+				// may have two keys (old name + new name) pointing to
+				// the same File, so delete both.
+				delete(filesNeeded, firstPart)
+				if file.oldName != &#34;&#34; {
+					delete(filesNeeded, first(file.oldName))
+					delete(filesNeeded, file.Name())
+				}
+				linesSinceLastFind = 0 // Reset counter</pre></div>
+<div class="edit-section edit-new"><div class="edit-label">+</div><pre class="edit-content">		} else if currentCommit.hash != &#34;&#34; {
+			// This is a filename line
+			filename := strings.TrimSpace(line)
+
+			// Try to match the full path first (for --changed-only files
+			// with relative paths like &#34;src/network/server.go&#34;), then
+			// fall back to the first component (for directory-level
+			// matching in normal mode, e.g. &#34;builtin/add.c&#34; -&gt; &#34;builtin&#34;)
+			var file *File
+			var matchKey string
+			if f, ok := filesNeeded[filename]; ok {
+				file = f
+				matchKey = filename
+			} else {
+				firstPart := first(filename)
+				if f, ok := filesNeeded[firstPart]; ok {
+					file = f
+					matchKey = firstPart
+				}
+			}
+
+			if file != nil {
+				// Found it! Populate the file info
+				file.hash = currentCommit.hash
+				file.shortHash = currentCommit.shortHash
+				file.lastModified = currentCommit.date
+				file.author = currentCommit.author
+				file.authorEmail = currentCommit.authorEmail
+				file.message = currentCommit.message
+
+				// Remove from needed set. For renamed/copied files we
+				// may have two keys (old name + new name) pointing to
+				// the same File, so delete both.
+				delete(filesNeeded, matchKey)
+				if file.oldName != &#34;&#34; {
+					delete(filesNeeded, first(file.oldName))
+					delete(filesNeeded, file.Name())
+				}
+				linesSinceLastFind = 0 // Reset counter</pre></div>
+</div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-00-59-429Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-00-59-429Z" class="timestamp-link"><time datetime="2026-04-11T02:00:59.429Z" data-timestamp="2026-04-11T02:00:59.429Z">2026-04-11T02:00:59.429Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now update <code>parseDiffStat</code> to also match full paths:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-00-59-840Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-00-59-840Z" class="timestamp-link"><time datetime="2026-04-11T02:00:59.840Z" data-timestamp="2026-04-11T02:00:59.840Z">2026-04-11T02:00:59.840Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01TdAmu1TJU2WQD4qnuQGud7"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 1125,
+  &#34;limit&#34;: 35
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-00-59-846Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-00-59-846Z" class="timestamp-link"><time datetime="2026-04-11T02:00:59.846Z" data-timestamp="2026-04-11T02:00:59.846Z">2026-04-11T02:00:59.846Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>1125		output, err := cmd.Output()
+1126		if err != nil {
+1127			// If HEAD doesn&#x27;t exist (empty repo with no commits), return empty result
+1128			// rather than crashing. Exit code 128 is git&#x27;s &quot;fatal error&quot; code.
+1129			if exitErr, ok := err.(*exec.ExitError); ok &amp;&amp; exitErr.ExitCode() == 128 {
+1130				return []byte{}
+1131			}
+1132			log.Fatalf(&quot;Diffstat error: %v&quot;, err)
+1133		}
+1134		return output
+1135	}
+1136	
+1137	func parseDiffStat(diffStat []byte, files []*File) {
+1138		diffStats := make(map[string][]Diff)
+1139		for line := range strings.SplitSeq(strings.TrimSpace(string(diffStat)), &quot;\n&quot;) {
+1140			parts := strings.Split(line, &quot;\t&quot;)
+1141			if len(parts) &lt; 3 {
+1142				continue
+1143			}
+1144	
+1145			plus := diffInt(parts[0])
+1146			minus := diffInt(parts[1])
+1147			path := first(strings.TrimSpace(parts[2]))
+1148			diffStats[path] = append(diffStats[path], Diff{plus, minus})
+1149		}
+1150	
+1151		for _, file := range files {
+1152			// if the file has any diffs, sum them up. This way we aggregate a
+1153			// directory&#x27;s diffs
+1154			if stats, ok := diffStats[file.Name()]; ok {
+1155				plus := 0
+1156				minus := 0
+1157				for _, stat := range stats {
+1158					plus += stat.plus
+1159					minus += stat.minus</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-01-05-762Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-01-05-762Z" class="timestamp-link"><time datetime="2026-04-11T02:01:05.762Z" data-timestamp="2026-04-11T02:01:05.762Z">2026-04-11T02:01:05.762Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p><code>parseDiffStat</code> uses <code>first()</code> on the path to collapse to directory level. For full-path files, we need to store both the full path and the first component. Let me update it:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-01-10-913Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-01-10-913Z" class="timestamp-link"><time datetime="2026-04-11T02:01:10.913Z" data-timestamp="2026-04-11T02:01:10.913Z">2026-04-11T02:01:10.913Z</time></a></div><div class="message-content"><div class="file-tool edit-tool" data-tool-id="toolu_01WPz49w8nKzu818wEboWvZv">
+<div class="file-tool-header edit-header"><span class="file-tool-icon">✏️</span> Edit <span class="file-tool-path">main.go</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/tree-experiment/main.go</div>
+<div class="truncatable"><div class="truncatable-content">
+<div class="edit-section edit-old"><div class="edit-label">−</div><pre class="edit-content">func parseDiffStat(diffStat []byte, files []*File) {
+	diffStats := make(map[string][]Diff)
+	for line := range strings.SplitSeq(strings.TrimSpace(string(diffStat)), &#34;\n&#34;) {
+		parts := strings.Split(line, &#34;\t&#34;)
+		if len(parts) &lt; 3 {
+			continue
+		}
+
+		plus := diffInt(parts[0])
+		minus := diffInt(parts[1])
+		path := first(strings.TrimSpace(parts[2]))
+		diffStats[path] = append(diffStats[path], Diff{plus, minus})
+	}
+
+	for _, file := range files {
+		// if the file has any diffs, sum them up. This way we aggregate a
+		// directory&#39;s diffs
+		if stats, ok := diffStats[file.Name()]; ok {</pre></div>
+<div class="edit-section edit-new"><div class="edit-label">+</div><pre class="edit-content">func parseDiffStat(diffStat []byte, files []*File) {
+	diffStats := make(map[string][]Diff)
+	for line := range strings.SplitSeq(strings.TrimSpace(string(diffStat)), &#34;\n&#34;) {
+		parts := strings.Split(line, &#34;\t&#34;)
+		if len(parts) &lt; 3 {
+			continue
+		}
+
+		plus := diffInt(parts[0])
+		minus := diffInt(parts[1])
+		fullPath := strings.TrimSpace(parts[2])
+		d := Diff{plus, minus}
+		// Store under both the full relative path (for --changed-only) and
+		// the first component (for directory-level aggregation in normal mode)
+		diffStats[fullPath] = append(diffStats[fullPath], d)
+		if firstPart := first(fullPath); firstPart != fullPath {
+			diffStats[firstPart] = append(diffStats[firstPart], d)
+		}
+	}
+
+	for _, file := range files {
+		// if the file has any diffs, sum them up. This way we aggregate a
+		// directory&#39;s diffs
+		if stats, ok := diffStats[file.Name()]; ok {</pre></div>
+</div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-01-10-923Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-01-10-923Z" class="timestamp-link"><time datetime="2026-04-11T02:01:10.923Z" data-timestamp="2026-04-11T02:01:10.923Z">2026-04-11T02:01:10.923Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/tree-experiment/main.go has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-01-14-371Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-01-14-371Z" class="timestamp-link"><time datetime="2026-04-11T02:01:14.371Z" data-timestamp="2026-04-11T02:01:14.371Z">2026-04-11T02:01:14.371Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now let's build and see if it compiles:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-01-14-949Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-01-14-949Z" class="timestamp-link"><time datetime="2026-04-11T02:01:14.949Z" data-timestamp="2026-04-11T02:01:14.949Z">2026-04-11T02:01:14.949Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01E5SLU9CZCLvaKuiQhYHTbB">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Build the project</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go build ./... 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-01-15-022Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-01-15-022Z" class="timestamp-link"><time datetime="2026-04-11T02:01:15.022Z" data-timestamp="2026-04-11T02:01:15.022Z">2026-04-11T02:01:15.022Z</time></a></div><div class="message-content"><div class="tool-result tool-error"><div class="truncatable"><div class="truncatable-content"><pre>Exit code 1
+open /Users/llimllib/Library/Caches/go-build/1a/1a3e30e317f7ec411027f494e2207c89367e32ab4eb4b77a889244ebe182cdc2-d: operation not permitted
+[rerun: b3]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-01-20-792Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-01-20-792Z" class="timestamp-link"><time datetime="2026-04-11T02:01:20.792Z" data-timestamp="2026-04-11T02:01:20.792Z">2026-04-11T02:01:20.792Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_018cDZzkMmkBU9oCzYFzHyT6">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Build the project</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go build ./... 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-01-21-151Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-01-21-151Z" class="timestamp-link"><time datetime="2026-04-11T02:01:21.151Z" data-timestamp="2026-04-11T02:01:21.151Z">2026-04-11T02:01:21.151Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>[rerun: b4]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-01-28-365Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-01-28-365Z" class="timestamp-link"><time datetime="2026-04-11T02:01:28.365Z" data-timestamp="2026-04-11T02:01:28.365Z">2026-04-11T02:01:28.365Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Compiles cleanly. Now let's run the existing tests:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-01-29-390Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-01-29-390Z" class="timestamp-link"><time datetime="2026-04-11T02:01:29.390Z" data-timestamp="2026-04-11T02:01:29.390Z">2026-04-11T02:01:29.390Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01Gdy15fPqzhUaCS4gCoW9UP">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Run tests</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go test ./... 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-01-30-799Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-01-30-799Z" class="timestamp-link"><time datetime="2026-04-11T02:01:30.799Z" data-timestamp="2026-04-11T02:01:30.799Z">2026-04-11T02:01:30.799Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>ok  	github.com/llimllib/git-ls	1.038s
+[rerun: b5]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-01-36-906Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-01-36-906Z" class="timestamp-link"><time datetime="2026-04-11T02:01:36.906Z" data-timestamp="2026-04-11T02:01:36.906Z">2026-04-11T02:01:36.906Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>All tests pass. Let me try it out on the actual repo to see it in action:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-01-37-280Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-01-37-280Z" class="timestamp-link"><time datetime="2026-04-11T02:01:37.280Z" data-timestamp="2026-04-11T02:01:37.280Z">2026-04-11T02:01:37.280Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01Neypthyq5aF164fiaKNixa">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Check what files are changed</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git diff --name-only HEAD 2&gt;&amp;1 | head -5</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-01-37-389Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-01-37-389Z" class="timestamp-link"><time datetime="2026-04-11T02:01:37.389Z" data-timestamp="2026-04-11T02:01:37.389Z">2026-04-11T02:01:37.389Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>main.go
+[rerun: b6]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-01-41-625Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-01-41-625Z" class="timestamp-link"><time datetime="2026-04-11T02:01:41.625Z" data-timestamp="2026-04-11T02:01:41.625Z">2026-04-11T02:01:41.625Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01BJzG3ojiiUWzJV5xZZXVTM">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Test --changed-only on current repo</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go run . --changed-only 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-01-42-115Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-01-42-115Z" class="timestamp-link"><time datetime="2026-04-11T02:01:42.115Z" data-timestamp="2026-04-11T02:01:42.115Z">2026-04-11T02:01:42.115Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>[31mOn branch tree-experiment[0m
+
+??      ]8;;file://adama/Users/llimllib/code/git-ls/tree-experiment/.claude\.claude]8;;\ [36m[0m                   [33m]8;;https://github.com/llimllib/git-ls/commits?author=\]8;;\[0m          ]8;;https://github.com/llimllib/git-ls/commit/\]8;;\                                   
+ M [32m+++[31m-[0m ]8;;file://adama/Users/llimllib/code/git-ls/tree-experiment/main.go\main.go]8;;\ [38;5;218m]8;;https://github.com/llimllib/git-ls/commit/7197d138c990ae0adab852069063bf183c8b0b63\7197d13]8;;\[0m 2026-04-10 [33m]8;;https://github.com/llimllib/git-ls/commits?author=bill@billmill.org\Bill Mill]8;;\[0m ]8;;https://github.com/llimllib/git-ls/commit/7197d138c990ae0adab852069063bf183c8b0b63\feat: strip ignored files from --ch]8;;\
+[rerun: b7]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-01-48-682Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-01-48-682Z" class="timestamp-link"><time datetime="2026-04-11T02:01:48.682Z" data-timestamp="2026-04-11T02:01:48.682Z">2026-04-11T02:01:48.682Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>It works. But the output only has files in the current directory since we only have changes there. Let me create a test scenario with subdirectory changes:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-01-51-408Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-01-51-408Z" class="timestamp-link"><time datetime="2026-04-11T02:01:51.408Z" data-timestamp="2026-04-11T02:01:51.408Z">2026-04-11T02:01:51.408Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01HYm1qkSpppkrK16sjivuVZ">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Create test repo with subdirectories</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">mkdir -p /tmp/claude/test-tree &amp;&amp; cd /tmp/claude/test-tree &amp;&amp; git init -b main &amp;&amp; git config user.email &#34;test@test.com&#34; &amp;&amp; git config user.name &#34;Test&#34; &amp;&amp; mkdir -p src/network src/trimble &amp;&amp; echo &#34;package main&#34; &gt; main.go &amp;&amp; echo &#34;package network&#34; &gt; src/network/server.go &amp;&amp; echo &#34;package network&#34; &gt; src/network/tork.go &amp;&amp; echo &#34;package trimble&#34; &gt; src/trimble/alpha.go &amp;&amp; echo &#34;# readme&#34; &gt; README.md &amp;&amp; git add . &amp;&amp; git commit -m &#34;initial commit&#34; 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-01-51-526Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-01-51-526Z" class="timestamp-link"><time datetime="2026-04-11T02:01:51.526Z" data-timestamp="2026-04-11T02:01:51.526Z">2026-04-11T02:01:51.526Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Initialized empty Git repository in /private/tmp/claude/test-tree/.git/
+[main (root-commit) c5f36b1] initial commit
+ 5 files changed, 5 insertions(+)
+ create mode 100644 README.md
+ create mode 100644 main.go
+ create mode 100644 src/network/server.go
+ create mode 100644 src/network/tork.go
+ create mode 100644 src/trimble/alpha.go
+Shell cwd was reset to /Users/llimllib/code/git-ls/tree-experiment
+[rerun: b8]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-01-56-635Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-01-56-635Z" class="timestamp-link"><time datetime="2026-04-11T02:01:56.635Z" data-timestamp="2026-04-11T02:01:56.635Z">2026-04-11T02:01:56.635Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01JbHnLGSgyfMvyPQ5XnGF1E">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Modify files in subdirectories</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">cd /tmp/claude/test-tree &amp;&amp; echo &#34;updated readme&#34; &gt; README.md &amp;&amp; echo &#34;package network // modified&#34; &gt; src/network/server.go &amp;&amp; echo &#34;package trimble // modified&#34; &gt; src/trimble/alpha.go &amp;&amp; echo &#34;package network // also modified&#34; &gt; src/network/tork.go 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-01-56-675Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-01-56-675Z" class="timestamp-link"><time datetime="2026-04-11T02:01:56.675Z" data-timestamp="2026-04-11T02:01:56.675Z">2026-04-11T02:01:56.675Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Shell cwd was reset to /Users/llimllib/code/git-ls/tree-experiment
+[rerun: b9]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-02-01-745Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-02-01-745Z" class="timestamp-link"><time datetime="2026-04-11T02:02:01.745Z" data-timestamp="2026-04-11T02:02:01.745Z">2026-04-11T02:02:01.745Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01E8xhDNtE3aUVeVBuCmXCwp">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Test --changed-only with subdirectory changes</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">cd /tmp/claude/test-tree &amp;&amp; /Users/llimllib/code/git-ls/tree-experiment/git-ls --changed-only 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-02-02-093Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-02-02-093Z" class="timestamp-link"><time datetime="2026-04-11T02:02:02.093Z" data-timestamp="2026-04-11T02:02:02.093Z">2026-04-11T02:02:02.093Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>[31mOn branch main[0m
+
+M [32m+[31m-[0m ]8;;file://adama/tmp/claude/test-tree/README.md\README.md]8;;\             [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+M [32m+[31m-[0m ]8;;file://adama/tmp/claude/test-tree/src/network/server.go\src/network/server.go]8;;\ [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+M [32m+[31m-[0m ]8;;file://adama/tmp/claude/test-tree/src/network/tork.go\src/network/tork.go]8;;\   [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+M [32m+[31m-[0m ]8;;file://adama/tmp/claude/test-tree/src/trimble/alpha.go\src/trimble/alpha.go]8;;\  [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+Shell cwd was reset to /Users/llimllib/code/git-ls/tree-experiment
+[rerun: b10]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-02-08-246Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-02-08-246Z" class="timestamp-link"><time datetime="2026-04-11T02:02:08.246Z" data-timestamp="2026-04-11T02:02:08.246Z">2026-04-11T02:02:08.246Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>That's working nicely. Files show their full relative paths with proper column alignment:</p>
+<pre><code>M +- README.md              c5f36b1 2026-04-10 Test initial commit
+M +- src/network/server.go  c5f36b1 2026-04-10 Test initial commit
+M +- src/network/tork.go    c5f36b1 2026-04-10 Test initial commit
+M +- src/trimble/alpha.go   c5f36b1 2026-04-10 Test initial commit
+</code></pre>
+<p>Let me also verify the normal (non <code>--changed-only</code>) mode still works:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-02-08-921Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-02-08-921Z" class="timestamp-link"><time datetime="2026-04-11T02:02:08.921Z" data-timestamp="2026-04-11T02:02:08.921Z">2026-04-11T02:02:08.921Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01FTxzba39m6fPVxH9cYcPJP">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Test normal mode still works</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">cd /tmp/claude/test-tree &amp;&amp; /Users/llimllib/code/git-ls/tree-experiment/git-ls 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-02-08-987Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-02-08-987Z" class="timestamp-link"><time datetime="2026-04-11T02:02:08.987Z" data-timestamp="2026-04-11T02:02:08.987Z">2026-04-11T02:02:08.987Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>[31mOn branch main[0m
+
+ *      [34m]8;;file://adama/tmp/claude/test-tree/.git\.git]8;;\     [0m [36m[0m                   [33m[0m                   
+        ]8;;file://adama/tmp/claude/test-tree/main.go\main.go]8;;\   [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+ M [32m+[31m-[0m   ]8;;file://adama/tmp/claude/test-tree/README.md\README.md]8;;\ [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+ M [32m++[31m--[0m [34m]8;;file://adama/tmp/claude/test-tree/src\src]8;;\      [0m [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+Shell cwd was reset to /Users/llimllib/code/git-ls/tree-experiment
+[rerun: b11]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-02-13-272Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-02-13-272Z" class="timestamp-link"><time datetime="2026-04-11T02:02:13.272Z" data-timestamp="2026-04-11T02:02:13.272Z">2026-04-11T02:02:13.272Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Normal mode still works as before — shows current directory entries with <code>src</code> as a directory. Let me also test edge cases: untracked files and staged additions.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-02-14-358Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-02-14-358Z" class="timestamp-link"><time datetime="2026-04-11T02:02:14.358Z" data-timestamp="2026-04-11T02:02:14.358Z">2026-04-11T02:02:14.358Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01N4WK1cNPKwipxLDePvQ1sN">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Test with untracked and staged files</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">cd /tmp/claude/test-tree &amp;&amp; echo &#34;new file&#34; &gt; src/network/newfile.go &amp;&amp; git add src/trimble/alpha.go &amp;&amp; /Users/llimllib/code/git-ls/tree-experiment/git-ls --changed-only 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-02-14-425Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-02-14-425Z" class="timestamp-link"><time datetime="2026-04-11T02:02:14.425Z" data-timestamp="2026-04-11T02:02:14.425Z">2026-04-11T02:02:14.425Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>[31mOn branch main[0m
+
+ M [32m+[31m-[0m ]8;;file://adama/tmp/claude/test-tree/README.md\README.md]8;;\              [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+??    ]8;;file://adama/tmp/claude/test-tree/src/network/newfile.go\src/network/newfile.go]8;;\ [36m[0m                   [33m[0m                   
+ M [32m+[31m-[0m ]8;;file://adama/tmp/claude/test-tree/src/network/server.go\src/network/server.go]8;;\  [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+ M [32m+[31m-[0m ]8;;file://adama/tmp/claude/test-tree/src/network/tork.go\src/network/tork.go]8;;\    [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+ M [32m+[31m-[0m ]8;;file://adama/tmp/claude/test-tree/src/trimble/alpha.go\src/trimble/alpha.go]8;;\   [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+Shell cwd was reset to /Users/llimllib/code/git-ls/tree-experiment
+[rerun: b12]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-02-19-486Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-02-19-486Z" class="timestamp-link"><time datetime="2026-04-11T02:02:19.486Z" data-timestamp="2026-04-11T02:02:19.486Z">2026-04-11T02:02:19.486Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Works well — untracked file <code>src/network/newfile.go</code> shows up with <code>??</code> status and no git history. Let me also run the tests one more time to make sure everything is solid:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-02-20-029Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-02-20-029Z" class="timestamp-link"><time datetime="2026-04-11T02:02:20.029Z" data-timestamp="2026-04-11T02:02:20.029Z">2026-04-11T02:02:20.029Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01GwVCygoJVchYmJh7e3PAKK">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Run tests verbose</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go test ./... -v 2&gt;&amp;1 | tail -30</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-02-21-100Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-02-21-100Z" class="timestamp-link"><time datetime="2026-04-11T02:02:21.100Z" data-timestamp="2026-04-11T02:02:21.100Z">2026-04-11T02:02:21.100Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>=== RUN   TestWorktreeWithSymlink/real_worktree
+=== RUN   TestWorktreeWithSymlink/symlink_to_worktree
+--- PASS: TestWorktreeWithSymlink (0.13s)
+    --- PASS: TestWorktreeWithSymlink/real_worktree (0.02s)
+    --- PASS: TestWorktreeWithSymlink/symlink_to_worktree (0.01s)
+=== RUN   TestSubdirectoryGitInfo
+--- PASS: TestSubdirectoryGitInfo (0.06s)
+=== RUN   TestEmptyRepository
+    main_test.go:816: Successfully ran gitDiffStat() in empty repository without crashing
+--- PASS: TestEmptyRepository (0.03s)
+=== RUN   TestChangedOnly
+--- PASS: TestChangedOnly (0.00s)
+=== RUN   TestUnmodifiedFileGetsGitInfo
+--- PASS: TestUnmodifiedFileGetsGitInfo (0.07s)
+=== RUN   TestSkipGitLogForIgnoredFiles
+--- PASS: TestSkipGitLogForIgnoredFiles (0.00s)
+=== RUN   TestRenamedFileGitInfo
+--- PASS: TestRenamedFileGitInfo (0.08s)
+=== RUN   TestHeadDescription
+=== RUN   TestHeadDescription/on_branch
+=== RUN   TestHeadDescription/detached_at
+=== RUN   TestHeadDescription/detached_from
+=== RUN   TestHeadDescription/rebase_in_progress
+--- PASS: TestHeadDescription (0.31s)
+    --- PASS: TestHeadDescription/on_branch (0.01s)
+    --- PASS: TestHeadDescription/detached_at (0.04s)
+    --- PASS: TestHeadDescription/detached_from (0.04s)
+    --- PASS: TestHeadDescription/rebase_in_progress (0.02s)
+PASS
+ok  	github.com/llimllib/git-ls	0.890s
+[rerun: b13]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-02-31-587Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-02-31-587Z" class="timestamp-link"><time datetime="2026-04-11T02:02:31.587Z" data-timestamp="2026-04-11T02:02:31.587Z">2026-04-11T02:02:31.587Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>All 15 tests pass. Here's a summary of the changes:</p>
+<p><strong>What changed in <code>main.go</code>:</strong></p>
+<ol>
+<li>
+<p><strong>Reordered the main flow</strong> (lines ~335-370): <code>fetchGitData()</code> and <code>curdir</code> calculation now happen before building the file list, since <code>--changed-only</code> needs the git status data to build files.</p>
+</li>
+<li>
+<p><strong>New function <code>changedFilesFromStatus</code></strong> (after line ~457): When <code>--changed-only</code> is active, builds <code>File</code> structs directly from <code>git status</code> output with full relative paths (e.g. <code>src/network/server.go</code>) instead of reading the current directory. Handles renames, deletes, ignores, and deduplication.</p>
+</li>
+<li>
+<p><strong>Updated <code>parseGitLog</code></strong> (line ~1019): Now tries to match git log filenames against the full relative path first, then falls back to <code>first()</code> for directory-level matching. This lets it find commit history for nested files.</p>
+</li>
+<li>
+<p><strong>Updated <code>parseDiffStat</code></strong> (line ~1137): Stores diff stats under both the full path and the first component, so both <code>--changed-only</code> (full path) and normal mode (directory aggregation) find their data.</p>
+</li>
+</ol></div></div></div>
+<div class="message user" id="msg-2026-04-11T02-05-07-972Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T02-05-07-972Z" class="timestamp-link"><time datetime="2026-04-11T02:05:07.972Z" data-timestamp="2026-04-11T02:05:07.972Z">2026-04-11T02:05:07.972Z</time></a></div><div class="message-content">
+<div class="user-content"><p>I'm having an internal debate on whether it's sensible to include this change in this tool. From one perspective, we're listing files with both regular "git ls" and "git ls -c", but in the second we're listing them by status rather than directory. From another perspective, that ought to be "git stat" or some different command name</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-05-22-700Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-05-22-700Z" class="timestamp-link"><time datetime="2026-04-11T02:05:22.700Z" data-timestamp="2026-04-11T02:05:22.700Z">2026-04-11T02:05:22.700Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>That's a fair tension. I think there's a reasonable argument that it still belongs in <code>git ls</code>:</p>
+<p>The tool's job is "list files with git annotations." <code>--changed-only</code> is already a filter on that list — it just says "only show files that have status." Showing their full paths is a natural consequence of the fact that they're no longer scoped to one directory. You're not changing <em>what</em> the tool does (list files with metadata), just <em>which</em> files and <em>how they're identified</em>.</p>
+<p>On the other hand, I see the <code>git stat</code> argument — once you're showing a flat list of changed files across the whole tree, you're basically in <code>git status</code> territory but with richer annotations. It starts feeling like a different verb.</p>
+<p>A middle-ground framing: <code>git ls</code> lists files in the current directory. <code>git ls -c</code> lists files in the current directory that have changed. The new behavior would be <code>git ls -c</code> lists changed files anywhere under the current directory — which is a subtle but real scope change from "filter the directory listing" to "search the tree for changes."</p>
+<p>I'd lean toward keeping it in <code>git ls</code> because:
+- It's a mode of the same tool, not a standalone workflow
+- Users who already reach for <code>git ls -c</code> would expect this, not a second command
+- Adding a whole new command for what amounts to "show paths instead of basenames" feels heavyweight</p>
+<p>But if it bugs you, you could also frame it as: the default <code>git ls -c</code> stays as-is (current directory), and a new flag like <code>--recursive</code> or <code>-r</code> opts into the tree-wide behavior. That way the scope change is explicit. Though that might be the flag creep you were trying to avoid.</p></div></div></div>
+<div class="message user" id="msg-2026-04-11T02-06-29-329Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T02-06-29-329Z" class="timestamp-link"><time datetime="2026-04-11T02:06:29.329Z" data-timestamp="2026-04-11T02:06:29.329Z">2026-04-11T02:06:29.329Z</time></a></div><div class="message-content">
+<div class="user-content"><p>yeah this is a good point - this PR as it stands would be a behavior change when in a subdirectory. Previously it would have listed the changed files in the current directory or below, but now it would list all changed files from the root</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-06-40-614Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-06-40-614Z" class="timestamp-link"><time datetime="2026-04-11T02:06:40.614Z" data-timestamp="2026-04-11T02:06:40.614Z">2026-04-11T02:06:40.614Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Right, and that's probably not what someone running <code>git ls -c</code> from a subdirectory expects. They're in <code>src/network/</code> and want to see what changed <em>here</em>, not everything across the whole repo.</p>
+<p>The current behavior — list the current directory's entries, filtered to changed ones — is actually correct for subdirectories. The gap is just that when you're at the repo root, changed files in subdirectories get collapsed into directory names like <code>src/</code> instead of showing <code>src/network/server.go</code>.</p>
+<p>So maybe the right behavior for <code>--changed-only</code> is: show changed files <strong>at or below</strong> the current directory, with paths relative to the current directory. That way:</p>
+<ul>
+<li>From the repo root: you see <code>src/network/server.go</code> (the useful new behavior)</li>
+<li>From <code>src/network/</code>: you see <code>server.go</code>, <code>tork.go</code> (same as before, no regression)</li>
+<li>From <code>src/</code>: you see <code>network/server.go</code>, <code>trimble/alpha.go</code></li>
+</ul>
+<p>That's really just making <code>--changed-only</code> recursive from wherever you are, which feels like the natural expectation. Want me to adjust the implementation? The <code>changedFilesFromStatus</code> function already filters out <code>..</code> paths, so it should mostly be right — I just need to verify the path handling is relative to cwd, not the repo root.</p></div></div></div>
+        
+
+<div class="pagination">
+<a href="index.html" class="index-link">Index</a>
+<a href="page-001.html">&larr; Prev</a>
+<a href="page-001.html">1</a>
+<span class="current">2</span>
+<a href="page-003.html">3</a>
+<a href="page-004.html">4</a>
+<a href="page-005.html">5</a>
+<a href="page-003.html">Next &rarr;</a>
+</div>
+
+    </div>
+    <script>
+document.querySelectorAll('time[data-timestamp]').forEach(function(el) {
+    const timestamp = el.getAttribute('data-timestamp');
+    const date = new Date(timestamp);
+    const now = new Date();
+    const isToday = date.toDateString() === now.toDateString();
+    const timeStr = date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+    if (isToday) { el.textContent = timeStr; }
+    else { el.textContent = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' ' + timeStr; }
+});
+document.querySelectorAll('pre.json').forEach(function(el) {
+    let text = el.textContent;
+    text = text.replace(/"([^"]+)":/g, '<span style="color: #ce93d8">"$1"</span>:');
+    text = text.replace(/: "([^"]*)"/g, ': <span style="color: #81d4fa">"$1"</span>');
+    text = text.replace(/: (\d+)/g, ': <span style="color: #ffcc80">$1</span>');
+    text = text.replace(/: (true|false|null)/g, ': <span style="color: #f48fb1">$1</span>');
+    el.innerHTML = text;
+});
+document.querySelectorAll('.truncatable').forEach(function(wrapper) {
+    const content = wrapper.querySelector('.truncatable-content');
+    const btn = wrapper.querySelector('.expand-btn');
+    if (content.scrollHeight > 250) {
+        wrapper.classList.add('truncated');
+        btn.addEventListener('click', function() {
+            if (wrapper.classList.contains('truncated')) { wrapper.classList.remove('truncated'); wrapper.classList.add('expanded'); btn.textContent = 'Show less'; }
+            else { wrapper.classList.remove('expanded'); wrapper.classList.add('truncated'); btn.textContent = 'Show more'; }
+        });
+    }
+});
+</script>
+</body>
+</html>

--- a/transcripts/47-changed-relative-paths.html/page-003.html
+++ b/transcripts/47-changed-relative-paths.html/page-003.html
@@ -1,0 +1,595 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Claude Code transcript - page 3</title>
+    <style>
+:root { --bg-color: #f5f5f5; --card-bg: #ffffff; --user-bg: #e3f2fd; --user-border: #1976d2; --assistant-bg: #f5f5f5; --assistant-border: #9e9e9e; --thinking-bg: #fff8e1; --thinking-border: #ffc107; --thinking-text: #666; --tool-bg: #f3e5f5; --tool-border: #9c27b0; --tool-result-bg: #e8f5e9; --tool-error-bg: #ffebee; --text-color: #212121; --text-muted: #757575; --code-bg: #263238; --code-text: #aed581; }
+* { box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg-color); color: var(--text-color); margin: 0; padding: 16px; line-height: 1.6; }
+.container { max-width: 800px; margin: 0 auto; }
+h1 { font-size: 1.5rem; margin-bottom: 24px; padding-bottom: 8px; border-bottom: 2px solid var(--user-border); }
+.header-row { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; border-bottom: 2px solid var(--user-border); padding-bottom: 8px; margin-bottom: 24px; }
+.header-row h1 { border-bottom: none; padding-bottom: 0; margin-bottom: 0; flex: 1; min-width: 200px; }
+.message { margin-bottom: 16px; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.message.user { background: var(--user-bg); border-left: 4px solid var(--user-border); }
+.message.assistant { background: var(--card-bg); border-left: 4px solid var(--assistant-border); }
+.message.tool-reply { background: #fff8e1; border-left: 4px solid #ff9800; }
+.tool-reply .role-label { color: #e65100; }
+.tool-reply .tool-result { background: transparent; padding: 0; margin: 0; }
+.tool-reply .tool-result .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff8e1); }
+.message-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 16px; background: rgba(0,0,0,0.03); font-size: 0.85rem; }
+.role-label { font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
+.user .role-label { color: var(--user-border); }
+time { color: var(--text-muted); font-size: 0.8rem; }
+.timestamp-link { color: inherit; text-decoration: none; }
+.timestamp-link:hover { text-decoration: underline; }
+.message:target { animation: highlight 2s ease-out; }
+@keyframes highlight { 0% { background-color: rgba(25, 118, 210, 0.2); } 100% { background-color: transparent; } }
+.message-content { padding: 16px; }
+.message-content p { margin: 0 0 12px 0; }
+.message-content p:last-child { margin-bottom: 0; }
+.thinking { background: var(--thinking-bg); border: 1px solid var(--thinking-border); border-radius: 8px; padding: 12px; margin: 12px 0; font-size: 0.9rem; color: var(--thinking-text); }
+.thinking-label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: #f57c00; margin-bottom: 8px; }
+.thinking p { margin: 8px 0; }
+.assistant-text { margin: 8px 0; }
+.tool-use { background: var(--tool-bg); border: 1px solid var(--tool-border); border-radius: 8px; padding: 12px; margin: 12px 0; }
+.tool-header { font-weight: 600; color: var(--tool-border); margin-bottom: 8px; display: flex; align-items: center; gap: 8px; }
+.tool-icon { font-size: 1.1rem; }
+.tool-description { font-size: 0.9rem; color: var(--text-muted); margin-bottom: 8px; font-style: italic; }
+.tool-result { background: var(--tool-result-bg); border-radius: 8px; padding: 12px; margin: 12px 0; }
+.tool-result.tool-error { background: var(--tool-error-bg); }
+.file-tool { border-radius: 8px; padding: 12px; margin: 12px 0; }
+.write-tool { background: linear-gradient(135deg, #e3f2fd 0%, #e8f5e9 100%); border: 1px solid #4caf50; }
+.edit-tool { background: linear-gradient(135deg, #fff3e0 0%, #fce4ec 100%); border: 1px solid #ff9800; }
+.file-tool-header { font-weight: 600; margin-bottom: 4px; display: flex; align-items: center; gap: 8px; font-size: 0.95rem; }
+.write-header { color: #2e7d32; }
+.edit-header { color: #e65100; }
+.file-tool-icon { font-size: 1rem; }
+.file-tool-path { font-family: monospace; background: rgba(0,0,0,0.08); padding: 2px 8px; border-radius: 4px; }
+.file-tool-fullpath { font-family: monospace; font-size: 0.8rem; color: var(--text-muted); margin-bottom: 8px; word-break: break-all; }
+.file-content { margin: 0; }
+.edit-section { display: flex; margin: 4px 0; border-radius: 4px; overflow: hidden; }
+.edit-label { padding: 8px 12px; font-weight: bold; font-family: monospace; display: flex; align-items: flex-start; }
+.edit-old { background: #fce4ec; }
+.edit-old .edit-label { color: #b71c1c; background: #f8bbd9; }
+.edit-old .edit-content { color: #880e4f; }
+.edit-new { background: #e8f5e9; }
+.edit-new .edit-label { color: #1b5e20; background: #a5d6a7; }
+.edit-new .edit-content { color: #1b5e20; }
+.edit-content { margin: 0; flex: 1; background: transparent; font-size: 0.85rem; }
+.edit-replace-all { font-size: 0.75rem; font-weight: normal; color: var(--text-muted); }
+.write-tool .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #e6f4ea); }
+.edit-tool .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff0e5); }
+.todo-list { background: linear-gradient(135deg, #e8f5e9 0%, #f1f8e9 100%); border: 1px solid #81c784; border-radius: 8px; padding: 12px; margin: 12px 0; }
+.todo-header { font-weight: 600; color: #2e7d32; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; font-size: 0.95rem; }
+.todo-items { list-style: none; margin: 0; padding: 0; }
+.todo-item { display: flex; align-items: flex-start; gap: 10px; padding: 6px 0; border-bottom: 1px solid rgba(0,0,0,0.06); font-size: 0.9rem; }
+.todo-item:last-child { border-bottom: none; }
+.todo-icon { flex-shrink: 0; width: 20px; height: 20px; display: flex; align-items: center; justify-content: center; font-weight: bold; border-radius: 50%; }
+.todo-completed .todo-icon { color: #2e7d32; background: rgba(46, 125, 50, 0.15); }
+.todo-completed .todo-content { color: #558b2f; text-decoration: line-through; }
+.todo-in-progress .todo-icon { color: #f57c00; background: rgba(245, 124, 0, 0.15); }
+.todo-in-progress .todo-content { color: #e65100; font-weight: 500; }
+.todo-pending .todo-icon { color: #757575; background: rgba(0,0,0,0.05); }
+.todo-pending .todo-content { color: #616161; }
+pre { background: var(--code-bg); color: var(--code-text); padding: 12px; border-radius: 6px; overflow-x: auto; font-size: 0.85rem; line-height: 1.5; margin: 8px 0; white-space: pre-wrap; word-wrap: break-word; }
+pre.json { color: #e0e0e0; }
+code { background: rgba(0,0,0,0.08); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+pre code { background: none; padding: 0; }
+.user-content { margin: 0; }
+.truncatable { position: relative; }
+.truncatable.truncated .truncatable-content { max-height: 200px; overflow: hidden; }
+.truncatable.truncated::after { content: ''; position: absolute; bottom: 32px; left: 0; right: 0; height: 60px; background: linear-gradient(to bottom, transparent, var(--card-bg)); pointer-events: none; }
+.message.user .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--user-bg)); }
+.message.tool-reply .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff8e1); }
+.tool-use .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--tool-bg)); }
+.tool-result .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--tool-result-bg)); }
+.expand-btn { display: none; width: 100%; padding: 8px 16px; margin-top: 4px; background: rgba(0,0,0,0.05); border: 1px solid rgba(0,0,0,0.1); border-radius: 6px; cursor: pointer; font-size: 0.85rem; color: var(--text-muted); }
+.expand-btn:hover { background: rgba(0,0,0,0.1); }
+.truncatable.truncated .expand-btn, .truncatable.expanded .expand-btn { display: block; }
+.pagination { display: flex; justify-content: center; gap: 8px; margin: 24px 0; flex-wrap: wrap; }
+.pagination a, .pagination span { padding: 5px 10px; border-radius: 6px; text-decoration: none; font-size: 0.85rem; }
+.pagination a { background: var(--card-bg); color: var(--user-border); border: 1px solid var(--user-border); }
+.pagination a:hover { background: var(--user-bg); }
+.pagination .current { background: var(--user-border); color: white; }
+.pagination .disabled { color: var(--text-muted); border: 1px solid #ddd; }
+.pagination .index-link { background: var(--user-border); color: white; }
+details.continuation { margin-bottom: 16px; }
+details.continuation summary { cursor: pointer; padding: 12px 16px; background: var(--user-bg); border-left: 4px solid var(--user-border); border-radius: 12px; font-weight: 500; color: var(--text-muted); }
+details.continuation summary:hover { background: rgba(25, 118, 210, 0.15); }
+details.continuation[open] summary { border-radius: 12px 12px 0 0; margin-bottom: 0; }
+.index-item { margin-bottom: 16px; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); background: var(--user-bg); border-left: 4px solid var(--user-border); }
+.index-item a { display: block; text-decoration: none; color: inherit; }
+.index-item a:hover { background: rgba(25, 118, 210, 0.1); }
+.index-item-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 16px; background: rgba(0,0,0,0.03); font-size: 0.85rem; }
+.index-item-number { font-weight: 600; color: var(--user-border); }
+.index-item-content { padding: 16px; }
+.index-item-stats { padding: 8px 16px 12px 32px; font-size: 0.85rem; color: var(--text-muted); border-top: 1px solid rgba(0,0,0,0.06); }
+.index-item-commit { margin-top: 6px; padding: 4px 8px; background: #fff3e0; border-radius: 4px; font-size: 0.85rem; color: #e65100; }
+.index-item-commit code { background: rgba(0,0,0,0.08); padding: 1px 4px; border-radius: 3px; font-size: 0.8rem; margin-right: 6px; }
+.commit-card { margin: 8px 0; padding: 10px 14px; background: #fff3e0; border-left: 4px solid #ff9800; border-radius: 6px; }
+.commit-card a { text-decoration: none; color: #5d4037; display: block; }
+.commit-card a:hover { color: #e65100; }
+.commit-card-hash { font-family: monospace; color: #e65100; font-weight: 600; margin-right: 8px; }
+.index-commit { margin-bottom: 12px; padding: 10px 16px; background: #fff3e0; border-left: 4px solid #ff9800; border-radius: 8px; box-shadow: 0 1px 2px rgba(0,0,0,0.05); }
+.index-commit a { display: block; text-decoration: none; color: inherit; }
+.index-commit a:hover { background: rgba(255, 152, 0, 0.1); margin: -10px -16px; padding: 10px 16px; border-radius: 8px; }
+.index-commit-header { display: flex; justify-content: space-between; align-items: center; font-size: 0.85rem; margin-bottom: 4px; }
+.index-commit-hash { font-family: monospace; color: #e65100; font-weight: 600; }
+.index-commit-msg { color: #5d4037; }
+.index-item-long-text { margin-top: 8px; padding: 12px; background: var(--card-bg); border-radius: 8px; border-left: 3px solid var(--assistant-border); }
+.index-item-long-text .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--card-bg)); }
+.index-item-long-text-content { color: var(--text-color); }
+#search-box { display: none; align-items: center; gap: 8px; }
+#search-box input { padding: 6px 12px; border: 1px solid var(--assistant-border); border-radius: 6px; font-size: 16px; width: 180px; }
+#search-box button, #modal-search-btn, #modal-close-btn { background: var(--user-border); color: white; border: none; border-radius: 6px; padding: 6px 10px; cursor: pointer; display: flex; align-items: center; justify-content: center; }
+#search-box button:hover, #modal-search-btn:hover { background: #1565c0; }
+#modal-close-btn { background: var(--text-muted); margin-left: 8px; }
+#modal-close-btn:hover { background: #616161; }
+#search-modal[open] { border: none; border-radius: 12px; box-shadow: 0 4px 24px rgba(0,0,0,0.2); padding: 0; width: 90vw; max-width: 900px; height: 80vh; max-height: 80vh; display: flex; flex-direction: column; }
+#search-modal::backdrop { background: rgba(0,0,0,0.5); }
+.search-modal-header { display: flex; align-items: center; gap: 8px; padding: 16px; border-bottom: 1px solid var(--assistant-border); background: var(--bg-color); border-radius: 12px 12px 0 0; }
+.search-modal-header input { flex: 1; padding: 8px 12px; border: 1px solid var(--assistant-border); border-radius: 6px; font-size: 16px; }
+#search-status { padding: 8px 16px; font-size: 0.85rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
+#search-results { flex: 1; overflow-y: auto; padding: 16px; }
+.search-result { margin-bottom: 16px; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.search-result a { display: block; text-decoration: none; color: inherit; }
+.search-result a:hover { background: rgba(25, 118, 210, 0.05); }
+.search-result-page { padding: 6px 12px; background: rgba(0,0,0,0.03); font-size: 0.8rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
+.search-result-content { padding: 12px; }
+.search-result mark { background: #fff59d; padding: 1px 2px; border-radius: 2px; }
+@media (max-width: 600px) { body { padding: 8px; } .message, .index-item { border-radius: 8px; } .message-content, .index-item-content { padding: 12px; } pre { font-size: 0.8rem; padding: 8px; } #search-box input { width: 120px; } #search-modal[open] { width: 95vw; height: 90vh; } }
+</style>
+</head>
+<body>
+    <div class="container">
+        <h1><a href="index.html" style="color: inherit; text-decoration: none;">Claude Code transcript</a> - page 3/5</h1>
+        
+
+<div class="pagination">
+<a href="index.html" class="index-link">Index</a>
+<a href="page-002.html">&larr; Prev</a>
+<a href="page-001.html">1</a>
+<a href="page-002.html">2</a>
+<span class="current">3</span>
+<a href="page-004.html">4</a>
+<a href="page-005.html">5</a>
+<a href="page-004.html">Next &rarr;</a>
+</div>
+
+        
+<div class="message user" id="msg-2026-04-11T02-07-05-425Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T02-07-05-425Z" class="timestamp-link"><time datetime="2026-04-11T02:07:05.425Z" data-timestamp="2026-04-11T02:07:05.425Z">2026-04-11T02:07:05.425Z</time></a></div><div class="message-content">
+<div class="user-content"><p>yes please, I like that</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-07-11-958Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-07-11-958Z" class="timestamp-link"><time datetime="2026-04-11T02:07:11.958Z" data-timestamp="2026-04-11T02:07:11.958Z">2026-04-11T02:07:11.958Z</time></a></div><div class="message-content">
+<div class="thinking"><div class="thinking-label">Thinking</div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-07-11-968Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-07-11-968Z" class="timestamp-link"><time datetime="2026-04-11T02:07:11.968Z" data-timestamp="2026-04-11T02:07:11.968Z">2026-04-11T02:07:11.968Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Let me verify the current path handling first:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-07-12-931Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-07-12-931Z" class="timestamp-link"><time datetime="2026-04-11T02:07:12.931Z" data-timestamp="2026-04-11T02:07:12.931Z">2026-04-11T02:07:12.931Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_011zfp9LoQBezRmWZV68xTqX"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 460,
+  &#34;limit&#34;: 65
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-07-12-949Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-07-12-949Z" class="timestamp-link"><time datetime="2026-04-11T02:07:12.949Z" data-timestamp="2026-04-11T02:07:12.949Z">2026-04-11T02:07:12.949Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>460	// git status output. Unlike the normal flow (which reads the current directory
+461	// and then filters), this produces files with full relative paths so that
+462	// --changed-only can show files from subdirectories.
+463	func changedFilesFromStatus(status []byte, curdir string) []*File {
+464		var files []*File
+465		seen := make(map[string]bool)
+466		for line := range strings.SplitSeq(string(status), &quot;\n&quot;) {
+467			if len(line) &lt; 3 {
+468				continue
+469			}
+470			statusCode := line[:2]
+471			path := line[3:]
+472	
+473			// Skip ignored files
+474			if statusCode == &quot;!!&quot; {
+475				continue
+476			}
+477	
+478			// For renames/copies, use the new name and record the old name
+479			var oldName string
+480			if (statusCode[0] == &#x27;R&#x27; || statusCode[0] == &#x27;C&#x27;) &amp;&amp; strings.Contains(path, &quot; -&gt; &quot;) {
+481				parts := strings.SplitN(path, &quot; -&gt; &quot;, 2)
+482				oldName = must(filepath.Rel(curdir, parts[0]))
+483				path = parts[1]
+484			}
+485	
+486			relPath := must(filepath.Rel(curdir, path))
+487	
+488			// Skip files outside the current directory (would start with &quot;..&quot;)
+489			if strings.HasPrefix(relPath, &quot;..&quot;) {
+490				continue
+491			}
+492	
+493			// Deduplicate (a file can appear in status with different codes)
+494			if seen[relPath] {
+495				continue
+496			}
+497			seen[relPath] = true
+498	
+499			isDeleted := statusCode == &quot; D&quot; || statusCode == &quot;D &quot;
+500			isExe := false
+501			if !isDeleted {
+502				if stat, err := os.Stat(relPath); err == nil {
+503					isExe = !stat.IsDir() &amp;&amp; stat.Mode()&amp;0o111 != 0
+504				}
+505			}
+506	
+507			file := &amp;File{
+508				name:      relPath,
+509				status:    strings.TrimSpace(statusCode),
+510				oldName:   oldName,
+511				isDeleted: isDeleted,
+512				isExe:     isExe,
+513			}
+514			files = append(files, file)
+515		}
+516		return files
+517	}
+518	
+519	func parseFormat(formatStr string) []Column {
+520		validCols := ValidColumns()
+521		colNames := strings.Split(formatStr, &quot;,&quot;)
+522		var columns []Column
+523	
+524		for _, name := range colNames {</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-07-18-856Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-07-18-856Z" class="timestamp-link"><time datetime="2026-04-11T02:07:18.856Z" data-timestamp="2026-04-11T02:07:18.856Z">2026-04-11T02:07:18.856Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>The path handling is already relative to <code>curdir</code> via <code>filepath.Rel(curdir, path)</code>, and it filters out <code>..</code> paths. So from <code>src/network/</code>, a file at <code>src/network/server.go</code> (in git status as repo-root-relative) would become <code>server.go</code>, and a file at <code>src/trimble/alpha.go</code> would become <code>../trimble/alpha.go</code> and get filtered out. That's correct.</p>
+<p>Let me test from a subdirectory to confirm:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-07-20-808Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-07-20-808Z" class="timestamp-link"><time datetime="2026-04-11T02:07:20.808Z" data-timestamp="2026-04-11T02:07:20.808Z">2026-04-11T02:07:20.808Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_012qYZ5G9quiPaJdn6eHqddk">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Reset test repo and modify files</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">cd /tmp/claude/test-tree &amp;&amp; git checkout -- . &amp;&amp; git clean -fd . &amp;&amp; echo &#34;modified&#34; &gt;&gt; README.md &amp;&amp; echo &#34;modified&#34; &gt;&gt; src/network/server.go &amp;&amp; echo &#34;modified&#34; &gt;&gt; src/network/tork.go &amp;&amp; echo &#34;modified&#34; &gt;&gt; src/trimble/alpha.go 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-07-20-871Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-07-20-871Z" class="timestamp-link"><time datetime="2026-04-11T02:07:20.871Z" data-timestamp="2026-04-11T02:07:20.871Z">2026-04-11T02:07:20.871Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Removing src/network/newfile.go
+Shell cwd was reset to /Users/llimllib/code/git-ls/tree-experiment
+[rerun: b14]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-07-26-565Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-07-26-565Z" class="timestamp-link"><time datetime="2026-04-11T02:07:26.565Z" data-timestamp="2026-04-11T02:07:26.565Z">2026-04-11T02:07:26.565Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01A2WsYf5QchXUULTqcMCVQJ">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Test --changed-only from different directory levels</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">cd /tmp/claude/test-tree &amp;&amp; echo &#34;=== From repo root ===&#34; &amp;&amp; /Users/llimllib/code/git-ls/tree-experiment/git-ls --changed-only 2&gt;&amp;1 &amp;&amp; echo &amp;&amp; echo &#34;=== From src/ ===&#34; &amp;&amp; cd src &amp;&amp; /Users/llimllib/code/git-ls/tree-experiment/git-ls --changed-only 2&gt;&amp;1 &amp;&amp; echo &amp;&amp; echo &#34;=== From src/network/ ===&#34; &amp;&amp; cd network &amp;&amp; /Users/llimllib/code/git-ls/tree-experiment/git-ls --changed-only 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-07-26-694Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-07-26-694Z" class="timestamp-link"><time datetime="2026-04-11T02:07:26.694Z" data-timestamp="2026-04-11T02:07:26.694Z">2026-04-11T02:07:26.694Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>=== From repo root ===
+[31mOn branch main[0m
+
+ M [32m+[31m[0m   ]8;;file://adama/tmp/claude/test-tree/README.md\README.md]8;;\             [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+ M [32m+[31m[0m   ]8;;file://adama/tmp/claude/test-tree/src/network/server.go\src/network/server.go]8;;\ [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+ M [32m+[31m[0m   ]8;;file://adama/tmp/claude/test-tree/src/network/tork.go\src/network/tork.go]8;;\   [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+MM [32m++[31m-[0m ]8;;file://adama/tmp/claude/test-tree/src/trimble/alpha.go\src/trimble/alpha.go]8;;\  [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+
+=== From src/ ===
+[31mOn branch main[0m
+
+ M [32m+[31m[0m   ]8;;file://adama/tmp/claude/test-tree/src/network/server.go\network/server.go]8;;\ [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+ M [32m+[31m[0m   ]8;;file://adama/tmp/claude/test-tree/src/network/tork.go\network/tork.go]8;;\   [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+MM [32m++[31m-[0m ]8;;file://adama/tmp/claude/test-tree/src/trimble/alpha.go\trimble/alpha.go]8;;\  [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+
+=== From src/network/ ===
+[31mOn branch main[0m
+
+M [32m+[31m[0m ]8;;file://adama/tmp/claude/test-tree/src/network/server.go\server.go]8;;\ [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+M [32m+[31m[0m ]8;;file://adama/tmp/claude/test-tree/src/network/tork.go\tork.go]8;;\   [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+Shell cwd was reset to /Users/llimllib/code/git-ls/tree-experiment
+[rerun: b15]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-07-33-433Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-07-33-433Z" class="timestamp-link"><time datetime="2026-04-11T02:07:33.433Z" data-timestamp="2026-04-11T02:07:33.433Z">2026-04-11T02:07:33.433Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>It's working exactly as intended:</p>
+<ul>
+<li><strong>From repo root</strong>: <code>README.md</code>, <code>src/network/server.go</code>, <code>src/network/tork.go</code>, <code>src/trimble/alpha.go</code></li>
+<li><strong>From <code>src/</code></strong>: <code>network/server.go</code>, <code>network/tork.go</code>, <code>trimble/alpha.go</code> (no <code>README.md</code> — it's outside)</li>
+<li><strong>From <code>src/network/</code></strong>: <code>server.go</code>, <code>tork.go</code> (just the two files here, basenames only)</li>
+</ul>
+<p>Paths are always relative to wherever you are, and files outside your current directory are excluded. Let me run the tests once more:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-07-34-042Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-07-34-042Z" class="timestamp-link"><time datetime="2026-04-11T02:07:34.042Z" data-timestamp="2026-04-11T02:07:34.042Z">2026-04-11T02:07:34.042Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01QwnVbogm3VY8RkzthzHWeA">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Run tests</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go test ./... 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-07-34-195Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-07-34-195Z" class="timestamp-link"><time datetime="2026-04-11T02:07:34.195Z" data-timestamp="2026-04-11T02:07:34.195Z">2026-04-11T02:07:34.195Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>ok  	github.com/llimllib/git-ls	(cached)
+[rerun: b16]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-07-39-470Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-07-39-470Z" class="timestamp-link"><time datetime="2026-04-11T02:07:39.470Z" data-timestamp="2026-04-11T02:07:39.470Z">2026-04-11T02:07:39.470Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>All good. The implementation already does the right thing — <code>filepath.Rel(curdir, path)</code> makes paths relative to where you are, and the <code>..</code> filter excludes files above you. No changes needed beyond what was already written.</p></div></div></div>
+<div class="message user" id="msg-2026-04-11T02-10-23-814Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T02-10-23-814Z" class="timestamp-link"><time datetime="2026-04-11T02:10:23.814Z" data-timestamp="2026-04-11T02:10:23.814Z">2026-04-11T02:10:23.814Z</time></a></div><div class="message-content">
+<div class="user-content"><p>--nerdfont doesn't work properly with it:</p>
+<p>```</p></div></div></div>
+<div class="message user" id="msg-2026-04-11T02-10-28-255Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T02-10-28-255Z" class="timestamp-link"><time datetime="2026-04-11T02:10:28.255Z" data-timestamp="2026-04-11T02:10:28.255Z">2026-04-11T02:10:28.255Z</time></a></div><div class="message-content">
+<div class="user-content"><p>--nerdfont doesn't work properly with it:</p>
+<pre><code>$ ~/code/git-ls/tree-experiment/git-ls -c --nerdfont
+On branch main
+
+   M +   README.md             c5f36b1 2026-04-10 Test initial commit
+   M +   src/network/server.go c5f36b1 2026-04-10 Test initial commit
+   M +   src/network/tork.go   c5f36b1 2026-04-10 Test initial commit
+   ++- src/trimble/alpha.go  c5f36b1 2026-04-10 Test initial commit
+</code></pre></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-10-33-011Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-10-33-011Z" class="timestamp-link"><time datetime="2026-04-11T02:10:33.011Z" data-timestamp="2026-04-11T02:10:33.011Z">2026-04-11T02:10:33.011Z</time></a></div><div class="message-content">
+<div class="thinking"><div class="thinking-label">Thinking</div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-10-33-552Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-10-33-552Z" class="timestamp-link"><time datetime="2026-04-11T02:10:33.552Z" data-timestamp="2026-04-11T02:10:33.552Z">2026-04-11T02:10:33.552Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Let me look at how nerd font status rendering works.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-10-34-890Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-10-34-890Z" class="timestamp-link"><time datetime="2026-04-11T02:10:34.890Z" data-timestamp="2026-04-11T02:10:34.890Z">2026-04-11T02:10:34.890Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01S4uoRPD9dGHcNsfMp9TFth"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;nerdFont|nerdfont|NerdFont&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/columns.go&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;-n&#34;: true
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-10-34-915Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-10-34-915Z" class="timestamp-link"><time datetime="2026-04-11T02:10:34.915Z" data-timestamp="2026-04-11T02:10:34.915Z">2026-04-11T02:10:34.915Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>20:// See https://www.nerdfonts.com/cheat-sheet for the full icon list.
+25:var nerdFontCharMap = map[byte]string{
+34:// nerdFontSpecialMap handles statuses that don&#x27;t follow the 2-char
+37:var nerdFontSpecialMap = map[string]string{
+50:// statusToNerdFont converts a git status string to a colored Nerd Font icon
+55:func statusToNerdFont(status string) string {
+64:		result.WriteString(statusPartToNerdFont(part))
+69:// statusPartToNerdFont converts a single status code to nerdfont icons.
+72:func statusPartToNerdFont(status string) string {
+74:	if icon, ok := nerdFontSpecialMap[status]; ok {
+81:		idxIcon, hasIdx := nerdFontCharMap[idx]
+82:		wtIcon, hasWt := nerdFontCharMap[wt]
+118:// nerdFontStatusWidth returns the visible width of a nerdfont status string,
+119:// i.e. the number of icon characters that statusToNerdFont will produce.
+120:func nerdFontStatusWidth(status string) int {
+121:	return width(statusToNerdFont(status))
+179:				if rctx.NerdFont {
+180:					w = nerdFontStatusWidth(file.status)
+219:		if rctx.NerdFont {
+220:			statusStr = statusToNerdFont(file.status)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-10-38-675Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-10-38-675Z" class="timestamp-link"><time datetime="2026-04-11T02:10:38.675Z" data-timestamp="2026-04-11T02:10:38.675Z">2026-04-11T02:10:38.675Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_011SbaAfVCnqsDfWxjnNosba"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/columns.go&#34;,
+  &#34;offset&#34;: 20,
+  &#34;limit&#34;: 110
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-10-38-685Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-10-38-685Z" class="timestamp-link"><time datetime="2026-04-11T02:10:38.685Z" data-timestamp="2026-04-11T02:10:38.685Z">2026-04-11T02:10:38.685Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>20	// See https://www.nerdfonts.com/cheat-sheet for the full icon list.
+21	//
+22	// Git&#x27;s porcelain status is two characters: [index][worktree].
+23	// The index (staged) character is colored green, worktree (unstaged) is red,
+24	// matching git&#x27;s own color convention.
+25	var nerdFontCharMap = map[byte]string{
+26		&#x27;M&#x27;: &quot;\uf040&quot;, // nf-fa-pencil (modified)
+27		&#x27;A&#x27;: &quot;\uf471&quot;, // nf-oct-diff_added (added)
+28		&#x27;D&#x27;: &quot;\uf014&quot;, // nf-fa-trash_o (deleted)
+29		&#x27;R&#x27;: &quot;\uf064&quot;, // nf-fa-share (renamed/moved)
+30		&#x27;C&#x27;: &quot;\uf0c5&quot;, // nf-fa-copy (copied)
+31		&#x27;U&#x27;: &quot;\uf0e7&quot;, // nf-fa-bolt (unmerged)
+32	}
+33	
+34	// nerdFontSpecialMap handles statuses that don&#x27;t follow the 2-char
+35	// [index][worktree] pattern, or where the two characters don&#x27;t represent
+36	// separate staged/unstaged states.
+37	var nerdFontSpecialMap = map[string]string{
+38		&quot;I&quot;:  &quot;\uf070&quot;, // nf-fa-eye_slash (ignored)
+39		&quot;*&quot;:  &quot;\ue5fb&quot;, // nf-custom-folder_git (.git directory)
+40		&quot;??&quot;: &quot;\uf128&quot;, // nf-fa-question (untracked — not a staged/unstaged split)
+41		&quot;UU&quot;: &quot;\uf0e7&quot;, // nf-fa-bolt (unmerged, both modified)
+42		&quot;AA&quot;: &quot;\uf0e7&quot;, // nf-fa-bolt (unmerged, both added)
+43		&quot;DD&quot;: &quot;\uf0e7&quot;, // nf-fa-bolt (unmerged, both deleted)
+44		&quot;AU&quot;: &quot;\uf0e7&quot;, // nf-fa-bolt (unmerged, added by us)
+45		&quot;UA&quot;: &quot;\uf0e7&quot;, // nf-fa-bolt (unmerged, added by them)
+46		&quot;DU&quot;: &quot;\uf0e7&quot;, // nf-fa-bolt (unmerged, deleted by us)
+47		&quot;UD&quot;: &quot;\uf0e7&quot;, // nf-fa-bolt (unmerged, deleted by them)
+48	}
+49	
+50	// statusToNerdFont converts a git status string to a colored Nerd Font icon
+51	// string. For 2-character statuses, the index (first) character is shown in
+52	// green and the worktree (second) character in red, preserving the
+53	// staged-vs-unstaged distinction. For compound statuses (comma-separated),
+54	// each part is converted independently.
+55	func statusToNerdFont(status string) string {
+56		if status == &quot;&quot; {
+57			return &quot;&quot;
+58		}
+59	
+60		// Handle compound statuses like &quot;M , D&quot;
+61		parts := strings.Split(status, &quot;,&quot;)
+62		var result strings.Builder
+63		for _, part := range parts {
+64			result.WriteString(statusPartToNerdFont(part))
+65		}
+66		return result.String()
+67	}
+68	
+69	// statusPartToNerdFont converts a single status code to nerdfont icons.
+70	// All returned strings include a trailing space to visually separate the
+71	// status icons from the adjacent diff column.
+72	func statusPartToNerdFont(status string) string {
+73		// Check special statuses first
+74		if icon, ok := nerdFontSpecialMap[status]; ok {
+75			return icon + &quot; &quot;
+76		}
+77	
+78		// Standard 2-char status: [index][worktree]
+79		if len(status) == 2 {
+80			idx, wt := status[0], status[1]
+81			idxIcon, hasIdx := nerdFontCharMap[idx]
+82			wtIcon, hasWt := nerdFontCharMap[wt]
+83	
+84			if hasIdx || hasWt {
+85				var result strings.Builder
+86	
+87				// Index (staged) character — green
+88				if hasIdx {
+89					result.WriteString(GREEN)
+90					result.WriteString(idxIcon)
+91					result.WriteString(RESET)
+92				}
+93	
+94				// Separate icons with a space to prevent terminal
+95				// rendering glitches with adjacent PUA glyphs
+96				if hasIdx &amp;&amp; hasWt {
+97					result.WriteByte(&#x27; &#x27;)
+98				}
+99	
+100				// Worktree (unstaged) character — red
+101				if hasWt {
+102					result.WriteString(RED)
+103					result.WriteString(wtIcon)
+104					result.WriteString(RESET)
+105				}
+106	
+107				// Trailing space to visually separate from the next column
+108				result.WriteByte(&#x27; &#x27;)
+109	
+110				return result.String()
+111			}
+112		}
+113	
+114		// Fallback: return the original text for unknown statuses
+115		return status
+116	}
+117	
+118	// nerdFontStatusWidth returns the visible width of a nerdfont status string,
+119	// i.e. the number of icon characters that statusToNerdFont will produce.
+120	func nerdFontStatusWidth(status string) int {
+121		return width(statusToNerdFont(status))
+122	}
+123	
+124	// Column represents a displayable column
+125	type Column string
+126	
+127	const (
+128		ColStatus        Column = &quot;status&quot;
+129		ColDiff          Column = &quot;diff&quot;</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-10-48-256Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-10-48-256Z" class="timestamp-link"><time datetime="2026-04-11T02:10:48.256Z" data-timestamp="2026-04-11T02:10:48.256Z">2026-04-11T02:10:48.256Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>I see the problem. The issue is with <code>statusCode</code> trimming. In <code>changedFilesFromStatus</code>, I have:</p>
+<pre><code class="language-go">status: strings.TrimSpace(statusCode),
+</code></pre>
+<p>The git status porcelain format for <code>src/trimble/alpha.go</code> is <code>MM</code> (modified in both index and worktree). But <code>statusCode</code> is <code>line[:2]</code> which is <code>"MM"</code> — that's fine. The <code>" M"</code> status has a leading space, and <code>TrimSpace</code> turns <code>" M"</code> into <code>"M"</code>.</p>
+<p>That's the bug — <code>" M"</code> (space + M, meaning unstaged modification) becomes <code>"M"</code> which is not a valid 2-char status code, so the nerd font renderer falls through to the fallback and just prints the raw text. The original <code>fileStatus</code> function stores statuses as-is without trimming.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-10-49-820Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-10-49-820Z" class="timestamp-link"><time datetime="2026-04-11T02:10:49.820Z" data-timestamp="2026-04-11T02:10:49.820Z">2026-04-11T02:10:49.820Z</time></a></div><div class="message-content"><div class="file-tool edit-tool" data-tool-id="toolu_018P8pczoXG5q4Bz8zLw6Wee">
+<div class="file-tool-header edit-header"><span class="file-tool-icon">✏️</span> Edit <span class="file-tool-path">main.go</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/tree-experiment/main.go</div>
+<div class="truncatable"><div class="truncatable-content">
+<div class="edit-section edit-old"><div class="edit-label">−</div><pre class="edit-content">		file := &amp;File{
+			name:      relPath,
+			status:    strings.TrimSpace(statusCode),
+			oldName:   oldName,
+			isDeleted: isDeleted,
+			isExe:     isExe,
+		}</pre></div>
+<div class="edit-section edit-new"><div class="edit-label">+</div><pre class="edit-content">		file := &amp;File{
+			name:      relPath,
+			status:    statusCode,
+			oldName:   oldName,
+			isDeleted: isDeleted,
+			isExe:     isExe,
+		}</pre></div>
+</div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-10-49-833Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-10-49-833Z" class="timestamp-link"><time datetime="2026-04-11T02:10:49.833Z" data-timestamp="2026-04-11T02:10:49.833Z">2026-04-11T02:10:49.833Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/tree-experiment/main.go has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-10-57-655Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-10-57-655Z" class="timestamp-link"><time datetime="2026-04-11T02:10:57.655Z" data-timestamp="2026-04-11T02:10:57.655Z">2026-04-11T02:10:57.655Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now the <code>changedFilesFilter</code> also needs to handle the un-trimmed statuses. Let me check — it filters on <code>file.status != ""</code> and <code>!= "I"</code> and <code>!= "*"</code>. Since <code>changedFilesFromStatus</code> already skips <code>!!</code> (ignored) files, and there's no <code>.git</code> entry in git status output, the filter isn't even called in the <code>--changed-only</code> path anymore. Let me verify:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-10-58-045Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-10-58-045Z" class="timestamp-link"><time datetime="2026-04-11T02:10:58.045Z" data-timestamp="2026-04-11T02:10:58.045Z">2026-04-11T02:10:58.045Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01PJywKEUSskk2yFbTThxyQ2"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 365,
+  &#34;limit&#34;: 10
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-10-58-056Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-10-58-056Z" class="timestamp-link"><time datetime="2026-04-11T02:10:58.056Z" data-timestamp="2026-04-11T02:10:58.056Z">2026-04-11T02:10:58.056Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>365	
+366			fileStatus(gitData.status, files, curdir)
+367	
+368			// Parse deleted files from git status and merge into file list
+369			deletedFiles := parseDeletedFiles(gitData.status, curdir)
+370			files = append(files, deletedFiles...)
+371		}
+372	
+373		// Now run git log on the files we&#x27;ll show
+374		// Skip git log for files that won&#x27;t have history:</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-11-07-649Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-11-07-649Z" class="timestamp-link"><time datetime="2026-04-11T02:11:07.649Z" data-timestamp="2026-04-11T02:11:07.649Z">2026-04-11T02:11:07.649Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Good — <code>changedFilesFilter</code> is not called in the <code>--changed-only</code> branch. But the <code>filesNeedingLog</code> logic below checks for <code>file.status == "I"</code>, <code>"??"</code>, <code>"*"</code>, and empty status. With the un-trimmed 2-char status codes like <code>" M"</code> and <code>"??"</code>, those checks still work. <code>"??"</code> matches exactly, and <code>" M"</code> won't match any of the skip conditions, which is correct.</p>
+<p>But wait — the <code>allNew</code> check looks at <code>status[0]</code>. For <code>" M"</code>, <code>status[0]</code> is a space, not <code>'A'</code>, so <code>allNew</code> would be false — that's correct, <code>" M"</code> has history.</p>
+<p>For <code>"A "</code> (staged addition), <code>status[0]</code> is <code>'A'</code>, so <code>allNew</code> stays true — correct, no history to look up.</p>
+<p>Let me build and test:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-11-08-716Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-11-08-716Z" class="timestamp-link"><time datetime="2026-04-11T02:11:08.716Z" data-timestamp="2026-04-11T02:11:08.716Z">2026-04-11T02:11:08.716Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01RL59Sh4asVYvpGpHXAsdQB">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Build and test nerdfont rendering</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go build ./... 2&gt;&amp;1 &amp;&amp; cd /tmp/claude/test-tree &amp;&amp; /Users/llimllib/code/git-ls/tree-experiment/git-ls -c --nerdfont 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-11-09-297Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-11-09-297Z" class="timestamp-link"><time datetime="2026-04-11T02:11:09.297Z" data-timestamp="2026-04-11T02:11:09.297Z">2026-04-11T02:11:09.297Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>[31mOn branch main[0m
+
+  [31m[0m  [32m+[31m[0m   ]8;;file://adama/tmp/claude/test-tree/README.md\README.md]8;;\             [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+  [31m[0m  [32m+[31m[0m   ]8;;file://adama/tmp/claude/test-tree/src/network/server.go\src/network/server.go]8;;\ [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+  [31m[0m  [32m+[31m[0m   ]8;;file://adama/tmp/claude/test-tree/src/network/tork.go\src/network/tork.go]8;;\   [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+[32m[0m [31m[0m  [32m++[31m-[0m ]8;;file://adama/tmp/claude/test-tree/src/trimble/alpha.go\src/trimble/alpha.go]8;;\  [38;5;36mc5f36b1[0m 2026-04-10 [33mTest[0m initial commit
+Shell cwd was reset to /Users/llimllib/code/git-ls/tree-experiment
+[rerun: b17]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-11-14-047Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-11-14-047Z" class="timestamp-link"><time datetime="2026-04-11T02:11:14.047Z" data-timestamp="2026-04-11T02:11:14.047Z">2026-04-11T02:11:14.047Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>The nerd font icons are rendering now (the escape sequences show the green/red icon codes). The <code>MM</code> file shows two icons and the <code>M</code> files show one. Let me also run the tests:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-11-15-241Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-11-15-241Z" class="timestamp-link"><time datetime="2026-04-11T02:11:15.241Z" data-timestamp="2026-04-11T02:11:15.241Z">2026-04-11T02:11:15.241Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01NPHoemAEQumFsyNW91Pzgj">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Run tests</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go test ./... 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-11-16-472Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-11-16-472Z" class="timestamp-link"><time datetime="2026-04-11T02:11:16.472Z" data-timestamp="2026-04-11T02:11:16.472Z">2026-04-11T02:11:16.472Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>ok  	github.com/llimllib/git-ls	0.915s
+[rerun: b18]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-11-21-001Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-11-21-001Z" class="timestamp-link"><time datetime="2026-04-11T02:11:21.001Z" data-timestamp="2026-04-11T02:11:21.001Z">2026-04-11T02:11:21.001Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>The fix was removing <code>strings.TrimSpace(statusCode)</code> — git's porcelain status codes are exactly 2 characters where the position matters (index vs worktree). <code>" M"</code> means "unstaged modification" and <code>"M "</code> means "staged modification." Trimming destroyed that distinction, so the nerd font renderer couldn't match the 2-char pattern.</p></div></div></div>
+<div class="message user" id="msg-2026-04-11T02-14-55-480Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T02-14-55-480Z" class="timestamp-link"><time datetime="2026-04-11T02:14:55.480Z" data-timestamp="2026-04-11T02:14:55.480Z">2026-04-11T02:14:55.480Z</time></a></div><div class="message-content">
+<div class="user-content"><p>okay, I'm pretty happy with this. No tests fail with this change, which makes me suspect that our tests are not very good</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-15-02-971Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-15-02-971Z" class="timestamp-link"><time datetime="2026-04-11T02:15:02.971Z" data-timestamp="2026-04-11T02:15:02.971Z">2026-04-11T02:15:02.971Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Yeah, there should be a test that exercises the new <code>changedFilesFromStatus</code> path — a real integration test that creates a repo with subdirectory changes and verifies <code>--changed-only</code> shows full relative paths. The unit test for <code>changedFilesFilter</code> still passes because that function is unchanged; it just doesn't get called in the <code>--changed-only</code> path anymore.</p>
+<p>Want me to write a test? I'm thinking something like:</p>
+<ol>
+<li>Create a repo with files in nested directories</li>
+<li>Modify files at different levels</li>
+<li>Run <code>--changed-only</code> from the repo root and verify files show full relative paths</li>
+<li>Run from a subdirectory and verify only files at/below that point appear, with correct relative paths</li>
+</ol></div></div></div>
+<div class="message user" id="msg-2026-04-11T02-16-13-931Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T02-16-13-931Z" class="timestamp-link"><time datetime="2026-04-11T02:16:13.931Z" data-timestamp="2026-04-11T02:16:13.931Z">2026-04-11T02:16:13.931Z</time></a></div><div class="message-content">
+<div class="user-content"><p>I tend to think that with this tool we should be leaning pretty heavily on integration tests. Doesn't the git repo have some sort of test script format that describes setting up a repo, making changes, and then expected output?</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-16-21-617Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-16-21-617Z" class="timestamp-link"><time datetime="2026-04-11T02:16:21.617Z" data-timestamp="2026-04-11T02:16:21.617Z">2026-04-11T02:16:21.617Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01Azjmu3LaJRB2LVhx6z5QWE"><div class="tool-header"><span class="tool-icon">⚙</span> Agent</div><div class="tool-description">Find test script format</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;subagent_type&#34;: &#34;Explore&#34;,
+  &#34;prompt&#34;: &#34;Look at the test infrastructure in /Users/llimllib/code/git-ls/tree-experiment. I&#39;m looking for any kind of test script format — something that describes setting up a git repo, making changes, and then checking expected output. Look at:\n\n1. main_test.go — how do the integration tests work? Is there a pattern of creating repos, running the binary, and checking output?\n2. Any test fixtures, testdata directories, or script files\n3. Any test helper functions that set up repos\n\nReport what you find with file paths and line numbers.&#34;
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-16-48-358Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-16-48-358Z" class="timestamp-link"><time datetime="2026-04-11T02:16:48.358Z" data-timestamp="2026-04-11T02:16:48.358Z">2026-04-11T02:16:48.358Z</time></a></div><div class="message-content"><div class="tool-result tool-error"><div class="truncatable"><div class="truncatable-content"><pre>The user doesn&#x27;t want to proceed with this tool use. The tool use was rejected (eg. if it was a file edit, the new_string was NOT written to the file). STOP what you are doing and wait for the user to tell you how to proceed.
+
+Note: The user&#x27;s next message may contain a correction or preference. Pay close attention — if they explain what went wrong or how they&#x27;d prefer you to work, consider saving that to memory for future sessions.</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+        
+
+<div class="pagination">
+<a href="index.html" class="index-link">Index</a>
+<a href="page-002.html">&larr; Prev</a>
+<a href="page-001.html">1</a>
+<a href="page-002.html">2</a>
+<span class="current">3</span>
+<a href="page-004.html">4</a>
+<a href="page-005.html">5</a>
+<a href="page-004.html">Next &rarr;</a>
+</div>
+
+    </div>
+    <script>
+document.querySelectorAll('time[data-timestamp]').forEach(function(el) {
+    const timestamp = el.getAttribute('data-timestamp');
+    const date = new Date(timestamp);
+    const now = new Date();
+    const isToday = date.toDateString() === now.toDateString();
+    const timeStr = date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+    if (isToday) { el.textContent = timeStr; }
+    else { el.textContent = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' ' + timeStr; }
+});
+document.querySelectorAll('pre.json').forEach(function(el) {
+    let text = el.textContent;
+    text = text.replace(/"([^"]+)":/g, '<span style="color: #ce93d8">"$1"</span>:');
+    text = text.replace(/: "([^"]*)"/g, ': <span style="color: #81d4fa">"$1"</span>');
+    text = text.replace(/: (\d+)/g, ': <span style="color: #ffcc80">$1</span>');
+    text = text.replace(/: (true|false|null)/g, ': <span style="color: #f48fb1">$1</span>');
+    el.innerHTML = text;
+});
+document.querySelectorAll('.truncatable').forEach(function(wrapper) {
+    const content = wrapper.querySelector('.truncatable-content');
+    const btn = wrapper.querySelector('.expand-btn');
+    if (content.scrollHeight > 250) {
+        wrapper.classList.add('truncated');
+        btn.addEventListener('click', function() {
+            if (wrapper.classList.contains('truncated')) { wrapper.classList.remove('truncated'); wrapper.classList.add('expanded'); btn.textContent = 'Show less'; }
+            else { wrapper.classList.remove('expanded'); wrapper.classList.add('truncated'); btn.textContent = 'Show more'; }
+        });
+    }
+});
+</script>
+</body>
+</html>

--- a/transcripts/47-changed-relative-paths.html/page-004.html
+++ b/transcripts/47-changed-relative-paths.html/page-004.html
@@ -1,0 +1,956 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Claude Code transcript - page 4</title>
+    <style>
+:root { --bg-color: #f5f5f5; --card-bg: #ffffff; --user-bg: #e3f2fd; --user-border: #1976d2; --assistant-bg: #f5f5f5; --assistant-border: #9e9e9e; --thinking-bg: #fff8e1; --thinking-border: #ffc107; --thinking-text: #666; --tool-bg: #f3e5f5; --tool-border: #9c27b0; --tool-result-bg: #e8f5e9; --tool-error-bg: #ffebee; --text-color: #212121; --text-muted: #757575; --code-bg: #263238; --code-text: #aed581; }
+* { box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg-color); color: var(--text-color); margin: 0; padding: 16px; line-height: 1.6; }
+.container { max-width: 800px; margin: 0 auto; }
+h1 { font-size: 1.5rem; margin-bottom: 24px; padding-bottom: 8px; border-bottom: 2px solid var(--user-border); }
+.header-row { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; border-bottom: 2px solid var(--user-border); padding-bottom: 8px; margin-bottom: 24px; }
+.header-row h1 { border-bottom: none; padding-bottom: 0; margin-bottom: 0; flex: 1; min-width: 200px; }
+.message { margin-bottom: 16px; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.message.user { background: var(--user-bg); border-left: 4px solid var(--user-border); }
+.message.assistant { background: var(--card-bg); border-left: 4px solid var(--assistant-border); }
+.message.tool-reply { background: #fff8e1; border-left: 4px solid #ff9800; }
+.tool-reply .role-label { color: #e65100; }
+.tool-reply .tool-result { background: transparent; padding: 0; margin: 0; }
+.tool-reply .tool-result .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff8e1); }
+.message-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 16px; background: rgba(0,0,0,0.03); font-size: 0.85rem; }
+.role-label { font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
+.user .role-label { color: var(--user-border); }
+time { color: var(--text-muted); font-size: 0.8rem; }
+.timestamp-link { color: inherit; text-decoration: none; }
+.timestamp-link:hover { text-decoration: underline; }
+.message:target { animation: highlight 2s ease-out; }
+@keyframes highlight { 0% { background-color: rgba(25, 118, 210, 0.2); } 100% { background-color: transparent; } }
+.message-content { padding: 16px; }
+.message-content p { margin: 0 0 12px 0; }
+.message-content p:last-child { margin-bottom: 0; }
+.thinking { background: var(--thinking-bg); border: 1px solid var(--thinking-border); border-radius: 8px; padding: 12px; margin: 12px 0; font-size: 0.9rem; color: var(--thinking-text); }
+.thinking-label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: #f57c00; margin-bottom: 8px; }
+.thinking p { margin: 8px 0; }
+.assistant-text { margin: 8px 0; }
+.tool-use { background: var(--tool-bg); border: 1px solid var(--tool-border); border-radius: 8px; padding: 12px; margin: 12px 0; }
+.tool-header { font-weight: 600; color: var(--tool-border); margin-bottom: 8px; display: flex; align-items: center; gap: 8px; }
+.tool-icon { font-size: 1.1rem; }
+.tool-description { font-size: 0.9rem; color: var(--text-muted); margin-bottom: 8px; font-style: italic; }
+.tool-result { background: var(--tool-result-bg); border-radius: 8px; padding: 12px; margin: 12px 0; }
+.tool-result.tool-error { background: var(--tool-error-bg); }
+.file-tool { border-radius: 8px; padding: 12px; margin: 12px 0; }
+.write-tool { background: linear-gradient(135deg, #e3f2fd 0%, #e8f5e9 100%); border: 1px solid #4caf50; }
+.edit-tool { background: linear-gradient(135deg, #fff3e0 0%, #fce4ec 100%); border: 1px solid #ff9800; }
+.file-tool-header { font-weight: 600; margin-bottom: 4px; display: flex; align-items: center; gap: 8px; font-size: 0.95rem; }
+.write-header { color: #2e7d32; }
+.edit-header { color: #e65100; }
+.file-tool-icon { font-size: 1rem; }
+.file-tool-path { font-family: monospace; background: rgba(0,0,0,0.08); padding: 2px 8px; border-radius: 4px; }
+.file-tool-fullpath { font-family: monospace; font-size: 0.8rem; color: var(--text-muted); margin-bottom: 8px; word-break: break-all; }
+.file-content { margin: 0; }
+.edit-section { display: flex; margin: 4px 0; border-radius: 4px; overflow: hidden; }
+.edit-label { padding: 8px 12px; font-weight: bold; font-family: monospace; display: flex; align-items: flex-start; }
+.edit-old { background: #fce4ec; }
+.edit-old .edit-label { color: #b71c1c; background: #f8bbd9; }
+.edit-old .edit-content { color: #880e4f; }
+.edit-new { background: #e8f5e9; }
+.edit-new .edit-label { color: #1b5e20; background: #a5d6a7; }
+.edit-new .edit-content { color: #1b5e20; }
+.edit-content { margin: 0; flex: 1; background: transparent; font-size: 0.85rem; }
+.edit-replace-all { font-size: 0.75rem; font-weight: normal; color: var(--text-muted); }
+.write-tool .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #e6f4ea); }
+.edit-tool .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff0e5); }
+.todo-list { background: linear-gradient(135deg, #e8f5e9 0%, #f1f8e9 100%); border: 1px solid #81c784; border-radius: 8px; padding: 12px; margin: 12px 0; }
+.todo-header { font-weight: 600; color: #2e7d32; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; font-size: 0.95rem; }
+.todo-items { list-style: none; margin: 0; padding: 0; }
+.todo-item { display: flex; align-items: flex-start; gap: 10px; padding: 6px 0; border-bottom: 1px solid rgba(0,0,0,0.06); font-size: 0.9rem; }
+.todo-item:last-child { border-bottom: none; }
+.todo-icon { flex-shrink: 0; width: 20px; height: 20px; display: flex; align-items: center; justify-content: center; font-weight: bold; border-radius: 50%; }
+.todo-completed .todo-icon { color: #2e7d32; background: rgba(46, 125, 50, 0.15); }
+.todo-completed .todo-content { color: #558b2f; text-decoration: line-through; }
+.todo-in-progress .todo-icon { color: #f57c00; background: rgba(245, 124, 0, 0.15); }
+.todo-in-progress .todo-content { color: #e65100; font-weight: 500; }
+.todo-pending .todo-icon { color: #757575; background: rgba(0,0,0,0.05); }
+.todo-pending .todo-content { color: #616161; }
+pre { background: var(--code-bg); color: var(--code-text); padding: 12px; border-radius: 6px; overflow-x: auto; font-size: 0.85rem; line-height: 1.5; margin: 8px 0; white-space: pre-wrap; word-wrap: break-word; }
+pre.json { color: #e0e0e0; }
+code { background: rgba(0,0,0,0.08); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+pre code { background: none; padding: 0; }
+.user-content { margin: 0; }
+.truncatable { position: relative; }
+.truncatable.truncated .truncatable-content { max-height: 200px; overflow: hidden; }
+.truncatable.truncated::after { content: ''; position: absolute; bottom: 32px; left: 0; right: 0; height: 60px; background: linear-gradient(to bottom, transparent, var(--card-bg)); pointer-events: none; }
+.message.user .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--user-bg)); }
+.message.tool-reply .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff8e1); }
+.tool-use .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--tool-bg)); }
+.tool-result .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--tool-result-bg)); }
+.expand-btn { display: none; width: 100%; padding: 8px 16px; margin-top: 4px; background: rgba(0,0,0,0.05); border: 1px solid rgba(0,0,0,0.1); border-radius: 6px; cursor: pointer; font-size: 0.85rem; color: var(--text-muted); }
+.expand-btn:hover { background: rgba(0,0,0,0.1); }
+.truncatable.truncated .expand-btn, .truncatable.expanded .expand-btn { display: block; }
+.pagination { display: flex; justify-content: center; gap: 8px; margin: 24px 0; flex-wrap: wrap; }
+.pagination a, .pagination span { padding: 5px 10px; border-radius: 6px; text-decoration: none; font-size: 0.85rem; }
+.pagination a { background: var(--card-bg); color: var(--user-border); border: 1px solid var(--user-border); }
+.pagination a:hover { background: var(--user-bg); }
+.pagination .current { background: var(--user-border); color: white; }
+.pagination .disabled { color: var(--text-muted); border: 1px solid #ddd; }
+.pagination .index-link { background: var(--user-border); color: white; }
+details.continuation { margin-bottom: 16px; }
+details.continuation summary { cursor: pointer; padding: 12px 16px; background: var(--user-bg); border-left: 4px solid var(--user-border); border-radius: 12px; font-weight: 500; color: var(--text-muted); }
+details.continuation summary:hover { background: rgba(25, 118, 210, 0.15); }
+details.continuation[open] summary { border-radius: 12px 12px 0 0; margin-bottom: 0; }
+.index-item { margin-bottom: 16px; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); background: var(--user-bg); border-left: 4px solid var(--user-border); }
+.index-item a { display: block; text-decoration: none; color: inherit; }
+.index-item a:hover { background: rgba(25, 118, 210, 0.1); }
+.index-item-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 16px; background: rgba(0,0,0,0.03); font-size: 0.85rem; }
+.index-item-number { font-weight: 600; color: var(--user-border); }
+.index-item-content { padding: 16px; }
+.index-item-stats { padding: 8px 16px 12px 32px; font-size: 0.85rem; color: var(--text-muted); border-top: 1px solid rgba(0,0,0,0.06); }
+.index-item-commit { margin-top: 6px; padding: 4px 8px; background: #fff3e0; border-radius: 4px; font-size: 0.85rem; color: #e65100; }
+.index-item-commit code { background: rgba(0,0,0,0.08); padding: 1px 4px; border-radius: 3px; font-size: 0.8rem; margin-right: 6px; }
+.commit-card { margin: 8px 0; padding: 10px 14px; background: #fff3e0; border-left: 4px solid #ff9800; border-radius: 6px; }
+.commit-card a { text-decoration: none; color: #5d4037; display: block; }
+.commit-card a:hover { color: #e65100; }
+.commit-card-hash { font-family: monospace; color: #e65100; font-weight: 600; margin-right: 8px; }
+.index-commit { margin-bottom: 12px; padding: 10px 16px; background: #fff3e0; border-left: 4px solid #ff9800; border-radius: 8px; box-shadow: 0 1px 2px rgba(0,0,0,0.05); }
+.index-commit a { display: block; text-decoration: none; color: inherit; }
+.index-commit a:hover { background: rgba(255, 152, 0, 0.1); margin: -10px -16px; padding: 10px 16px; border-radius: 8px; }
+.index-commit-header { display: flex; justify-content: space-between; align-items: center; font-size: 0.85rem; margin-bottom: 4px; }
+.index-commit-hash { font-family: monospace; color: #e65100; font-weight: 600; }
+.index-commit-msg { color: #5d4037; }
+.index-item-long-text { margin-top: 8px; padding: 12px; background: var(--card-bg); border-radius: 8px; border-left: 3px solid var(--assistant-border); }
+.index-item-long-text .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--card-bg)); }
+.index-item-long-text-content { color: var(--text-color); }
+#search-box { display: none; align-items: center; gap: 8px; }
+#search-box input { padding: 6px 12px; border: 1px solid var(--assistant-border); border-radius: 6px; font-size: 16px; width: 180px; }
+#search-box button, #modal-search-btn, #modal-close-btn { background: var(--user-border); color: white; border: none; border-radius: 6px; padding: 6px 10px; cursor: pointer; display: flex; align-items: center; justify-content: center; }
+#search-box button:hover, #modal-search-btn:hover { background: #1565c0; }
+#modal-close-btn { background: var(--text-muted); margin-left: 8px; }
+#modal-close-btn:hover { background: #616161; }
+#search-modal[open] { border: none; border-radius: 12px; box-shadow: 0 4px 24px rgba(0,0,0,0.2); padding: 0; width: 90vw; max-width: 900px; height: 80vh; max-height: 80vh; display: flex; flex-direction: column; }
+#search-modal::backdrop { background: rgba(0,0,0,0.5); }
+.search-modal-header { display: flex; align-items: center; gap: 8px; padding: 16px; border-bottom: 1px solid var(--assistant-border); background: var(--bg-color); border-radius: 12px 12px 0 0; }
+.search-modal-header input { flex: 1; padding: 8px 12px; border: 1px solid var(--assistant-border); border-radius: 6px; font-size: 16px; }
+#search-status { padding: 8px 16px; font-size: 0.85rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
+#search-results { flex: 1; overflow-y: auto; padding: 16px; }
+.search-result { margin-bottom: 16px; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.search-result a { display: block; text-decoration: none; color: inherit; }
+.search-result a:hover { background: rgba(25, 118, 210, 0.05); }
+.search-result-page { padding: 6px 12px; background: rgba(0,0,0,0.03); font-size: 0.8rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
+.search-result-content { padding: 12px; }
+.search-result mark { background: #fff59d; padding: 1px 2px; border-radius: 2px; }
+@media (max-width: 600px) { body { padding: 8px; } .message, .index-item { border-radius: 8px; } .message-content, .index-item-content { padding: 12px; } pre { font-size: 0.8rem; padding: 8px; } #search-box input { width: 120px; } #search-modal[open] { width: 95vw; height: 90vh; } }
+</style>
+</head>
+<body>
+    <div class="container">
+        <h1><a href="index.html" style="color: inherit; text-decoration: none;">Claude Code transcript</a> - page 4/5</h1>
+        
+
+<div class="pagination">
+<a href="index.html" class="index-link">Index</a>
+<a href="page-003.html">&larr; Prev</a>
+<a href="page-001.html">1</a>
+<a href="page-002.html">2</a>
+<a href="page-003.html">3</a>
+<span class="current">4</span>
+<a href="page-005.html">5</a>
+<a href="page-005.html">Next &rarr;</a>
+</div>
+
+        
+<div class="message user" id="msg-2026-04-11T02-16-48-359Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T02-16-48-359Z" class="timestamp-link"><time datetime="2026-04-11T02:16:48.359Z" data-timestamp="2026-04-11T02:16:48.359Z">2026-04-11T02:16:48.359Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>[Request interrupted by user for tool use]</p></div></div></div>
+<div class="message user" id="msg-2026-04-11T02-17-08-160Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T02-17-08-160Z" class="timestamp-link"><time datetime="2026-04-11T02:17:08.160Z" data-timestamp="2026-04-11T02:17:08.160Z">2026-04-11T02:17:08.160Z</time></a></div><div class="message-content">
+<div class="user-content"><p>by "the git repo" I meant git/git, the source code for the git command line; not this git repo</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-17-16-647Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-17-16-647Z" class="timestamp-link"><time datetime="2026-04-11T02:17:16.647Z" data-timestamp="2026-04-11T02:17:16.647Z">2026-04-11T02:17:16.647Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Ah, good call. I know git/git uses a test framework based on shell scripts with helper functions like <code>test_expect_success</code>, <code>test_expect_failure</code>, etc. in <code>t/</code> directory. There's also the <code>test_cmp</code> pattern where you write expected output to a file and compare.</p>
+<p>But I'm not sure that's exactly what you're after — are you thinking about adopting something like that for git-ls, or were you thinking of a simpler script-based test format? Something like <a href="https://pkg.go.dev/golang.org/x/tools/txtar">txtar</a> (Go's test archive format used by <code>testscript</code>) might be a closer fit — it lets you describe a sequence of commands and expected outputs in a single file, and there's a Go library for it.</p>
+<p>Want me to look into <code>testscript</code> / <code>txtar</code> as a test harness for this?</p></div></div></div>
+<div class="message user" id="msg-2026-04-11T02-18-21-627Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T02-18-21-627Z" class="timestamp-link"><time datetime="2026-04-11T02:18:21.627Z" data-timestamp="2026-04-11T02:18:21.627Z">2026-04-11T02:18:21.627Z</time></a></div><div class="message-content">
+<div class="user-content"><p>I think some sort of format along that line would be a nice fit; set up a repository and expect output from the CLI, but I don't care that much about the particular format or tools, just that we make a sensible choice that's reasonably easy to read and modify</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-18-27-732Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-18-27-732Z" class="timestamp-link"><time datetime="2026-04-11T02:18:27.732Z" data-timestamp="2026-04-11T02:18:27.732Z">2026-04-11T02:18:27.732Z</time></a></div><div class="message-content">
+<div class="thinking"><div class="thinking-label">Thinking</div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-18-29-173Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-18-29-173Z" class="timestamp-link"><time datetime="2026-04-11T02:18:29.173Z" data-timestamp="2026-04-11T02:18:29.173Z">2026-04-11T02:18:29.173Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Let me look at <code>testscript</code> — it's the standard Go tool for this exact use case (Roger Peppe's package, used by the Go team itself for testing <code>cmd/go</code>).</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-18-34-760Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-18-34-760Z" class="timestamp-link"><time datetime="2026-04-11T02:18:34.760Z" data-timestamp="2026-04-11T02:18:34.760Z">2026-04-11T02:18:34.760Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01TWtjJHzW5gi3u7AnR2m7MJ"><div class="tool-header"><span class="tool-icon">⚙</span> Agent</div><div class="tool-description">Research testscript package</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;subagent_type&#34;: &#34;general-purpose&#34;,
+  &#34;prompt&#34;: &#34;Research the Go `testscript` package for CLI integration testing. I need to understand:\n\n1. Look at https://pkg.go.dev/github.com/rogpeppe/go-testscript/v2 — what&#39;s the basic setup? How do you wire it into `go test`?\n2. What does a `.txtar` test script look like? Show me the format — the command section and the file archive section.\n3. What built-in commands are available (exec, cmp, stdout, stderr, etc.)?\n4. How do you register your own binary so `exec mycommand` works?\n5. Can you filter/match partial output (e.g. just check that certain lines appear, ignoring ANSI codes)?\n\nKeep it concise — I want to evaluate whether this is the right fit for testing a CLI tool that outputs colored terminal text. Report in under 400 words.&#34;
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-18-56-350Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-18-56-350Z" class="timestamp-link"><time datetime="2026-04-11T02:18:56.350Z" data-timestamp="2026-04-11T02:18:56.350Z">2026-04-11T02:18:56.350Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>
+
+Here&#x27;s a concise evaluation of `go-testscript` for CLI integration testing:
+
+**1. Basic Setup**
+
+Wire it into `go test` with a single `TestMain` function:
+
+```go
+func TestMain(m *testing.M) {
+    testscript.RunMain(m, map[string]func() int{
+        &quot;git-ls&quot;: mainFunc, // register your binary
+    })
+}
+
+func TestScript(t *testing.T) {
+    testscript.Run(t, testscript.Params{
+        Dir: &quot;testdata/scripts&quot;, // directory of .txtar files
+    })
+}
+```
+
+**2. `.txtar` Format**
+
+Two sections: commands at the top, then a file archive below:
+
+```
+# This is a comment
+exec git-ls --color=never
+stdout &#x27;expected output&#x27;
+! stderr .
+
+-- somefile.txt --
+contents of somefile.txt
+-- go.mod --
+module example
+```
+
+Commands run sequentially. The `--` delimited sections create files in a temporary working directory before the script runs.
+
+**3. Built-in Commands**
+
+- `exec cmd args...` -- run a command, fail on non-zero exit
+- `! exec cmd args...` -- expect non-zero exit
+- `stdout &#x27;pattern&#x27;` -- match last exec&#x27;s stdout against a regexp
+- `stderr &#x27;pattern&#x27;` -- same for stderr
+- `cmp file1 file2` -- compare file contents
+- `cmpenv file1 file2` -- compare with env var expansion
+- `exists file` -- assert file exists
+- `cp src dst` -- copy files
+- `env KEY=VALUE` -- set environment variables
+- `skip [message]` -- skip test
+- `stop` -- stop script early (success)
+- `grep pattern file` -- grep a file
+
+Prefix any command with `!` to negate (expect failure).
+
+**4. Registering Your Binary**
+
+The `RunMain` map (shown above) registers functions as &quot;binaries&quot; available to `exec`. The function signature is `func() int` (returns exit code). Your binary runs in-process -- no separate compilation needed, which makes tests fast.
+
+**5. Partial/Filtered Output Matching**
+
+`stdout` and `stderr` take Go regexps, so partial matching is natural -- `stdout &#x27;sometext&#x27;` matches if that pattern appears anywhere in the output. For ANSI codes, you have two practical options:
+
+- Pass `--color=never` or set `NO_COLOR=1` / `TERM=dumb` via `env` in the script -- simplest approach.
+- Use regexp patterns that skip ANSI escapes, e.g. `stdout &#x27;\x1b\[.*?mexpected text&#x27;` -- ugly but works.
+- Use `Params.Setup` to add a custom command that strips ANSI before comparing.
+
+**Verdict for your use case:** Good fit. The `env NO_COLOR=1` approach is cleanest for most tests. For tests that specifically validate color output, you can use regexp matching against ANSI sequences or write a small custom `stripansi` command via `Params.Cmds`. The in-process binary execution means tests are fast, and the txtar format keeps each test self-contained.</pre><pre>agentId: ad0fb31b2d484bec4 (use SendMessage with to: &#x27;ad0fb31b2d484bec4&#x27; to continue this agent)
+&lt;usage&gt;total_tokens: 10521
+tool_uses: 0
+duration_ms: 21588&lt;/usage&gt;</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-19-09-537Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-19-09-537Z" class="timestamp-link"><time datetime="2026-04-11T02:19:09.537Z" data-timestamp="2026-04-11T02:19:09.537Z">2026-04-11T02:19:09.537Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p><code>testscript</code> looks like a good fit. Here's what a test would look like:</p>
+<pre><code class="language-txtar"># Test that --changed-only shows full relative paths from repo root
+env NO_COLOR=1
+
+exec git init -b main
+exec git config user.email test@test.com
+exec git config user.name Test
+
+exec mkdir -p src/network src/trimble
+exec cp README.md README.md
+exec cp server.go src/network/server.go
+exec cp alpha.go src/trimble/alpha.go
+
+exec git add .
+exec git commit -m 'initial'
+
+exec cp modified-readme.txt README.md
+exec cp modified-server.go src/network/server.go
+
+exec git-ls --changed-only
+stdout 'README\.md'
+stdout 'src/network/server\.go'
+! stdout 'src/trimble'
+
+-- README.md --
+# readme
+-- modified-readme.txt --
+# updated readme
+-- server.go --
+package network
+-- modified-server.go --
+package network // modified
+-- alpha.go --
+package trimble
+</code></pre>
+<p>The format is easy to read, each test is a self-contained file, and you wire it up with a small <code>TestScript</code> function that registers your binary. <code>stdout</code> takes a regex so you can match partial output and ignore column padding. <code>env NO_COLOR=1</code> would let you skip ANSI codes (though you'd need to add <code>NO_COLOR</code> support to git-ls — it's a common convention).</p>
+<p>The main question is whether your <code>main()</code> calls <code>os.Exit()</code> directly or returns an int. <code>testscript</code> needs a <code>func() int</code> to register as a binary. If <code>main()</code> does <code>log.Fatal</code> / <code>os.Exit</code>, you'd need a small refactor to extract a <code>run() int</code> function.</p>
+<p>Want me to set this up?</p></div></div></div>
+<div class="message user" id="msg-2026-04-11T02-20-48-353Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T02-20-48-353Z" class="timestamp-link"><time datetime="2026-04-11T02:20:48.353Z" data-timestamp="2026-04-11T02:20:48.353Z">2026-04-11T02:20:48.353Z</time></a></div><div class="message-content">
+<div class="user-content"><p>it does a mixture, but ditching the fatalf's would be no great loss, the <code>log</code> package is not a great fit for a CLI anyway</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-20-52-570Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-20-52-570Z" class="timestamp-link"><time datetime="2026-04-11T02:20:52.570Z" data-timestamp="2026-04-11T02:20:52.570Z">2026-04-11T02:20:52.570Z</time></a></div><div class="message-content">
+<div class="thinking"><div class="thinking-label">Thinking</div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-20-53-107Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-20-53-107Z" class="timestamp-link"><time datetime="2026-04-11T02:20:53.107Z" data-timestamp="2026-04-11T02:20:53.107Z">2026-04-11T02:20:53.107Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Let me see all the exit points in the code.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-20-53-877Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-20-53-877Z" class="timestamp-link"><time datetime="2026-04-11T02:20:53.877Z" data-timestamp="2026-04-11T02:20:53.877Z">2026-04-11T02:20:53.877Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_016uCo9VnDYZ8EUF7m87LZ3p"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;log\\.Fatal|os\\.Exit&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;-n&#34;: true
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-20-53-893Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-20-53-893Z" class="timestamp-link"><time datetime="2026-04-11T02:20:53.893Z" data-timestamp="2026-04-11T02:20:53.893Z">2026-04-11T02:20:53.893Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>274:			os.Exit(0)
+278:			os.Exit(0)
+295:					log.Fatalf(&quot;--diffWidth requires an argument&quot;)
+308:					log.Fatalf(&quot;--format requires an argument&quot;)
+329:			log.Fatalf(&quot;Failed to change directory to %s: %v&quot;, dir, err)
+354:			log.Fatalf(&quot;Failed to read directory %s: %v&quot;, dir, err)
+415:		log.Fatalf(&quot;Error: git log streaming failed: %v&quot;, err)
+531:			os.Exit(1)
+705:		log.Fatalf(&quot;Failed to get git status: %v&quot;, err)
+851:		log.Fatalf(&quot;Failed to get git status: %v&quot;, err)
+862:		log.Fatalf(&quot;Failed to get git status: %v&quot;, err)
+1132:		log.Fatalf(&quot;Diffstat error: %v&quot;, err)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-21-00-640Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-21-00-640Z" class="timestamp-link"><time datetime="2026-04-11T02:21:00.640Z" data-timestamp="2026-04-11T02:21:00.640Z">2026-04-11T02:21:00.640Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01GeUsVrhxSqAXcucZ5ZUcfc"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;^func main\\(\\)&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;-n&#34;: true
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-21-00-658Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-21-00-658Z" class="timestamp-link"><time datetime="2026-04-11T02:21:00.658Z" data-timestamp="2026-04-11T02:21:00.658Z">2026-04-11T02:21:00.658Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>263:func main() {</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-21-05-368Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-21-05-368Z" class="timestamp-link"><time datetime="2026-04-11T02:21:05.368Z" data-timestamp="2026-04-11T02:21:05.368Z">2026-04-11T02:21:05.368Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_016TJnHR6DrCoiuVVdXiAAxu"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 263,
+  &#34;limit&#34;: 10
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-21-05-397Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-21-05-397Z" class="timestamp-link"><time datetime="2026-04-11T02:21:05.397Z" data-timestamp="2026-04-11T02:21:05.397Z">2026-04-11T02:21:05.397Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>263	func main() {
+264		argv := os.Args[1:]
+265		diffWidth := 4
+266		monoHash := false
+267		nerdFont := false
+268		changedOnly := false
+269		debug := false
+270		var formatColumns []Column
+271		for len(argv) &gt; 0 {
+272			if argv[0] == &quot;--version&quot; {</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-21-08-963Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-21-08-963Z" class="timestamp-link"><time datetime="2026-04-11T02:21:08.963Z" data-timestamp="2026-04-11T02:21:08.963Z">2026-04-11T02:21:08.963Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Let me also check <code>columns.go</code> for any exits:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-21-09-677Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-21-09-677Z" class="timestamp-link"><time datetime="2026-04-11T02:21:09.677Z" data-timestamp="2026-04-11T02:21:09.677Z">2026-04-11T02:21:09.677Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_018y2zFmvGp9LMXmt9c7inRj"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;log\\.Fatal|os\\.Exit&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/columns.go&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;-n&#34;: true
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-21-09-702Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-21-09-702Z" class="timestamp-link"><time datetime="2026-04-11T02:21:09.702Z" data-timestamp="2026-04-11T02:21:09.702Z">2026-04-11T02:21:09.702Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>No matches found</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-21-15-913Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-21-15-913Z" class="timestamp-link"><time datetime="2026-04-11T02:21:15.913Z" data-timestamp="2026-04-11T02:21:15.913Z">2026-04-11T02:21:15.913Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Good, exits are all in <code>main.go</code>. Let me also check how <code>os.Exit(1)</code> at line 531 is used:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-21-16-476Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-21-16-476Z" class="timestamp-link"><time datetime="2026-04-11T02:21:16.476Z" data-timestamp="2026-04-11T02:21:16.476Z">2026-04-11T02:21:16.476Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01E1hyzTpyNPJgPrTZzQcNbD"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 525,
+  &#34;limit&#34;: 12
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-21-16-492Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-21-16-492Z" class="timestamp-link"><time datetime="2026-04-11T02:21:16.492Z" data-timestamp="2026-04-11T02:21:16.492Z">2026-04-11T02:21:16.492Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>525			name = strings.TrimSpace(name)
+526			if col, ok := validCols[name]; ok {
+527				columns = append(columns, col)
+528			} else {
+529				fmt.Fprintf(os.Stderr, &quot;Error: Invalid column name &#x27;%s&#x27;\n&quot;, name)
+530				fmt.Fprintf(os.Stderr, &quot;Valid columns: status, diff, filename, shorthash, hash, date, author, email, numstat, commitmessage\n&quot;)
+531				os.Exit(1)
+532			}
+533		}
+534	
+535		return columns
+536	}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-21-21-750Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-21-21-750Z" class="timestamp-link"><time datetime="2026-04-11T02:21:21.750Z" data-timestamp="2026-04-11T02:21:21.750Z">2026-04-11T02:21:21.750Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now let me check the helper functions that use <code>log.Fatalf</code>:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-21-22-162Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-21-22-162Z" class="timestamp-link"><time datetime="2026-04-11T02:21:22.162Z" data-timestamp="2026-04-11T02:21:22.162Z">2026-04-11T02:21:22.162Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01ERAPkj2cprcy8Gwju6cMt7"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 695,
+  &#34;limit&#34;: 30
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-21-22-179Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-21-22-179Z" class="timestamp-link"><time datetime="2026-04-11T02:21:22.179Z" data-timestamp="2026-04-11T02:21:22.179Z">2026-04-11T02:21:22.179Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>695		}
+696	}
+697	
+698	func gitRemotes() []byte {
+699		// disable core.fsmonitor because git will run malicious executables
+700		// https://github.com/califio/publications/blob/main/MADBugs/vim-vs-emacs-vs-claude/Emacs.md
+701		// we do this on every `git` call
+702		cmd := exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;remote&quot;, &quot;-v&quot;)
+703		out, err := cmd.Output()
+704		if err != nil {
+705			log.Fatalf(&quot;Failed to get git status: %v&quot;, err)
+706		}
+707		return out
+708	}
+709	
+710	func isGithub(out []byte) string {
+711		githubRe := regexp.MustCompile(`github.com[:/]([\w-_]+)/([\w-_]+)`)
+712		matches := githubRe.FindStringSubmatch(string(out))
+713		if len(matches) == 3 {
+714			return fmt.Sprintf(&quot;https://github.com/%s/%s&quot;, matches[1], matches[2])
+715		}
+716		return &quot;&quot;
+717	}
+718	
+719	// headDescription returns a string describing the current HEAD state,
+720	// matching git-status output: &quot;On branch X&quot;, &quot;HEAD detached at X&quot;,
+721	// &quot;HEAD detached from X&quot;, or rebase-in-progress messages.
+722	// The returned string includes the prefix (e.g. &quot;On branch &quot;).
+723	func headDescription() string {
+724		// Try symbolic-ref first — if it works, we&#x27;re on a branch</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-21-22-803Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-21-22-803Z" class="timestamp-link"><time datetime="2026-04-11T02:21:22.803Z" data-timestamp="2026-04-11T02:21:22.803Z">2026-04-11T02:21:22.803Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01FJRMzESy59bKjj5UTMyaE5"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 845,
+  &#34;limit&#34;: 25
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-21-22-817Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-21-22-817Z" class="timestamp-link"><time datetime="2026-04-11T02:21:22.817Z" data-timestamp="2026-04-11T02:21:22.817Z">2026-04-11T02:21:22.817Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>845	
+846	// gitRoot returns the root directory of the git repository
+847	func gitRoot() string {
+848		cmd := exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;rev-parse&quot;, &quot;--show-toplevel&quot;)
+849		out, err := cmd.Output()
+850		if err != nil {
+851			log.Fatalf(&quot;Failed to get git status: %v&quot;, err)
+852		}
+853		return strings.TrimSpace(string(out))
+854	}
+855	
+856	// gitStatus accepts a dir and a slice of files, and adds the git status to
+857	// each file in place
+858	func gitStatus() []byte {
+859		cmd := exec.Command(&quot;git&quot;, &quot;-c&quot;, &quot;core.fsmonitor=false&quot;, &quot;status&quot;, &quot;--porcelain&quot;, &quot;--ignored&quot;)
+860		out, err := cmd.Output()
+861		if err != nil {
+862			log.Fatalf(&quot;Failed to get git status: %v&quot;, err)
+863		}
+864		return out
+865	}
+866	
+867	func fileStatus(status []byte, files []*File, curdir string) {
+868		gitStatusMap := make(map[string][]string)
+869		// oldNameMap tracks the old (pre-rename) path for renamed/copied files,</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-21-29-940Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-21-29-940Z" class="timestamp-link"><time datetime="2026-04-11T02:21:29.940Z" data-timestamp="2026-04-11T02:21:29.940Z">2026-04-11T02:21:29.940Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now let me also check if there's a <code>NO_COLOR</code> or similar env check already:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-21-31-567Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-21-31-567Z" class="timestamp-link"><time datetime="2026-04-11T02:21:31.567Z" data-timestamp="2026-04-11T02:21:31.567Z">2026-04-11T02:21:31.567Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_011vZ2B7BFvhm8qCyHZ8C3KN"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;NO_COLOR|TERM|isatty|IsTerm&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;-n&#34;: true
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-21-31-593Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-21-31-593Z" class="timestamp-link"><time datetime="2026-04-11T02:21:31.593Z" data-timestamp="2026-04-11T02:21:31.593Z">2026-04-11T02:21:31.593Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>No matches found</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-21-37-433Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-21-37-433Z" class="timestamp-link"><time datetime="2026-04-11T02:21:37.433Z" data-timestamp="2026-04-11T02:21:37.433Z">2026-04-11T02:21:37.433Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_016ZryAGraFri5EQj33WPPCF"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;RESET|BLUE|RED|GREEN&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;-n&#34;: true,
+  &#34;head_limit&#34;: 10
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-21-37-448Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-21-37-448Z" class="timestamp-link"><time datetime="2026-04-11T02:21:37.448Z" data-timestamp="2026-04-11T02:21:37.448Z">2026-04-11T02:21:37.448Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>70:	BLUE      = &quot;\x1b[34m&quot;
+72:	GREEN     = &quot;\x1b[32m&quot;
+73:	RED       = &quot;\x1b[31m&quot;
+74:	RESET     = &quot;\x1b[0m&quot;
+438:	fmt.Printf(&quot;%s%s%s\n\n&quot;, RED, gitData.currentBranch, RESET)
+552:		issueText := fmt.Sprintf(&quot;%s%s%s&quot;, BLUE, commitMsg[issueIx[0]:issueIx[1]], RESET)
+645:			GREEN,
+647:			RED,
+649:			RESET)
+652:		GREEN,
+
+[Showing results with pagination = limit: 10]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-21-41-607Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-21-41-607Z" class="timestamp-link"><time datetime="2026-04-11T02:21:41.607Z" data-timestamp="2026-04-11T02:21:41.607Z">2026-04-11T02:21:41.607Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>OK — the color constants are hardcoded. Let me check how the existing tests handle color output:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-21-42-742Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-21-42-742Z" class="timestamp-link"><time datetime="2026-04-11T02:21:42.742Z" data-timestamp="2026-04-11T02:21:42.742Z">2026-04-11T02:21:42.742Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01E1r3u4P5NzD5Uoux4t7Emz"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;ANSI|ansi|color|stripColor|\\\\x1b&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main_test.go&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;-n&#34;: true
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-21-42-760Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-21-42-760Z" class="timestamp-link"><time datetime="2026-04-11T02:21:42.760Z" data-timestamp="2026-04-11T02:21:42.760Z">2026-04-11T02:21:42.760Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>397:			name: &quot;same hash returns same color&quot;,
+408:			color := hashToColor(tt.hash)
+412:				if color != CYAN {
+413:					t.Errorf(&quot;hashToColor(\&quot;\&quot;) = %q, expected CYAN (%q)&quot;, color, CYAN)
+418:			// Non-empty hash should return a valid 8-bit color code
+419:			if !strings.HasPrefix(color, &quot;\x1b[38;5;&quot;) || !strings.HasSuffix(color, &quot;m&quot;) {
+420:				t.Errorf(&quot;hashToColor(%q) = %q, expected 8-bit color format&quot;, tt.hash, color)
+423:			// Same hash should always return same color
+424:			color2 := hashToColor(tt.hash)
+425:			if color != color2 {
+426:				t.Errorf(&quot;hashToColor not deterministic: first call=%q, second call=%q&quot;, color, color2)
+431:	// Test that different hashes (likely) produce different colors
+434:	color1 := hashToColor(hash1)
+435:	color2 := hashToColor(hash2)
+436:	if color1 == color2 {
+437:		t.Errorf(&quot;Different hashes produced same color: %q and %q both got %q&quot;, hash1, hash2, color1)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-21-49-411Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-21-49-411Z" class="timestamp-link"><time datetime="2026-04-11T02:21:49.411Z" data-timestamp="2026-04-11T02:21:49.411Z">2026-04-11T02:21:49.411Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>OK, the tests don't deal with stripping ANSI. Here's my plan:</p>
+<ol>
+<li>Refactor <code>main()</code> → extract a <code>run(args []string, stdout, stderr io.Writer) int</code> function</li>
+<li>Add <code>NO_COLOR</code> support (it's a widely-adopted convention, useful beyond testing)</li>
+<li>Add <code>testscript</code> dependency and wire it up</li>
+<li>Write integration tests for the <code>--changed-only</code> behavior</li>
+</ol>
+<p>Let me do this in steps. First, the <code>run()</code> refactor and <code>NO_COLOR</code>:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-21-50-130Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-21-50-130Z" class="timestamp-link"><time datetime="2026-04-11T02:21:50.130Z" data-timestamp="2026-04-11T02:21:50.130Z">2026-04-11T02:21:50.130Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01XGceXCaQVGmgbn5uk5SGWA"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 263,
+  &#34;limit&#34;: 180
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-21-50-151Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-21-50-151Z" class="timestamp-link"><time datetime="2026-04-11T02:21:50.151Z" data-timestamp="2026-04-11T02:21:50.151Z">2026-04-11T02:21:50.151Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>263	func main() {
+264		argv := os.Args[1:]
+265		diffWidth := 4
+266		monoHash := false
+267		nerdFont := false
+268		changedOnly := false
+269		debug := false
+270		var formatColumns []Column
+271		for len(argv) &gt; 0 {
+272			if argv[0] == &quot;--version&quot; {
+273				printVersion()
+274				os.Exit(0)
+275			}
+276			if argv[0] == &quot;--help&quot; || argv[0] == &quot;-h&quot; {
+277				usage()
+278				os.Exit(0)
+279			}
+280			if argv[0] == &quot;--mono-hash&quot; {
+281				monoHash = true
+282				argv = argv[1:]
+283			} else if argv[0] == &quot;--nerdfont&quot; {
+284				nerdFont = true
+285				argv = argv[1:]
+286			} else if argv[0] == &quot;--changed-only&quot; || argv[0] == &quot;-c&quot; {
+287				changedOnly = true
+288				argv = argv[1:]
+289			} else if strings.HasPrefix(argv[0], &quot;--diffWidth&quot;) {
+290				if len(argv) == 1 {
+291					if strings.Contains(argv[0], &quot;=&quot;) {
+292						parts := strings.SplitN(argv[0], &quot;=&quot;, 2)
+293						diffWidth = must(strconv.Atoi(parts[1]))
+294					} else {
+295						log.Fatalf(&quot;--diffWidth requires an argument&quot;)
+296					}
+297					argv = argv[1:]
+298				} else {
+299					diffWidth = must(strconv.Atoi(argv[1]))
+300					argv = argv[2:]
+301				}
+302			} else if strings.HasPrefix(argv[0], &quot;--format&quot;) {
+303				if len(argv) == 1 {
+304					if strings.Contains(argv[0], &quot;=&quot;) {
+305						parts := strings.SplitN(argv[0], &quot;=&quot;, 2)
+306						formatColumns = parseFormat(parts[1])
+307					} else {
+308						log.Fatalf(&quot;--format requires an argument&quot;)
+309					}
+310					argv = argv[1:]
+311				} else {
+312					formatColumns = parseFormat(argv[1])
+313					argv = argv[2:]
+314				}
+315			} else if strings.HasPrefix(argv[0], &quot;--debug&quot;) {
+316				debug = true
+317				argv = argv[1:]
+318			} else {
+319				// Non-flag argument (directory), stop parsing flags
+320				break
+321			}
+322		}
+323	
+324		var dir string
+325		if len(argv) &gt; 0 {
+326			dir = argv[0]
+327	
+328			if err := os.Chdir(dir); err != nil {
+329				log.Fatalf(&quot;Failed to change directory to %s: %v&quot;, dir, err)
+330			}
+331		} else {
+332			dir = &quot;.&quot;
+333		}
+334	
+335		// Fetch all git data in parallel
+336		gitData := fetchGitData()
+337	
+338		// Resolve symlinks to match git&#x27;s perspective. Git internally resolves
+339		// symlinks when working with worktrees, so we need to do the same to
+340		// ensure filepath.Rel() works correctly in fileStatus().
+341		// https://github.com/llimllib/git-ls/issues/34
+342		resolved := must(filepath.EvalSymlinks(must(filepath.Abs(&quot;.&quot;))))
+343		curdir := must(filepath.Rel(gitData.root, resolved))
+344	
+345		var files []*File
+346		if changedOnly {
+347			// In --changed-only mode, build the file list directly from git
+348			// status so we can show files from subdirectories with their full
+349			// relative paths (e.g. &quot;src/network/server.go&quot; not just &quot;src/&quot;)
+350			files = changedFilesFromStatus(gitData.status, curdir)
+351		} else {
+352			osfiles, err := os.ReadDir(&quot;.&quot;)
+353			if err != nil {
+354				log.Fatalf(&quot;Failed to read directory %s: %v&quot;, dir, err)
+355			}
+356	
+357			for _, file := range osfiles {
+358				stat, _ := os.Stat(file.Name())
+359				files = append(files, &amp;File{
+360					entry: file,
+361					isDir: file.IsDir(),
+362					isExe: !file.IsDir() &amp;&amp; stat.Mode()&amp;0o111 != 0,
+363				})
+364			}
+365	
+366			fileStatus(gitData.status, files, curdir)
+367	
+368			// Parse deleted files from git status and merge into file list
+369			deletedFiles := parseDeletedFiles(gitData.status, curdir)
+370			files = append(files, deletedFiles...)
+371		}
+372	
+373		// Now run git log on the files we&#x27;ll show
+374		// Skip git log for files that won&#x27;t have history:
+375		// - I: Ignored files - not tracked by git
+376		// - ??: Untracked files - not in git yet
+377		// - *: .git directory - git metadata, not file history
+378		// - A: Newly added files
+379		//   Examples: &quot;A &quot;, &quot;AM&quot;, &quot;AD&quot; - staged additions not yet committed
+380		//   But &quot;M &quot;, &quot;MM&quot;, or mixed dirs like &quot;A ,M &quot; have history
+381		var filesNeedingLog []*File
+382		for _, file := range files {
+383			if file.status == &quot;I&quot; || file.status == &quot;??&quot; || file.status == &quot;*&quot; {
+384				continue
+385			}
+386			// Empty status means unmodified tracked file — it has history
+387			if file.status == &quot;&quot; {
+388				filesNeedingLog = append(filesNeedingLog, file)
+389				continue
+390			}
+391			// Check if ALL statuses in a comma-separated list are new additions
+392			// For directories, status might be &quot;A ,M &quot; if it has both new and modified files
+393			allNew := true
+394			for status := range strings.SplitSeq(file.status, &quot;,&quot;) {
+395				status = strings.TrimSpace(status)
+396				// Check if this individual status represents a file with history
+397				// If first char (index) is not &#x27;A&#x27; and not untracked, it has history
+398				if len(status) &gt; 0 &amp;&amp; status[0] != &#x27;A&#x27; &amp;&amp; status != &quot;??&quot; {
+399					allNew = false
+400					break
+401				}
+402			}
+403			if !allNew {
+404				filesNeedingLog = append(filesNeedingLog, file)
+405			}
+406		}
+407	
+408		if debug {
+409			for _, file := range filesNeedingLog {
+410				log.Printf(&quot;%s,&quot;, file.Name())
+411			}
+412			fmt.Printf(&quot;\n&quot;)
+413		}
+414		if err := parseGitLog(filesNeedingLog); err != nil {
+415			log.Fatalf(&quot;Error: git log streaming failed: %v&quot;, err)
+416		}
+417		parseDiffStat(gitData.diffStat, files)
+418	
+419		// generate a diffStat graph for every file
+420		for _, file := range files {
+421			file.diffStat = makeDiffGraph(file, diffWidth)
+422		}
+423	
+424		// Sort files by name
+425		slices.SortFunc(files, func(a, b *File) int {
+426			return strings.Compare(strings.ToLower(a.Name()), strings.ToLower(b.Name()))
+427		})
+428	
+429		// Use default columns if not specified
+430		if len(formatColumns) == 0 {
+431			formatColumns = AllColumns()
+432		}
+433	
+434		maxWidth := columns(os.Stdout.Fd())
+435		if maxWidth == 0 {
+436			maxWidth = 80 // default when not a TTY
+437		}
+438		fmt.Printf(&quot;%s%s%s\n\n&quot;, RED, gitData.currentBranch, RESET)
+439		rctx := &amp;RenderContext{
+440			GithubURL: isGithub(gitData.remotes),
+441			Dir:       must(filepath.Abs(&quot;.&quot;)),
+442			MonoHash:  monoHash,</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-21-56-470Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-21-56-470Z" class="timestamp-link"><time datetime="2026-04-11T02:21:56.470Z" data-timestamp="2026-04-11T02:21:56.470Z">2026-04-11T02:21:56.470Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>OK, this is a substantial refactor. Let me do it in pieces:</p>
+<ol>
+<li>Add <code>NO_COLOR</code> support</li>
+<li>Extract <code>run()</code> from <code>main()</code></li>
+<li>Convert <code>log.Fatalf</code> → <code>fmt.Fprintf(stderr)</code> + return</li>
+<li>Add <code>testscript</code> and write tests</li>
+</ol>
+<p>Let me start with <code>NO_COLOR</code>. The convention (https://no-color.org) is: if <code>NO_COLOR</code> env var is set (to anything), disable colors.</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-21-56-875Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-21-56-875Z" class="timestamp-link"><time datetime="2026-04-11T02:21:56.875Z" data-timestamp="2026-04-11T02:21:56.875Z">2026-04-11T02:21:56.875Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01ArNmG14SwPfnADJs1aguWA"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 69,
+  &#34;limit&#34;: 30
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-21-56-900Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-21-56-900Z" class="timestamp-link"><time datetime="2026-04-11T02:21:56.900Z" data-timestamp="2026-04-11T02:21:56.900Z">2026-04-11T02:21:56.900Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>69	const (
+70		BLUE      = &quot;\x1b[34m&quot;
+71		CYAN      = &quot;\x1b[36m&quot;
+72		GREEN     = &quot;\x1b[32m&quot;
+73		RED       = &quot;\x1b[31m&quot;
+74		RESET     = &quot;\x1b[0m&quot;
+75		YELLOW    = &quot;\x1b[33m&quot;
+76		STRIKEOUT = &quot;\x1b[9m&quot;
+77	)
+78	
+79	// validHashColors contains pre-computed 8-bit terminal color codes
+80	// from the 6x6x6 RGB cube (16-231), excluding colors that are too dark,
+81	// too light, or too gray.
+82	var validHashColors = []int{
+83		18, 19, 20, 21, 24, 25, 26, 27, 28, 29,
+84		30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+85		40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+86		50, 51, 54, 55, 56, 57, 61, 62, 63, 64,
+87		67, 68, 69, 70, 71, 72, 73, 74, 75, 76,
+88		77, 78, 79, 80, 81, 82, 83, 84, 85, 86,
+89		87, 88, 89, 90, 91, 92, 93, 94, 97, 98,
+90		99, 100, 104, 105, 106, 107, 110, 111, 112, 113,
+91		114, 115, 116, 117, 118, 119, 120, 121, 122, 123,
+92		124, 125, 126, 127, 128, 129, 130, 131, 132, 133,
+93		134, 135, 136, 137, 140, 141, 142, 143, 147, 148,
+94		149, 150, 153, 154, 155, 156, 157, 158, 159, 160,
+95		161, 162, 163, 164, 165, 166, 167, 168, 169, 170,
+96		171, 172, 173, 174, 175, 176, 177, 178, 179, 180,
+97		183, 184, 185, 186, 190, 191, 192, 193, 196, 197,
+98		198, 199, 200, 201, 202, 203, 204, 205, 206, 207,</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-22-01-229Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-22-01-229Z" class="timestamp-link"><time datetime="2026-04-11T02:22:01.229Z" data-timestamp="2026-04-11T02:22:01.229Z">2026-04-11T02:22:01.229Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>The colors are constants, which means they can't be conditionally disabled. I need to make them variables that get set based on <code>NO_COLOR</code>. Let me also check where they're used in <code>columns.go</code>:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-22-01-815Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-22-01-815Z" class="timestamp-link"><time datetime="2026-04-11T02:22:01.815Z" data-timestamp="2026-04-11T02:22:01.815Z">2026-04-11T02:22:01.815Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01WABx57w2A5NXBzZ4zHzgbM"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;BLUE|CYAN|GREEN|RED|RESET|YELLOW|STRIKEOUT&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/columns.go&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;-n&#34;: true
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-22-01-824Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-22-01-824Z" class="timestamp-link"><time datetime="2026-04-11T02:22:01.824Z" data-timestamp="2026-04-11T02:22:01.824Z">2026-04-11T02:22:01.824Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>89:				result.WriteString(GREEN)
+91:				result.WriteString(RESET)
+102:				result.WriteString(RED)
+104:				result.WriteString(RESET)
+246:		must(fmt.Fprintf(out, &quot;%s%s&quot;, RED, STRIKEOUT))
+248:		must(fmt.Fprintf(out, &quot;%s&quot;, BLUE))
+250:		must(fmt.Fprintf(out, &quot;%s&quot;, GREEN))
+268:		must(fmt.Fprintf(out, &quot;%s&quot;, RESET))
+279:			color = CYAN
+286:			must(fmt.Fprintf(out, &quot;%s%s%s&quot;, color, link(commitURL, shortHash[:min(len(shortHash), maxWidth)]), RESET))
+288:			must(fmt.Fprintf(out, &quot;%s%s%s&quot;, color, shortHash[:min(len(shortHash), maxWidth)], RESET))
+303:			color = CYAN
+309:			must(fmt.Fprintf(out, &quot;%s%s%s&quot;, color, link(commitURL, file.hash), RESET))
+311:			must(fmt.Fprintf(out, &quot;%s%s%s&quot;, color, file.hash, RESET))
+342:			must(fmt.Fprintf(out, &quot;%s%s%s&quot;, YELLOW, link(authorLink, truncatedAuthor), RESET))
+348:			must(fmt.Fprintf(out, &quot;%s%s%s&quot;, YELLOW, truncatedAuthor, RESET))</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-22-06-406Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-22-06-406Z" class="timestamp-link"><time datetime="2026-04-11T02:22:06.406Z" data-timestamp="2026-04-11T02:22:06.406Z">2026-04-11T02:22:06.406Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01Dv2JXWaJ2UYJ95EfF4NWtg"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;func link\\(|func hashToColor&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;-n&#34;: true
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-22-06-429Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-22-06-429Z" class="timestamp-link"><time datetime="2026-04-11T02:22:06.429Z" data-timestamp="2026-04-11T02:22:06.429Z">2026-04-11T02:22:06.429Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>main.go:105:func hashToColor(hash string) string {
+main.go:538:func link(url string, name string) string {</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-22-13-155Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-22-13-155Z" class="timestamp-link"><time datetime="2026-04-11T02:22:13.155Z" data-timestamp="2026-04-11T02:22:13.155Z">2026-04-11T02:22:13.155Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_011hQ5NXHcEzD6BcvUAcLzQh"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 105,
+  &#34;limit&#34;: 20
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-22-13-165Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-22-13-165Z" class="timestamp-link"><time datetime="2026-04-11T02:22:13.165Z" data-timestamp="2026-04-11T02:22:13.165Z">2026-04-11T02:22:13.165Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>105	func hashToColor(hash string) string {
+106		if hash == &quot;&quot; {
+107			return CYAN
+108		}
+109	
+110		// Calculate a numeric hash from the commit hash string
+111		var h uint32
+112		for i := 0; i &lt; len(hash) &amp;&amp; i &lt; 8; i++ {
+113			h = h*31 + uint32(hash[i])
+114		}
+115	
+116		// Select a color from the pre-computed valid colors using the hash
+117		colorCode := validHashColors[h%uint32(len(validHashColors))]
+118		return fmt.Sprintf(&quot;\x1b[38;5;%dm&quot;, colorCode)
+119	}
+120	
+121	func must[T any](a T, e error) T {
+122		if e != nil {
+123			panic(e)
+124		}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-22-13-581Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-22-13-581Z" class="timestamp-link"><time datetime="2026-04-11T02:22:13.581Z" data-timestamp="2026-04-11T02:22:13.581Z">2026-04-11T02:22:13.581Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01ERz5EtgpXn2vmaoecsDfb4"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 538,
+  &#34;limit&#34;: 20
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-22-13-596Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-22-13-596Z" class="timestamp-link"><time datetime="2026-04-11T02:22:13.596Z" data-timestamp="2026-04-11T02:22:13.596Z">2026-04-11T02:22:13.596Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>538	func link(url string, name string) string {
+539		// hyperlink format: \e]8;;&lt;url&gt;\e\&lt;link text&gt;\e]8;;\e\
+540		return fmt.Sprintf(&quot;\x1b]8;;%s\x1b\\%s\x1b]8;;\x1b\\&quot;, url, name)
+541	}
+542	
+543	func linkify(commitMsg string, github string, hash string) string {
+544		issueRe := regexp.MustCompile(`#(\d+)`)
+545		issueIx := issueRe.FindStringIndex(commitMsg)
+546		out := make([]string, 0, 16)
+547		for issueIx != nil {
+548			commitURL := fmt.Sprintf(&quot;%s/commit/%s&quot;, github, hash)
+549			out = append(out, link(commitURL, commitMsg[:issueIx[0]]))
+550	
+551			issueURL := fmt.Sprintf(&quot;%s/pull/%s&quot;, github, commitMsg[issueIx[0]+1:issueIx[1]])
+552			issueText := fmt.Sprintf(&quot;%s%s%s&quot;, BLUE, commitMsg[issueIx[0]:issueIx[1]], RESET)
+553			out = append(out, link(issueURL, issueText))
+554	
+555			commitMsg = commitMsg[issueIx[1]:]
+556			issueIx = issueRe.FindStringIndex(commitMsg)
+557		}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-22-19-197Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-22-19-197Z" class="timestamp-link"><time datetime="2026-04-11T02:22:19.197Z" data-timestamp="2026-04-11T02:22:19.197Z">2026-04-11T02:22:19.197Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>OK, I need to also disable hyperlinks when <code>NO_COLOR</code> is set (they contain escape sequences). Let me also check the <code>makeDiffGraph</code> function since it uses colors:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-22-20-220Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-22-20-220Z" class="timestamp-link"><time datetime="2026-04-11T02:22:20.220Z" data-timestamp="2026-04-11T02:22:20.220Z">2026-04-11T02:22:20.220Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01QvB3g8iLQ4tTmCvBEQJecV"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;func makeDiffGraph\&#34;&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;-n&#34;: true
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-22-20-238Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-22-20-238Z" class="timestamp-link"><time datetime="2026-04-11T02:22:20.238Z" data-timestamp="2026-04-11T02:22:20.238Z">2026-04-11T02:22:20.238Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>No matches found</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-22-20-460Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-22-20-460Z" class="timestamp-link"><time datetime="2026-04-11T02:22:20.460Z" data-timestamp="2026-04-11T02:22:20.460Z">2026-04-11T02:22:20.460Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01J8Ho5CXJKifbwCrxZYHxZh"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/columns.go&#34;,
+  &#34;offset&#34;: 630,
+  &#34;limit&#34;: 50
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-22-20-470Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-22-20-470Z" class="timestamp-link"><time datetime="2026-04-11T02:22:20.470Z" data-timestamp="2026-04-11T02:22:20.470Z">2026-04-11T02:22:20.470Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>&lt;system-reminder&gt;Warning: the file exists but is shorter than the provided offset (630). The file has 447 lines.&lt;/system-reminder&gt;</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-22-23-910Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-22-23-910Z" class="timestamp-link"><time datetime="2026-04-11T02:22:23.910Z" data-timestamp="2026-04-11T02:22:23.910Z">2026-04-11T02:22:23.910Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01XEvoTFd6k8AZX1jPS6Mast"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;func makeDiffGraph&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;-n&#34;: true
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-22-23-929Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-22-23-929Z" class="timestamp-link"><time datetime="2026-04-11T02:22:23.929Z" data-timestamp="2026-04-11T02:22:23.929Z">2026-04-11T02:22:23.929Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>main.go:637:func makeDiffGraph(file *File, width int) string {</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-22-27-524Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-22-27-524Z" class="timestamp-link"><time datetime="2026-04-11T02:22:27.524Z" data-timestamp="2026-04-11T02:22:27.524Z">2026-04-11T02:22:27.524Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01EV92Gb4Sd1yvrshfHq3WYY"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 637,
+  &#34;limit&#34;: 55
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-22-27-537Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-22-27-537Z" class="timestamp-link"><time datetime="2026-04-11T02:22:27.537Z" data-timestamp="2026-04-11T02:22:27.537Z">2026-04-11T02:22:27.537Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>637	func makeDiffGraph(file *File, width int) string {
+638		if file.diffSum == nil {
+639			return &quot;&quot;
+640		}
+641		plus := file.diffSum.plus
+642		minus := file.diffSum.minus
+643		if plus+minus &lt;= width {
+644			return fmt.Sprintf(&quot;%s%s%s%s%s&quot;,
+645				GREEN,
+646				strings.Repeat(&quot;+&quot;, plus),
+647				RED,
+648				strings.Repeat(&quot;-&quot;, minus),
+649				RESET)
+650		}
+651		return fmt.Sprintf(&quot;%s%s%s%s%s&quot;,
+652			GREEN,
+653			strings.Repeat(&quot;+&quot;, scaleLinear(plus, width, plus+minus)),
+654			RED,
+655			strings.Repeat(&quot;-&quot;, scaleLinear(minus, width, plus+minus)),
+656			RESET)
+657	}
+658	
+659	func showColumns(out io.Writer, maxWidth int, files []*File, rctx *RenderContext, columns []Column) {
+660		// Calculate max widths for each column
+661		colWidths := calculateColumnWidths(files, columns, rctx)
+662	
+663		// Render each file
+664		for _, file := range files {
+665			lineWidth := 0
+666	
+667			// Render each column in order
+668			for i, col := range columns {
+669				// Add space between columns (except before first column)
+670				if i &gt; 0 {
+671					must(fmt.Fprintf(out, &quot; &quot;))
+672					lineWidth += 1
+673				}
+674	
+675				// Check if we have space for this column
+676				if lineWidth &gt;= maxWidth {
+677					break
+678				}
+679	
+680				// Calculate available width for this column
+681				availableWidth := maxWidth - lineWidth
+682				colWidth := min(colWidths[col], availableWidth)
+683	
+684				// Render the column
+685				renderer := getColumnRenderer(col)
+686				renderer(out, file, colWidth, rctx)
+687				lineWidth += colWidth
+688			}
+689	
+690			// Reset any remaining formatting (like strikethrough for deleted files)
+691			if file.isDeleted {</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message user" id="msg-2026-04-11T02-22-31-954Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T02-22-31-954Z" class="timestamp-link"><time datetime="2026-04-11T02:22:31.954Z" data-timestamp="2026-04-11T02:22:31.954Z">2026-04-11T02:22:31.954Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>[Request interrupted by user]</p></div></div></div>
+        
+
+<div class="pagination">
+<a href="index.html" class="index-link">Index</a>
+<a href="page-003.html">&larr; Prev</a>
+<a href="page-001.html">1</a>
+<a href="page-002.html">2</a>
+<a href="page-003.html">3</a>
+<span class="current">4</span>
+<a href="page-005.html">5</a>
+<a href="page-005.html">Next &rarr;</a>
+</div>
+
+    </div>
+    <script>
+document.querySelectorAll('time[data-timestamp]').forEach(function(el) {
+    const timestamp = el.getAttribute('data-timestamp');
+    const date = new Date(timestamp);
+    const now = new Date();
+    const isToday = date.toDateString() === now.toDateString();
+    const timeStr = date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+    if (isToday) { el.textContent = timeStr; }
+    else { el.textContent = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' ' + timeStr; }
+});
+document.querySelectorAll('pre.json').forEach(function(el) {
+    let text = el.textContent;
+    text = text.replace(/"([^"]+)":/g, '<span style="color: #ce93d8">"$1"</span>:');
+    text = text.replace(/: "([^"]*)"/g, ': <span style="color: #81d4fa">"$1"</span>');
+    text = text.replace(/: (\d+)/g, ': <span style="color: #ffcc80">$1</span>');
+    text = text.replace(/: (true|false|null)/g, ': <span style="color: #f48fb1">$1</span>');
+    el.innerHTML = text;
+});
+document.querySelectorAll('.truncatable').forEach(function(wrapper) {
+    const content = wrapper.querySelector('.truncatable-content');
+    const btn = wrapper.querySelector('.expand-btn');
+    if (content.scrollHeight > 250) {
+        wrapper.classList.add('truncated');
+        btn.addEventListener('click', function() {
+            if (wrapper.classList.contains('truncated')) { wrapper.classList.remove('truncated'); wrapper.classList.add('expanded'); btn.textContent = 'Show less'; }
+            else { wrapper.classList.remove('expanded'); wrapper.classList.add('truncated'); btn.textContent = 'Show more'; }
+        });
+    }
+});
+</script>
+</body>
+</html>

--- a/transcripts/47-changed-relative-paths.html/page-005.html
+++ b/transcripts/47-changed-relative-paths.html/page-005.html
@@ -1,0 +1,2375 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Claude Code transcript - page 5</title>
+    <style>
+:root { --bg-color: #f5f5f5; --card-bg: #ffffff; --user-bg: #e3f2fd; --user-border: #1976d2; --assistant-bg: #f5f5f5; --assistant-border: #9e9e9e; --thinking-bg: #fff8e1; --thinking-border: #ffc107; --thinking-text: #666; --tool-bg: #f3e5f5; --tool-border: #9c27b0; --tool-result-bg: #e8f5e9; --tool-error-bg: #ffebee; --text-color: #212121; --text-muted: #757575; --code-bg: #263238; --code-text: #aed581; }
+* { box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg-color); color: var(--text-color); margin: 0; padding: 16px; line-height: 1.6; }
+.container { max-width: 800px; margin: 0 auto; }
+h1 { font-size: 1.5rem; margin-bottom: 24px; padding-bottom: 8px; border-bottom: 2px solid var(--user-border); }
+.header-row { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; border-bottom: 2px solid var(--user-border); padding-bottom: 8px; margin-bottom: 24px; }
+.header-row h1 { border-bottom: none; padding-bottom: 0; margin-bottom: 0; flex: 1; min-width: 200px; }
+.message { margin-bottom: 16px; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.message.user { background: var(--user-bg); border-left: 4px solid var(--user-border); }
+.message.assistant { background: var(--card-bg); border-left: 4px solid var(--assistant-border); }
+.message.tool-reply { background: #fff8e1; border-left: 4px solid #ff9800; }
+.tool-reply .role-label { color: #e65100; }
+.tool-reply .tool-result { background: transparent; padding: 0; margin: 0; }
+.tool-reply .tool-result .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff8e1); }
+.message-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 16px; background: rgba(0,0,0,0.03); font-size: 0.85rem; }
+.role-label { font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
+.user .role-label { color: var(--user-border); }
+time { color: var(--text-muted); font-size: 0.8rem; }
+.timestamp-link { color: inherit; text-decoration: none; }
+.timestamp-link:hover { text-decoration: underline; }
+.message:target { animation: highlight 2s ease-out; }
+@keyframes highlight { 0% { background-color: rgba(25, 118, 210, 0.2); } 100% { background-color: transparent; } }
+.message-content { padding: 16px; }
+.message-content p { margin: 0 0 12px 0; }
+.message-content p:last-child { margin-bottom: 0; }
+.thinking { background: var(--thinking-bg); border: 1px solid var(--thinking-border); border-radius: 8px; padding: 12px; margin: 12px 0; font-size: 0.9rem; color: var(--thinking-text); }
+.thinking-label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: #f57c00; margin-bottom: 8px; }
+.thinking p { margin: 8px 0; }
+.assistant-text { margin: 8px 0; }
+.tool-use { background: var(--tool-bg); border: 1px solid var(--tool-border); border-radius: 8px; padding: 12px; margin: 12px 0; }
+.tool-header { font-weight: 600; color: var(--tool-border); margin-bottom: 8px; display: flex; align-items: center; gap: 8px; }
+.tool-icon { font-size: 1.1rem; }
+.tool-description { font-size: 0.9rem; color: var(--text-muted); margin-bottom: 8px; font-style: italic; }
+.tool-result { background: var(--tool-result-bg); border-radius: 8px; padding: 12px; margin: 12px 0; }
+.tool-result.tool-error { background: var(--tool-error-bg); }
+.file-tool { border-radius: 8px; padding: 12px; margin: 12px 0; }
+.write-tool { background: linear-gradient(135deg, #e3f2fd 0%, #e8f5e9 100%); border: 1px solid #4caf50; }
+.edit-tool { background: linear-gradient(135deg, #fff3e0 0%, #fce4ec 100%); border: 1px solid #ff9800; }
+.file-tool-header { font-weight: 600; margin-bottom: 4px; display: flex; align-items: center; gap: 8px; font-size: 0.95rem; }
+.write-header { color: #2e7d32; }
+.edit-header { color: #e65100; }
+.file-tool-icon { font-size: 1rem; }
+.file-tool-path { font-family: monospace; background: rgba(0,0,0,0.08); padding: 2px 8px; border-radius: 4px; }
+.file-tool-fullpath { font-family: monospace; font-size: 0.8rem; color: var(--text-muted); margin-bottom: 8px; word-break: break-all; }
+.file-content { margin: 0; }
+.edit-section { display: flex; margin: 4px 0; border-radius: 4px; overflow: hidden; }
+.edit-label { padding: 8px 12px; font-weight: bold; font-family: monospace; display: flex; align-items: flex-start; }
+.edit-old { background: #fce4ec; }
+.edit-old .edit-label { color: #b71c1c; background: #f8bbd9; }
+.edit-old .edit-content { color: #880e4f; }
+.edit-new { background: #e8f5e9; }
+.edit-new .edit-label { color: #1b5e20; background: #a5d6a7; }
+.edit-new .edit-content { color: #1b5e20; }
+.edit-content { margin: 0; flex: 1; background: transparent; font-size: 0.85rem; }
+.edit-replace-all { font-size: 0.75rem; font-weight: normal; color: var(--text-muted); }
+.write-tool .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #e6f4ea); }
+.edit-tool .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff0e5); }
+.todo-list { background: linear-gradient(135deg, #e8f5e9 0%, #f1f8e9 100%); border: 1px solid #81c784; border-radius: 8px; padding: 12px; margin: 12px 0; }
+.todo-header { font-weight: 600; color: #2e7d32; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; font-size: 0.95rem; }
+.todo-items { list-style: none; margin: 0; padding: 0; }
+.todo-item { display: flex; align-items: flex-start; gap: 10px; padding: 6px 0; border-bottom: 1px solid rgba(0,0,0,0.06); font-size: 0.9rem; }
+.todo-item:last-child { border-bottom: none; }
+.todo-icon { flex-shrink: 0; width: 20px; height: 20px; display: flex; align-items: center; justify-content: center; font-weight: bold; border-radius: 50%; }
+.todo-completed .todo-icon { color: #2e7d32; background: rgba(46, 125, 50, 0.15); }
+.todo-completed .todo-content { color: #558b2f; text-decoration: line-through; }
+.todo-in-progress .todo-icon { color: #f57c00; background: rgba(245, 124, 0, 0.15); }
+.todo-in-progress .todo-content { color: #e65100; font-weight: 500; }
+.todo-pending .todo-icon { color: #757575; background: rgba(0,0,0,0.05); }
+.todo-pending .todo-content { color: #616161; }
+pre { background: var(--code-bg); color: var(--code-text); padding: 12px; border-radius: 6px; overflow-x: auto; font-size: 0.85rem; line-height: 1.5; margin: 8px 0; white-space: pre-wrap; word-wrap: break-word; }
+pre.json { color: #e0e0e0; }
+code { background: rgba(0,0,0,0.08); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+pre code { background: none; padding: 0; }
+.user-content { margin: 0; }
+.truncatable { position: relative; }
+.truncatable.truncated .truncatable-content { max-height: 200px; overflow: hidden; }
+.truncatable.truncated::after { content: ''; position: absolute; bottom: 32px; left: 0; right: 0; height: 60px; background: linear-gradient(to bottom, transparent, var(--card-bg)); pointer-events: none; }
+.message.user .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--user-bg)); }
+.message.tool-reply .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, #fff8e1); }
+.tool-use .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--tool-bg)); }
+.tool-result .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--tool-result-bg)); }
+.expand-btn { display: none; width: 100%; padding: 8px 16px; margin-top: 4px; background: rgba(0,0,0,0.05); border: 1px solid rgba(0,0,0,0.1); border-radius: 6px; cursor: pointer; font-size: 0.85rem; color: var(--text-muted); }
+.expand-btn:hover { background: rgba(0,0,0,0.1); }
+.truncatable.truncated .expand-btn, .truncatable.expanded .expand-btn { display: block; }
+.pagination { display: flex; justify-content: center; gap: 8px; margin: 24px 0; flex-wrap: wrap; }
+.pagination a, .pagination span { padding: 5px 10px; border-radius: 6px; text-decoration: none; font-size: 0.85rem; }
+.pagination a { background: var(--card-bg); color: var(--user-border); border: 1px solid var(--user-border); }
+.pagination a:hover { background: var(--user-bg); }
+.pagination .current { background: var(--user-border); color: white; }
+.pagination .disabled { color: var(--text-muted); border: 1px solid #ddd; }
+.pagination .index-link { background: var(--user-border); color: white; }
+details.continuation { margin-bottom: 16px; }
+details.continuation summary { cursor: pointer; padding: 12px 16px; background: var(--user-bg); border-left: 4px solid var(--user-border); border-radius: 12px; font-weight: 500; color: var(--text-muted); }
+details.continuation summary:hover { background: rgba(25, 118, 210, 0.15); }
+details.continuation[open] summary { border-radius: 12px 12px 0 0; margin-bottom: 0; }
+.index-item { margin-bottom: 16px; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); background: var(--user-bg); border-left: 4px solid var(--user-border); }
+.index-item a { display: block; text-decoration: none; color: inherit; }
+.index-item a:hover { background: rgba(25, 118, 210, 0.1); }
+.index-item-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 16px; background: rgba(0,0,0,0.03); font-size: 0.85rem; }
+.index-item-number { font-weight: 600; color: var(--user-border); }
+.index-item-content { padding: 16px; }
+.index-item-stats { padding: 8px 16px 12px 32px; font-size: 0.85rem; color: var(--text-muted); border-top: 1px solid rgba(0,0,0,0.06); }
+.index-item-commit { margin-top: 6px; padding: 4px 8px; background: #fff3e0; border-radius: 4px; font-size: 0.85rem; color: #e65100; }
+.index-item-commit code { background: rgba(0,0,0,0.08); padding: 1px 4px; border-radius: 3px; font-size: 0.8rem; margin-right: 6px; }
+.commit-card { margin: 8px 0; padding: 10px 14px; background: #fff3e0; border-left: 4px solid #ff9800; border-radius: 6px; }
+.commit-card a { text-decoration: none; color: #5d4037; display: block; }
+.commit-card a:hover { color: #e65100; }
+.commit-card-hash { font-family: monospace; color: #e65100; font-weight: 600; margin-right: 8px; }
+.index-commit { margin-bottom: 12px; padding: 10px 16px; background: #fff3e0; border-left: 4px solid #ff9800; border-radius: 8px; box-shadow: 0 1px 2px rgba(0,0,0,0.05); }
+.index-commit a { display: block; text-decoration: none; color: inherit; }
+.index-commit a:hover { background: rgba(255, 152, 0, 0.1); margin: -10px -16px; padding: 10px 16px; border-radius: 8px; }
+.index-commit-header { display: flex; justify-content: space-between; align-items: center; font-size: 0.85rem; margin-bottom: 4px; }
+.index-commit-hash { font-family: monospace; color: #e65100; font-weight: 600; }
+.index-commit-msg { color: #5d4037; }
+.index-item-long-text { margin-top: 8px; padding: 12px; background: var(--card-bg); border-radius: 8px; border-left: 3px solid var(--assistant-border); }
+.index-item-long-text .truncatable.truncated::after { background: linear-gradient(to bottom, transparent, var(--card-bg)); }
+.index-item-long-text-content { color: var(--text-color); }
+#search-box { display: none; align-items: center; gap: 8px; }
+#search-box input { padding: 6px 12px; border: 1px solid var(--assistant-border); border-radius: 6px; font-size: 16px; width: 180px; }
+#search-box button, #modal-search-btn, #modal-close-btn { background: var(--user-border); color: white; border: none; border-radius: 6px; padding: 6px 10px; cursor: pointer; display: flex; align-items: center; justify-content: center; }
+#search-box button:hover, #modal-search-btn:hover { background: #1565c0; }
+#modal-close-btn { background: var(--text-muted); margin-left: 8px; }
+#modal-close-btn:hover { background: #616161; }
+#search-modal[open] { border: none; border-radius: 12px; box-shadow: 0 4px 24px rgba(0,0,0,0.2); padding: 0; width: 90vw; max-width: 900px; height: 80vh; max-height: 80vh; display: flex; flex-direction: column; }
+#search-modal::backdrop { background: rgba(0,0,0,0.5); }
+.search-modal-header { display: flex; align-items: center; gap: 8px; padding: 16px; border-bottom: 1px solid var(--assistant-border); background: var(--bg-color); border-radius: 12px 12px 0 0; }
+.search-modal-header input { flex: 1; padding: 8px 12px; border: 1px solid var(--assistant-border); border-radius: 6px; font-size: 16px; }
+#search-status { padding: 8px 16px; font-size: 0.85rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
+#search-results { flex: 1; overflow-y: auto; padding: 16px; }
+.search-result { margin-bottom: 16px; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.search-result a { display: block; text-decoration: none; color: inherit; }
+.search-result a:hover { background: rgba(25, 118, 210, 0.05); }
+.search-result-page { padding: 6px 12px; background: rgba(0,0,0,0.03); font-size: 0.8rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
+.search-result-content { padding: 12px; }
+.search-result mark { background: #fff59d; padding: 1px 2px; border-radius: 2px; }
+@media (max-width: 600px) { body { padding: 8px; } .message, .index-item { border-radius: 8px; } .message-content, .index-item-content { padding: 12px; } pre { font-size: 0.8rem; padding: 8px; } #search-box input { width: 120px; } #search-modal[open] { width: 95vw; height: 90vh; } }
+</style>
+</head>
+<body>
+    <div class="container">
+        <h1><a href="index.html" style="color: inherit; text-decoration: none;">Claude Code transcript</a> - page 5/5</h1>
+        
+
+<div class="pagination">
+<a href="index.html" class="index-link">Index</a>
+<a href="page-004.html">&larr; Prev</a>
+<a href="page-001.html">1</a>
+<a href="page-002.html">2</a>
+<a href="page-003.html">3</a>
+<a href="page-004.html">4</a>
+<span class="current">5</span>
+<span class="disabled">Next &rarr;</span>
+</div>
+
+        
+<div class="message user" id="msg-2026-04-11T02-23-18-795Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T02-23-18-795Z" class="timestamp-link"><time datetime="2026-04-11T02:23:18.795Z" data-timestamp="2026-04-11T02:23:18.795Z">2026-04-11T02:23:18.795Z</time></a></div><div class="message-content">
+<div class="user-content"><p>wait I don't like the idea of disabling hyperlinks when NO_COLOR is set, a user could plausibly be using NO_COLOR in their terminal and want hyperlinks.</p>
+<p>What about an undocumented NO_HYPERLINKS or NO_ANSI env var that's used only for testing</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-23-28-834Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-23-28-834Z" class="timestamp-link"><time datetime="2026-04-11T02:23:28.834Z" data-timestamp="2026-04-11T02:23:28.834Z">2026-04-11T02:23:28.834Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Good point. Let me keep <code>NO_COLOR</code> doing just what the spec says — disable colors — and add a separate <code>NO_HYPERLINKS</code> for the link escapes. For testing we'd set both.</p>
+<p>Actually, thinking about it more: <code>NO_COLOR</code> should disable color codes, and the <code>link()</code> function's escape sequences aren't color — they're OSC 8 hyperlinks. So <code>NO_COLOR</code> shouldn't touch them at all per the spec. For testing, we just need to strip or ignore them in our test assertions. <code>testscript</code>'s <code>stdout</code> takes a regex, so we can match the text content and skip the escapes.</p>
+<p>So the plan is:
+1. <code>NO_COLOR</code> — sets color vars to <code>""</code>, leaves hyperlinks alone
+2. In testscript tests, use regex matching to check text content (ignoring hyperlink escapes)</p>
+<p>Let me do it.</p></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-23-31-920Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-23-31-920Z" class="timestamp-link"><time datetime="2026-04-11T02:23:31.920Z" data-timestamp="2026-04-11T02:23:31.920Z">2026-04-11T02:23:31.920Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/tree-experiment/main.go has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-23-31-892Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-23-31-892Z" class="timestamp-link"><time datetime="2026-04-11T02:23:31.892Z" data-timestamp="2026-04-11T02:23:31.892Z">2026-04-11T02:23:31.892Z</time></a></div><div class="message-content"><div class="file-tool edit-tool" data-tool-id="toolu_01XpFc2o4qnSsNfuNoeiPKJh">
+<div class="file-tool-header edit-header"><span class="file-tool-icon">✏️</span> Edit <span class="file-tool-path">main.go</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/tree-experiment/main.go</div>
+<div class="truncatable"><div class="truncatable-content">
+<div class="edit-section edit-old"><div class="edit-label">−</div><pre class="edit-content">const (
+	BLUE      = &#34;\x1b[34m&#34;
+	CYAN      = &#34;\x1b[36m&#34;
+	GREEN     = &#34;\x1b[32m&#34;
+	RED       = &#34;\x1b[31m&#34;
+	RESET     = &#34;\x1b[0m&#34;
+	YELLOW    = &#34;\x1b[33m&#34;
+	STRIKEOUT = &#34;\x1b[9m&#34;
+)</pre></div>
+<div class="edit-section edit-new"><div class="edit-label">+</div><pre class="edit-content">var (
+	BLUE      = &#34;\x1b[34m&#34;
+	CYAN      = &#34;\x1b[36m&#34;
+	GREEN     = &#34;\x1b[32m&#34;
+	RED       = &#34;\x1b[31m&#34;
+	RESET     = &#34;\x1b[0m&#34;
+	YELLOW    = &#34;\x1b[33m&#34;
+	STRIKEOUT = &#34;\x1b[9m&#34;
+)
+
+func init() {
+	if _, ok := os.LookupEnv(&#34;NO_COLOR&#34;); ok {
+		BLUE = &#34;&#34;
+		CYAN = &#34;&#34;
+		GREEN = &#34;&#34;
+		RED = &#34;&#34;
+		RESET = &#34;&#34;
+		YELLOW = &#34;&#34;
+		STRIKEOUT = &#34;&#34;
+	}
+}</pre></div>
+</div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-23-36-507Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-23-36-507Z" class="timestamp-link"><time datetime="2026-04-11T02:23:36.507Z" data-timestamp="2026-04-11T02:23:36.507Z">2026-04-11T02:23:36.507Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now I also need to handle <code>hashToColor</code> — it generates color codes directly:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-23-37-822Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-23-37-822Z" class="timestamp-link"><time datetime="2026-04-11T02:23:37.822Z" data-timestamp="2026-04-11T02:23:37.822Z">2026-04-11T02:23:37.822Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01LtZvR6mpkXfFZjAkwP7RFV"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 115,
+  &#34;limit&#34;: 15
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-23-37-843Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-23-37-843Z" class="timestamp-link"><time datetime="2026-04-11T02:23:37.843Z" data-timestamp="2026-04-11T02:23:37.843Z">2026-04-11T02:23:37.843Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>115	// hashToColor generates a color code for a commit hash.
+116	// It uses 8-bit terminal colors (\e[38;5;&lt;n&gt;m) from the pre-computed validHashColors.
+117	func hashToColor(hash string) string {
+118		if hash == &quot;&quot; {
+119			return CYAN
+120		}
+121	
+122		// Calculate a numeric hash from the commit hash string
+123		var h uint32
+124		for i := 0; i &lt; len(hash) &amp;&amp; i &lt; 8; i++ {
+125			h = h*31 + uint32(hash[i])
+126		}
+127	
+128		// Select a color from the pre-computed valid colors using the hash
+129		colorCode := validHashColors[h%uint32(len(validHashColors))]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-23-44-421Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-23-44-421Z" class="timestamp-link"><time datetime="2026-04-11T02:23:44.421Z" data-timestamp="2026-04-11T02:23:44.421Z">2026-04-11T02:23:44.421Z</time></a></div><div class="message-content"><div class="file-tool edit-tool" data-tool-id="toolu_01WVMzbjadppV2JXWDN9inPC">
+<div class="file-tool-header edit-header"><span class="file-tool-icon">✏️</span> Edit <span class="file-tool-path">main.go</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/tree-experiment/main.go</div>
+<div class="truncatable"><div class="truncatable-content">
+<div class="edit-section edit-old"><div class="edit-label">−</div><pre class="edit-content">	// Select a color from the pre-computed valid colors using the hash
+	colorCode := validHashColors[h%uint32(len(validHashColors))]
+	return fmt.Sprintf(&#34;\x1b[38;5;%dm&#34;, colorCode)</pre></div>
+<div class="edit-section edit-new"><div class="edit-label">+</div><pre class="edit-content">	// Select a color from the pre-computed valid colors using the hash
+	colorCode := validHashColors[h%uint32(len(validHashColors))]
+	if RESET == &#34;&#34; {
+		return &#34;&#34;
+	}
+	return fmt.Sprintf(&#34;\x1b[38;5;%dm&#34;, colorCode)</pre></div>
+</div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-23-44-442Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-23-44-442Z" class="timestamp-link"><time datetime="2026-04-11T02:23:44.442Z" data-timestamp="2026-04-11T02:23:44.442Z">2026-04-11T02:23:44.442Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/tree-experiment/main.go has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-23-50-535Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-23-50-535Z" class="timestamp-link"><time datetime="2026-04-11T02:23:50.535Z" data-timestamp="2026-04-11T02:23:50.535Z">2026-04-11T02:23:50.535Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now let me refactor <code>main()</code> into <code>run()</code> so testscript can call it. I need to convert <code>log.Fatalf</code> calls to return error codes, and have <code>main()</code> call <code>run()</code>:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-23-51-060Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-23-51-060Z" class="timestamp-link"><time datetime="2026-04-11T02:23:51.060Z" data-timestamp="2026-04-11T02:23:51.060Z">2026-04-11T02:23:51.060Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01QamcmD41oauDAN9vgeorcV"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 273,
+  &#34;limit&#34;: 180
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-23-51-074Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-23-51-074Z" class="timestamp-link"><time datetime="2026-04-11T02:23:51.074Z" data-timestamp="2026-04-11T02:23:51.074Z">2026-04-11T02:23:51.074Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>273	
+274	%s
+275	`, link(&quot;https://github.com/llimllib/git-ls&quot;, &quot;https://github.com/llimllib/git-ls&quot;))
+276	}
+277	
+278	func main() {
+279		argv := os.Args[1:]
+280		diffWidth := 4
+281		monoHash := false
+282		nerdFont := false
+283		changedOnly := false
+284		debug := false
+285		var formatColumns []Column
+286		for len(argv) &gt; 0 {
+287			if argv[0] == &quot;--version&quot; {
+288				printVersion()
+289				os.Exit(0)
+290			}
+291			if argv[0] == &quot;--help&quot; || argv[0] == &quot;-h&quot; {
+292				usage()
+293				os.Exit(0)
+294			}
+295			if argv[0] == &quot;--mono-hash&quot; {
+296				monoHash = true
+297				argv = argv[1:]
+298			} else if argv[0] == &quot;--nerdfont&quot; {
+299				nerdFont = true
+300				argv = argv[1:]
+301			} else if argv[0] == &quot;--changed-only&quot; || argv[0] == &quot;-c&quot; {
+302				changedOnly = true
+303				argv = argv[1:]
+304			} else if strings.HasPrefix(argv[0], &quot;--diffWidth&quot;) {
+305				if len(argv) == 1 {
+306					if strings.Contains(argv[0], &quot;=&quot;) {
+307						parts := strings.SplitN(argv[0], &quot;=&quot;, 2)
+308						diffWidth = must(strconv.Atoi(parts[1]))
+309					} else {
+310						log.Fatalf(&quot;--diffWidth requires an argument&quot;)
+311					}
+312					argv = argv[1:]
+313				} else {
+314					diffWidth = must(strconv.Atoi(argv[1]))
+315					argv = argv[2:]
+316				}
+317			} else if strings.HasPrefix(argv[0], &quot;--format&quot;) {
+318				if len(argv) == 1 {
+319					if strings.Contains(argv[0], &quot;=&quot;) {
+320						parts := strings.SplitN(argv[0], &quot;=&quot;, 2)
+321						formatColumns = parseFormat(parts[1])
+322					} else {
+323						log.Fatalf(&quot;--format requires an argument&quot;)
+324					}
+325					argv = argv[1:]
+326				} else {
+327					formatColumns = parseFormat(argv[1])
+328					argv = argv[2:]
+329				}
+330			} else if strings.HasPrefix(argv[0], &quot;--debug&quot;) {
+331				debug = true
+332				argv = argv[1:]
+333			} else {
+334				// Non-flag argument (directory), stop parsing flags
+335				break
+336			}
+337		}
+338	
+339		var dir string
+340		if len(argv) &gt; 0 {
+341			dir = argv[0]
+342	
+343			if err := os.Chdir(dir); err != nil {
+344				log.Fatalf(&quot;Failed to change directory to %s: %v&quot;, dir, err)
+345			}
+346		} else {
+347			dir = &quot;.&quot;
+348		}
+349	
+350		// Fetch all git data in parallel
+351		gitData := fetchGitData()
+352	
+353		// Resolve symlinks to match git&#x27;s perspective. Git internally resolves
+354		// symlinks when working with worktrees, so we need to do the same to
+355		// ensure filepath.Rel() works correctly in fileStatus().
+356		// https://github.com/llimllib/git-ls/issues/34
+357		resolved := must(filepath.EvalSymlinks(must(filepath.Abs(&quot;.&quot;))))
+358		curdir := must(filepath.Rel(gitData.root, resolved))
+359	
+360		var files []*File
+361		if changedOnly {
+362			// In --changed-only mode, build the file list directly from git
+363			// status so we can show files from subdirectories with their full
+364			// relative paths (e.g. &quot;src/network/server.go&quot; not just &quot;src/&quot;)
+365			files = changedFilesFromStatus(gitData.status, curdir)
+366		} else {
+367			osfiles, err := os.ReadDir(&quot;.&quot;)
+368			if err != nil {
+369				log.Fatalf(&quot;Failed to read directory %s: %v&quot;, dir, err)
+370			}
+371	
+372			for _, file := range osfiles {
+373				stat, _ := os.Stat(file.Name())
+374				files = append(files, &amp;File{
+375					entry: file,
+376					isDir: file.IsDir(),
+377					isExe: !file.IsDir() &amp;&amp; stat.Mode()&amp;0o111 != 0,
+378				})
+379			}
+380	
+381			fileStatus(gitData.status, files, curdir)
+382	
+383			// Parse deleted files from git status and merge into file list
+384			deletedFiles := parseDeletedFiles(gitData.status, curdir)
+385			files = append(files, deletedFiles...)
+386		}
+387	
+388		// Now run git log on the files we&#x27;ll show
+389		// Skip git log for files that won&#x27;t have history:
+390		// - I: Ignored files - not tracked by git
+391		// - ??: Untracked files - not in git yet
+392		// - *: .git directory - git metadata, not file history
+393		// - A: Newly added files
+394		//   Examples: &quot;A &quot;, &quot;AM&quot;, &quot;AD&quot; - staged additions not yet committed
+395		//   But &quot;M &quot;, &quot;MM&quot;, or mixed dirs like &quot;A ,M &quot; have history
+396		var filesNeedingLog []*File
+397		for _, file := range files {
+398			if file.status == &quot;I&quot; || file.status == &quot;??&quot; || file.status == &quot;*&quot; {
+399				continue
+400			}
+401			// Empty status means unmodified tracked file — it has history
+402			if file.status == &quot;&quot; {
+403				filesNeedingLog = append(filesNeedingLog, file)
+404				continue
+405			}
+406			// Check if ALL statuses in a comma-separated list are new additions
+407			// For directories, status might be &quot;A ,M &quot; if it has both new and modified files
+408			allNew := true
+409			for status := range strings.SplitSeq(file.status, &quot;,&quot;) {
+410				status = strings.TrimSpace(status)
+411				// Check if this individual status represents a file with history
+412				// If first char (index) is not &#x27;A&#x27; and not untracked, it has history
+413				if len(status) &gt; 0 &amp;&amp; status[0] != &#x27;A&#x27; &amp;&amp; status != &quot;??&quot; {
+414					allNew = false
+415					break
+416				}
+417			}
+418			if !allNew {
+419				filesNeedingLog = append(filesNeedingLog, file)
+420			}
+421		}
+422	
+423		if debug {
+424			for _, file := range filesNeedingLog {
+425				log.Printf(&quot;%s,&quot;, file.Name())
+426			}
+427			fmt.Printf(&quot;\n&quot;)
+428		}
+429		if err := parseGitLog(filesNeedingLog); err != nil {
+430			log.Fatalf(&quot;Error: git log streaming failed: %v&quot;, err)
+431		}
+432		parseDiffStat(gitData.diffStat, files)
+433	
+434		// generate a diffStat graph for every file
+435		for _, file := range files {
+436			file.diffStat = makeDiffGraph(file, diffWidth)
+437		}
+438	
+439		// Sort files by name
+440		slices.SortFunc(files, func(a, b *File) int {
+441			return strings.Compare(strings.ToLower(a.Name()), strings.ToLower(b.Name()))
+442		})
+443	
+444		// Use default columns if not specified
+445		if len(formatColumns) == 0 {
+446			formatColumns = AllColumns()
+447		}
+448	
+449		maxWidth := columns(os.Stdout.Fd())
+450		if maxWidth == 0 {
+451			maxWidth = 80 // default when not a TTY
+452		}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-23-56-661Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-23-56-661Z" class="timestamp-link"><time datetime="2026-04-11T02:23:56.661Z" data-timestamp="2026-04-11T02:23:56.661Z">2026-04-11T02:23:56.661Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01TDnV9FtBUfUzu8wJFHqbrB"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 452,
+  &#34;limit&#34;: 10
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-23-56-664Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-23-56-664Z" class="timestamp-link"><time datetime="2026-04-11T02:23:56.664Z" data-timestamp="2026-04-11T02:23:56.664Z">2026-04-11T02:23:56.664Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>452		}
+453		fmt.Printf(&quot;%s%s%s\n\n&quot;, RED, gitData.currentBranch, RESET)
+454		rctx := &amp;RenderContext{
+455			GithubURL: isGithub(gitData.remotes),
+456			Dir:       must(filepath.Abs(&quot;.&quot;)),
+457			MonoHash:  monoHash,
+458			NerdFont:  nerdFont,
+459		}
+460		showColumns(os.Stdout, maxWidth, files, rctx, formatColumns)
+461	}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-24-03-031Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-24-03-031Z" class="timestamp-link"><time datetime="2026-04-11T02:24:03.031Z" data-timestamp="2026-04-11T02:24:03.031Z">2026-04-11T02:24:03.031Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now let me also check the helper functions that <code>log.Fatalf</code> — I need to convert those too:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-24-04-325Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-24-04-325Z" class="timestamp-link"><time datetime="2026-04-11T02:24:04.325Z" data-timestamp="2026-04-11T02:24:04.325Z">2026-04-11T02:24:04.325Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01CncqZdsqdajAH67FR61j2G"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;offset&#34;: 695,
+  &#34;limit&#34;: 20
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-24-04-348Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-24-04-348Z" class="timestamp-link"><time datetime="2026-04-11T02:24:04.348Z" data-timestamp="2026-04-11T02:24:04.348Z">2026-04-11T02:24:04.348Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>695				// Calculate available width for this column
+696				availableWidth := maxWidth - lineWidth
+697				colWidth := min(colWidths[col], availableWidth)
+698	
+699				// Render the column
+700				renderer := getColumnRenderer(col)
+701				renderer(out, file, colWidth, rctx)
+702				lineWidth += colWidth
+703			}
+704	
+705			// Reset any remaining formatting (like strikethrough for deleted files)
+706			if file.isDeleted {
+707				must(fmt.Fprintf(out, &quot;%s&quot;, RESET))
+708			}
+709			must(fmt.Fprintf(out, &quot;\n&quot;))
+710		}
+711	}
+712	
+713	func gitRemotes() []byte {
+714		// disable core.fsmonitor because git will run malicious executables</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-24-12-702Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-24-12-702Z" class="timestamp-link"><time datetime="2026-04-11T02:24:12.702Z" data-timestamp="2026-04-11T02:24:12.702Z">2026-04-11T02:24:12.702Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>OK, the helper functions (<code>gitRemotes</code>, <code>gitRoot</code>, <code>gitStatus</code>, <code>gitDiffStat</code>) use <code>log.Fatalf</code> but they're called inside <code>fetchGitData</code> via goroutines. Converting those to return errors would be a bigger refactor of the parallel fetch pattern. For now, let me convert just <code>main()</code> into <code>run()</code> with <code>fmt.Fprintf(os.Stderr, ...)</code> for the errors in the main flow, and leave the helper goroutine fatals as-is — they'll still terminate the process on git failures, which is reasonable behavior. We can clean those up later.</p></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-24-42-231Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-24-42-231Z" class="timestamp-link"><time datetime="2026-04-11T02:24:42.231Z" data-timestamp="2026-04-11T02:24:42.231Z">2026-04-11T02:24:42.231Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/tree-experiment/main.go has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-24-42-210Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-24-42-210Z" class="timestamp-link"><time datetime="2026-04-11T02:24:42.210Z" data-timestamp="2026-04-11T02:24:42.210Z">2026-04-11T02:24:42.210Z</time></a></div><div class="message-content"><div class="file-tool edit-tool" data-tool-id="toolu_01WXo2MK53m8GZ1QdeHcRTdg">
+<div class="file-tool-header edit-header"><span class="file-tool-icon">✏️</span> Edit <span class="file-tool-path">main.go</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/tree-experiment/main.go</div>
+<div class="truncatable"><div class="truncatable-content">
+<div class="edit-section edit-old"><div class="edit-label">−</div><pre class="edit-content">func main() {
+	argv := os.Args[1:]
+	diffWidth := 4
+	monoHash := false
+	nerdFont := false
+	changedOnly := false
+	debug := false
+	var formatColumns []Column
+	for len(argv) &gt; 0 {
+		if argv[0] == &#34;--version&#34; {
+			printVersion()
+			os.Exit(0)
+		}
+		if argv[0] == &#34;--help&#34; || argv[0] == &#34;-h&#34; {
+			usage()
+			os.Exit(0)
+		}
+		if argv[0] == &#34;--mono-hash&#34; {
+			monoHash = true
+			argv = argv[1:]
+		} else if argv[0] == &#34;--nerdfont&#34; {
+			nerdFont = true
+			argv = argv[1:]
+		} else if argv[0] == &#34;--changed-only&#34; || argv[0] == &#34;-c&#34; {
+			changedOnly = true
+			argv = argv[1:]
+		} else if strings.HasPrefix(argv[0], &#34;--diffWidth&#34;) {
+			if len(argv) == 1 {
+				if strings.Contains(argv[0], &#34;=&#34;) {
+					parts := strings.SplitN(argv[0], &#34;=&#34;, 2)
+					diffWidth = must(strconv.Atoi(parts[1]))
+				} else {
+					log.Fatalf(&#34;--diffWidth requires an argument&#34;)
+				}
+				argv = argv[1:]
+			} else {
+				diffWidth = must(strconv.Atoi(argv[1]))
+				argv = argv[2:]
+			}
+		} else if strings.HasPrefix(argv[0], &#34;--format&#34;) {
+			if len(argv) == 1 {
+				if strings.Contains(argv[0], &#34;=&#34;) {
+					parts := strings.SplitN(argv[0], &#34;=&#34;, 2)
+					formatColumns = parseFormat(parts[1])
+				} else {
+					log.Fatalf(&#34;--format requires an argument&#34;)
+				}
+				argv = argv[1:]
+			} else {
+				formatColumns = parseFormat(argv[1])
+				argv = argv[2:]
+			}
+		} else if strings.HasPrefix(argv[0], &#34;--debug&#34;) {
+			debug = true
+			argv = argv[1:]
+		} else {
+			// Non-flag argument (directory), stop parsing flags
+			break
+		}
+	}
+
+	var dir string
+	if len(argv) &gt; 0 {
+		dir = argv[0]
+
+		if err := os.Chdir(dir); err != nil {
+			log.Fatalf(&#34;Failed to change directory to %s: %v&#34;, dir, err)
+		}
+	} else {
+		dir = &#34;.&#34;
+	}
+
+	// Fetch all git data in parallel
+	gitData := fetchGitData()
+
+	// Resolve symlinks to match git&#39;s perspective. Git internally resolves
+	// symlinks when working with worktrees, so we need to do the same to
+	// ensure filepath.Rel() works correctly in fileStatus().
+	// https://github.com/llimllib/git-ls/issues/34
+	resolved := must(filepath.EvalSymlinks(must(filepath.Abs(&#34;.&#34;))))
+	curdir := must(filepath.Rel(gitData.root, resolved))
+
+	var files []*File
+	if changedOnly {
+		// In --changed-only mode, build the file list directly from git
+		// status so we can show files from subdirectories with their full
+		// relative paths (e.g. &#34;src/network/server.go&#34; not just &#34;src/&#34;)
+		files = changedFilesFromStatus(gitData.status, curdir)
+	} else {
+		osfiles, err := os.ReadDir(&#34;.&#34;)
+		if err != nil {
+			log.Fatalf(&#34;Failed to read directory %s: %v&#34;, dir, err)
+		}
+
+		for _, file := range osfiles {
+			stat, _ := os.Stat(file.Name())
+			files = append(files, &amp;File{
+				entry: file,
+				isDir: file.IsDir(),
+				isExe: !file.IsDir() &amp;&amp; stat.Mode()&amp;0o111 != 0,
+			})
+		}
+
+		fileStatus(gitData.status, files, curdir)
+
+		// Parse deleted files from git status and merge into file list
+		deletedFiles := parseDeletedFiles(gitData.status, curdir)
+		files = append(files, deletedFiles...)
+	}
+
+	// Now run git log on the files we&#39;ll show
+	// Skip git log for files that won&#39;t have history:
+	// - I: Ignored files - not tracked by git
+	// - ??: Untracked files - not in git yet
+	// - *: .git directory - git metadata, not file history
+	// - A: Newly added files
+	//   Examples: &#34;A &#34;, &#34;AM&#34;, &#34;AD&#34; - staged additions not yet committed
+	//   But &#34;M &#34;, &#34;MM&#34;, or mixed dirs like &#34;A ,M &#34; have history
+	var filesNeedingLog []*File
+	for _, file := range files {
+		if file.status == &#34;I&#34; || file.status == &#34;??&#34; || file.status == &#34;*&#34; {
+			continue
+		}
+		// Empty status means unmodified tracked file — it has history
+		if file.status == &#34;&#34; {
+			filesNeedingLog = append(filesNeedingLog, file)
+			continue
+		}
+		// Check if ALL statuses in a comma-separated list are new additions
+		// For directories, status might be &#34;A ,M &#34; if it has both new and modified files
+		allNew := true
+		for status := range strings.SplitSeq(file.status, &#34;,&#34;) {
+			status = strings.TrimSpace(status)
+			// Check if this individual status represents a file with history
+			// If first char (index) is not &#39;A&#39; and not untracked, it has history
+			if len(status) &gt; 0 &amp;&amp; status[0] != &#39;A&#39; &amp;&amp; status != &#34;??&#34; {
+				allNew = false
+				break
+			}
+		}
+		if !allNew {
+			filesNeedingLog = append(filesNeedingLog, file)
+		}
+	}
+
+	if debug {
+		for _, file := range filesNeedingLog {
+			log.Printf(&#34;%s,&#34;, file.Name())
+		}
+		fmt.Printf(&#34;\n&#34;)
+	}
+	if err := parseGitLog(filesNeedingLog); err != nil {
+		log.Fatalf(&#34;Error: git log streaming failed: %v&#34;, err)
+	}
+	parseDiffStat(gitData.diffStat, files)
+
+	// generate a diffStat graph for every file
+	for _, file := range files {
+		file.diffStat = makeDiffGraph(file, diffWidth)
+	}
+
+	// Sort files by name
+	slices.SortFunc(files, func(a, b *File) int {
+		return strings.Compare(strings.ToLower(a.Name()), strings.ToLower(b.Name()))
+	})
+
+	// Use default columns if not specified
+	if len(formatColumns) == 0 {
+		formatColumns = AllColumns()
+	}
+
+	maxWidth := columns(os.Stdout.Fd())
+	if maxWidth == 0 {
+		maxWidth = 80 // default when not a TTY
+	}
+	fmt.Printf(&#34;%s%s%s\n\n&#34;, RED, gitData.currentBranch, RESET)
+	rctx := &amp;RenderContext{
+		GithubURL: isGithub(gitData.remotes),
+		Dir:       must(filepath.Abs(&#34;.&#34;)),
+		MonoHash:  monoHash,
+		NerdFont:  nerdFont,
+	}
+	showColumns(os.Stdout, maxWidth, files, rctx, formatColumns)
+}</pre></div>
+<div class="edit-section edit-new"><div class="edit-label">+</div><pre class="edit-content">func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	argv := os.Args[1:]
+	diffWidth := 4
+	monoHash := false
+	nerdFont := false
+	changedOnly := false
+	debug := false
+	var formatColumns []Column
+	for len(argv) &gt; 0 {
+		if argv[0] == &#34;--version&#34; {
+			printVersion()
+			return 0
+		}
+		if argv[0] == &#34;--help&#34; || argv[0] == &#34;-h&#34; {
+			usage()
+			return 0
+		}
+		if argv[0] == &#34;--mono-hash&#34; {
+			monoHash = true
+			argv = argv[1:]
+		} else if argv[0] == &#34;--nerdfont&#34; {
+			nerdFont = true
+			argv = argv[1:]
+		} else if argv[0] == &#34;--changed-only&#34; || argv[0] == &#34;-c&#34; {
+			changedOnly = true
+			argv = argv[1:]
+		} else if strings.HasPrefix(argv[0], &#34;--diffWidth&#34;) {
+			if len(argv) == 1 {
+				if strings.Contains(argv[0], &#34;=&#34;) {
+					parts := strings.SplitN(argv[0], &#34;=&#34;, 2)
+					diffWidth = must(strconv.Atoi(parts[1]))
+				} else {
+					fmt.Fprintf(os.Stderr, &#34;--diffWidth requires an argument\n&#34;)
+					return 1
+				}
+				argv = argv[1:]
+			} else {
+				diffWidth = must(strconv.Atoi(argv[1]))
+				argv = argv[2:]
+			}
+		} else if strings.HasPrefix(argv[0], &#34;--format&#34;) {
+			if len(argv) == 1 {
+				if strings.Contains(argv[0], &#34;=&#34;) {
+					parts := strings.SplitN(argv[0], &#34;=&#34;, 2)
+					formatColumns = parseFormat(parts[1])
+				} else {
+					fmt.Fprintf(os.Stderr, &#34;--format requires an argument\n&#34;)
+					return 1
+				}
+				argv = argv[1:]
+			} else {
+				formatColumns = parseFormat(argv[1])
+				argv = argv[2:]
+			}
+		} else if strings.HasPrefix(argv[0], &#34;--debug&#34;) {
+			debug = true
+			argv = argv[1:]
+		} else {
+			// Non-flag argument (directory), stop parsing flags
+			break
+		}
+	}
+
+	var dir string
+	if len(argv) &gt; 0 {
+		dir = argv[0]
+
+		if err := os.Chdir(dir); err != nil {
+			fmt.Fprintf(os.Stderr, &#34;Failed to change directory to %s: %v\n&#34;, dir, err)
+			return 1
+		}
+	} else {
+		dir = &#34;.&#34;
+	}
+
+	// Fetch all git data in parallel
+	gitData := fetchGitData()
+
+	// Resolve symlinks to match git&#39;s perspective. Git internally resolves
+	// symlinks when working with worktrees, so we need to do the same to
+	// ensure filepath.Rel() works correctly in fileStatus().
+	// https://github.com/llimllib/git-ls/issues/34
+	resolved := must(filepath.EvalSymlinks(must(filepath.Abs(&#34;.&#34;))))
+	curdir := must(filepath.Rel(gitData.root, resolved))
+
+	var files []*File
+	if changedOnly {
+		// In --changed-only mode, build the file list directly from git
+		// status so we can show files from subdirectories with their full
+		// relative paths (e.g. &#34;src/network/server.go&#34; not just &#34;src/&#34;)
+		files = changedFilesFromStatus(gitData.status, curdir)
+	} else {
+		osfiles, err := os.ReadDir(&#34;.&#34;)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, &#34;Failed to read directory %s: %v\n&#34;, dir, err)
+			return 1
+		}
+
+		for _, file := range osfiles {
+			stat, _ := os.Stat(file.Name())
+			files = append(files, &amp;File{
+				entry: file,
+				isDir: file.IsDir(),
+				isExe: !file.IsDir() &amp;&amp; stat.Mode()&amp;0o111 != 0,
+			})
+		}
+
+		fileStatus(gitData.status, files, curdir)
+
+		// Parse deleted files from git status and merge into file list
+		deletedFiles := parseDeletedFiles(gitData.status, curdir)
+		files = append(files, deletedFiles...)
+	}
+
+	// Now run git log on the files we&#39;ll show
+	// Skip git log for files that won&#39;t have history:
+	// - I: Ignored files - not tracked by git
+	// - ??: Untracked files - not in git yet
+	// - *: .git directory - git metadata, not file history
+	// - A: Newly added files
+	//   Examples: &#34;A &#34;, &#34;AM&#34;, &#34;AD&#34; - staged additions not yet committed
+	//   But &#34;M &#34;, &#34;MM&#34;, or mixed dirs like &#34;A ,M &#34; have history
+	var filesNeedingLog []*File
+	for _, file := range files {
+		if file.status == &#34;I&#34; || file.status == &#34;??&#34; || file.status == &#34;*&#34; {
+			continue
+		}
+		// Empty status means unmodified tracked file — it has history
+		if file.status == &#34;&#34; {
+			filesNeedingLog = append(filesNeedingLog, file)
+			continue
+		}
+		// Check if ALL statuses in a comma-separated list are new additions
+		// For directories, status might be &#34;A ,M &#34; if it has both new and modified files
+		allNew := true
+		for status := range strings.SplitSeq(file.status, &#34;,&#34;) {
+			status = strings.TrimSpace(status)
+			// Check if this individual status represents a file with history
+			// If first char (index) is not &#39;A&#39; and not untracked, it has history
+			if len(status) &gt; 0 &amp;&amp; status[0] != &#39;A&#39; &amp;&amp; status != &#34;??&#34; {
+				allNew = false
+				break
+			}
+		}
+		if !allNew {
+			filesNeedingLog = append(filesNeedingLog, file)
+		}
+	}
+
+	if debug {
+		for _, file := range filesNeedingLog {
+			fmt.Fprintf(os.Stderr, &#34;%s,&#34;, file.Name())
+		}
+		fmt.Printf(&#34;\n&#34;)
+	}
+	if err := parseGitLog(filesNeedingLog); err != nil {
+		fmt.Fprintf(os.Stderr, &#34;Error: git log streaming failed: %v\n&#34;, err)
+		return 1
+	}
+	parseDiffStat(gitData.diffStat, files)
+
+	// generate a diffStat graph for every file
+	for _, file := range files {
+		file.diffStat = makeDiffGraph(file, diffWidth)
+	}
+
+	// Sort files by name
+	slices.SortFunc(files, func(a, b *File) int {
+		return strings.Compare(strings.ToLower(a.Name()), strings.ToLower(b.Name()))
+	})
+
+	// Use default columns if not specified
+	if len(formatColumns) == 0 {
+		formatColumns = AllColumns()
+	}
+
+	maxWidth := columns(os.Stdout.Fd())
+	if maxWidth == 0 {
+		maxWidth = 80 // default when not a TTY
+	}
+	fmt.Printf(&#34;%s%s%s\n\n&#34;, RED, gitData.currentBranch, RESET)
+	rctx := &amp;RenderContext{
+		GithubURL: isGithub(gitData.remotes),
+		Dir:       must(filepath.Abs(&#34;.&#34;)),
+		MonoHash:  monoHash,
+		NerdFont:  nerdFont,
+	}
+	showColumns(os.Stdout, maxWidth, files, rctx, formatColumns)
+	return 0
+}</pre></div>
+</div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-24-49-293Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-24-49-293Z" class="timestamp-link"><time datetime="2026-04-11T02:24:49.293Z" data-timestamp="2026-04-11T02:24:49.293Z">2026-04-11T02:24:49.293Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now I can remove the <code>log</code> import since we no longer use it in the main flow. Let me check if it's still used elsewhere:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-24-49-935Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-24-49-935Z" class="timestamp-link"><time datetime="2026-04-11T02:24:49.935Z" data-timestamp="2026-04-11T02:24:49.935Z">2026-04-11T02:24:49.935Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01AYsQZqvtpJ6yAyzy2kRX3H"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;log\\.&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main.go&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;,
+  &#34;-n&#34;: true
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-24-49-984Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-24-49-984Z" class="timestamp-link"><time datetime="2026-04-11T02:24:49.984Z" data-timestamp="2026-04-11T02:24:49.984Z">2026-04-11T02:24:49.984Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>730:		log.Fatalf(&quot;Failed to get git status: %v&quot;, err)
+876:		log.Fatalf(&quot;Failed to get git status: %v&quot;, err)
+887:		log.Fatalf(&quot;Failed to get git status: %v&quot;, err)
+1157:		log.Fatalf(&quot;Diffstat error: %v&quot;, err)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-24-54-543Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-24-54-543Z" class="timestamp-link"><time datetime="2026-04-11T02:24:54.543Z" data-timestamp="2026-04-11T02:24:54.543Z">2026-04-11T02:24:54.543Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Still used in the helper functions — leave <code>log</code> imported. Let me build:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-24-55-463Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-24-55-463Z" class="timestamp-link"><time datetime="2026-04-11T02:24:55.463Z" data-timestamp="2026-04-11T02:24:55.463Z">2026-04-11T02:24:55.463Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01ULUSZzpK9ULZFCrwtjJFnp">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Build after refactor</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go build ./... 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-24-55-839Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-24-55-839Z" class="timestamp-link"><time datetime="2026-04-11T02:24:55.839Z" data-timestamp="2026-04-11T02:24:55.839Z">2026-04-11T02:24:55.839Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>[rerun: b19]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-24-59-659Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-24-59-659Z" class="timestamp-link"><time datetime="2026-04-11T02:24:59.659Z" data-timestamp="2026-04-11T02:24:59.659Z">2026-04-11T02:24:59.659Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01QVdtYqVJEZBYW5yd8pmc77">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Run tests</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go test ./... 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-25-01-053Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-25-01-053Z" class="timestamp-link"><time datetime="2026-04-11T02:25:01.053Z" data-timestamp="2026-04-11T02:25:01.053Z">2026-04-11T02:25:01.053Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>ok  	github.com/llimllib/git-ls	1.025s
+[rerun: b20]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-25-05-212Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-25-05-212Z" class="timestamp-link"><time datetime="2026-04-11T02:25:05.212Z" data-timestamp="2026-04-11T02:25:05.212Z">2026-04-11T02:25:05.212Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Let me also quickly test <code>NO_COLOR</code>:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-25-06-746Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-25-06-746Z" class="timestamp-link"><time datetime="2026-04-11T02:25:06.746Z" data-timestamp="2026-04-11T02:25:06.746Z">2026-04-11T02:25:06.746Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01LaSjLimD4LGVKkSEfxjGDv">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Test NO_COLOR output</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">cd /tmp/claude/test-tree &amp;&amp; NO_COLOR=1 /Users/llimllib/code/git-ls/tree-experiment/git-ls --changed-only 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-25-07-075Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-25-07-075Z" class="timestamp-link"><time datetime="2026-04-11T02:25:07.075Z" data-timestamp="2026-04-11T02:25:07.075Z">2026-04-11T02:25:07.075Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>On branch main
+
+ M +   ]8;;file://adama/tmp/claude/test-tree/README.md\README.md]8;;\             c5f36b1 2026-04-10 Test initial commit
+ M +   ]8;;file://adama/tmp/claude/test-tree/src/network/server.go\src/network/server.go]8;;\ c5f36b1 2026-04-10 Test initial commit
+ M +   ]8;;file://adama/tmp/claude/test-tree/src/network/tork.go\src/network/tork.go]8;;\   c5f36b1 2026-04-10 Test initial commit
+MM ++- ]8;;file://adama/tmp/claude/test-tree/src/trimble/alpha.go\src/trimble/alpha.go]8;;\  c5f36b1 2026-04-10 Test initial commit
+A  +   ]8;;file://adama/tmp/claude/test-tree/src/trimble/bananas\src/trimble/bananas]8;;\
+Shell cwd was reset to /Users/llimllib/code/git-ls/tree-experiment
+[rerun: b21]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-25-12-361Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-25-12-361Z" class="timestamp-link"><time datetime="2026-04-11T02:25:12.361Z" data-timestamp="2026-04-11T02:25:12.361Z">2026-04-11T02:25:12.361Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>No color codes — just the hyperlink OSC 8 sequences remain, as intended. Now let me set up <code>testscript</code>. First, add the dependency:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-25-13-042Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-25-13-042Z" class="timestamp-link"><time datetime="2026-04-11T02:25:13.042Z" data-timestamp="2026-04-11T02:25:13.042Z">2026-04-11T02:25:13.042Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_017jyr6VzFJTBbeSBMfq8R5f">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Add testscript dependency</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go get github.com/rogpeppe/go-testscript/v2 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-25-15-913Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-25-15-913Z" class="timestamp-link"><time datetime="2026-04-11T02:25:15.913Z" data-timestamp="2026-04-11T02:25:15.913Z">2026-04-11T02:25:15.913Z</time></a></div><div class="message-content"><div class="tool-result tool-error"><div class="truncatable"><div class="truncatable-content"><pre>Exit code 1
+go: module github.com/rogpeppe/go-testscript/v2: git ls-remote -q https://github.com/rogpeppe/go-testscript in /Users/llimllib/go/pkg/mod/cache/vcs/053267290b3ee57dc17487c9313e8bf5fcf5c0acec76f09cd13f94ee7c638ce0: exit status 128:
+	remote: Repository not found.
+	fatal: repository &#x27;https://github.com/rogpeppe/go-testscript/&#x27; not found
+[rerun: b22]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-25-19-733Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-25-19-733Z" class="timestamp-link"><time datetime="2026-04-11T02:25:19.733Z" data-timestamp="2026-04-11T02:25:19.733Z">2026-04-11T02:25:19.733Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Hmm, let me find the right module path:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-25-20-653Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-25-20-653Z" class="timestamp-link"><time datetime="2026-04-11T02:25:20.653Z" data-timestamp="2026-04-11T02:25:20.653Z">2026-04-11T02:25:20.653Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_013t6oRAjkCkmHKJCBuekdzm">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Try testscript without v2</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go get github.com/rogpeppe/go-testscript 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-25-21-666Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-25-21-666Z" class="timestamp-link"><time datetime="2026-04-11T02:25:21.666Z" data-timestamp="2026-04-11T02:25:21.666Z">2026-04-11T02:25:21.666Z</time></a></div><div class="message-content"><div class="tool-result tool-error"><div class="truncatable"><div class="truncatable-content"><pre>Exit code 1
+go: module github.com/rogpeppe/go-testscript: git ls-remote -q origin in /Users/llimllib/go/pkg/mod/cache/vcs/053267290b3ee57dc17487c9313e8bf5fcf5c0acec76f09cd13f94ee7c638ce0: exit status 128:
+	remote: Repository not found.
+	fatal: repository &#x27;https://github.com/rogpeppe/go-testscript/&#x27; not found
+[rerun: b23]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-25-27-104Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-25-27-104Z" class="timestamp-link"><time datetime="2026-04-11T02:25:27.104Z" data-timestamp="2026-04-11T02:25:27.104Z">2026-04-11T02:25:27.104Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>That repo must have moved. It's now part of the Go tools:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-25-27-956Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-25-27-956Z" class="timestamp-link"><time datetime="2026-04-11T02:25:27.956Z" data-timestamp="2026-04-11T02:25:27.956Z">2026-04-11T02:25:27.956Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01Q38D9n6xQs1Aefxw1DWWwZ">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Try go-internal/testscript</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go get github.com/rogpeppe/go-internal/testscript 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-25-30-194Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-25-30-194Z" class="timestamp-link"><time datetime="2026-04-11T02:25:30.194Z" data-timestamp="2026-04-11T02:25:30.194Z">2026-04-11T02:25:30.194Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>go: downloading golang.org/x/sys v0.26.0
+go: downloading golang.org/x/tools v0.26.0
+go: added github.com/rogpeppe/go-internal v1.14.1
+go: added golang.org/x/sys v0.26.0
+go: added golang.org/x/tools v0.26.0
+[rerun: b24]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-25-34-778Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-25-34-778Z" class="timestamp-link"><time datetime="2026-04-11T02:25:34.778Z" data-timestamp="2026-04-11T02:25:34.778Z">2026-04-11T02:25:34.778Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now let me create the testscript infrastructure and tests. First, the test harness:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-25-36-526Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-25-36-526Z" class="timestamp-link"><time datetime="2026-04-11T02:25:36.526Z" data-timestamp="2026-04-11T02:25:36.526Z">2026-04-11T02:25:36.526Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_012c74cStnqL3TuXmoXghP67">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Check if testdata exists</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">ls /Users/llimllib/code/git-ls/tree-experiment/testdata 2&gt;&amp;1 || echo &#34;no testdata dir&#34;</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-25-36-612Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-25-36-612Z" class="timestamp-link"><time datetime="2026-04-11T02:25:36.612Z" data-timestamp="2026-04-11T02:25:36.612Z">2026-04-11T02:25:36.612Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>gls: cannot access &#x27;/Users/llimllib/code/git-ls/tree-experiment/testdata&#x27;: No such file or directory
+no testdata dir
+[rerun: b25]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-25-41-114Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-25-41-114Z" class="timestamp-link"><time datetime="2026-04-11T02:25:41.114Z" data-timestamp="2026-04-11T02:25:41.114Z">2026-04-11T02:25:41.114Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_015KA6WTEQE3c7d7Tb6fgADf">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Create testdata/scripts directory</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">mkdir -p /Users/llimllib/code/git-ls/tree-experiment/testdata/scripts</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-25-41-178Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-25-41-178Z" class="timestamp-link"><time datetime="2026-04-11T02:25:41.178Z" data-timestamp="2026-04-11T02:25:41.178Z">2026-04-11T02:25:41.178Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>[rerun: b26]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-25-45-661Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-25-45-661Z" class="timestamp-link"><time datetime="2026-04-11T02:25:45.661Z" data-timestamp="2026-04-11T02:25:45.661Z">2026-04-11T02:25:45.661Z</time></a></div><div class="message-content"><div class="file-tool write-tool" data-tool-id="toolu_019Vhn1JLiN6tXWxyKTuNayq">
+<div class="file-tool-header write-header"><span class="file-tool-icon">📝</span> Write <span class="file-tool-path">script_test.go</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/tree-experiment/script_test.go</div>
+<div class="truncatable"><div class="truncatable-content"><pre class="file-content">package main
+
+import (
+	&#34;os&#34;
+	&#34;testing&#34;
+
+	&#34;github.com/rogpeppe/go-internal/testscript&#34;
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testscript.RunMain(m, map[string]func() int{
+		&#34;git-ls&#34;: run,
+	}))
+}
+
+func TestScript(t *testing.T) {
+	testscript.Run(t, testscript.Params{
+		Dir: &#34;testdata/scripts&#34;,
+	})
+}
+</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-25-45-695Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-25-45-695Z" class="timestamp-link"><time datetime="2026-04-11T02:25:45.695Z" data-timestamp="2026-04-11T02:25:45.695Z">2026-04-11T02:25:45.695Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>File created successfully at: /Users/llimllib/code/git-ls/tree-experiment/script_test.go (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-25-51-393Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-25-51-393Z" class="timestamp-link"><time datetime="2026-04-11T02:25:51.393Z" data-timestamp="2026-04-11T02:25:51.393Z">2026-04-11T02:25:51.393Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Wait — there's already a <code>TestMain</code> in the existing test file, which would conflict. Let me check:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-25-51-825Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-25-51-825Z" class="timestamp-link"><time datetime="2026-04-11T02:25:51.825Z" data-timestamp="2026-04-11T02:25:51.825Z">2026-04-11T02:25:51.825Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01CcG1UfFsXJP2zAfc9NTAFD"><div class="tool-header"><span class="tool-icon">⚙</span> Grep</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;pattern&#34;: &#34;func TestMain&#34;,
+  &#34;path&#34;: &#34;/Users/llimllib/code/git-ls/tree-experiment/main_test.go&#34;,
+  &#34;output_mode&#34;: &#34;content&#34;
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-25-51-874Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-25-51-874Z" class="timestamp-link"><time datetime="2026-04-11T02:25:51.874Z" data-timestamp="2026-04-11T02:25:51.874Z">2026-04-11T02:25:51.874Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>No matches found</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-25-58-009Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-25-58-009Z" class="timestamp-link"><time datetime="2026-04-11T02:25:58.009Z" data-timestamp="2026-04-11T02:25:58.009Z">2026-04-11T02:25:58.009Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>No conflict, good. And the deprecation note says to use <code>Main</code> instead. Let me update:</p></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-25-59-509Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-25-59-509Z" class="timestamp-link"><time datetime="2026-04-11T02:25:59.509Z" data-timestamp="2026-04-11T02:25:59.509Z">2026-04-11T02:25:59.509Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/tree-experiment/script_test.go has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-25-59-467Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-25-59-467Z" class="timestamp-link"><time datetime="2026-04-11T02:25:59.467Z" data-timestamp="2026-04-11T02:25:59.467Z">2026-04-11T02:25:59.467Z</time></a></div><div class="message-content"><div class="file-tool write-tool" data-tool-id="toolu_01P1bG2evk55cm7nHyyXMLnf">
+<div class="file-tool-header write-header"><span class="file-tool-icon">📝</span> Write <span class="file-tool-path">script_test.go</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/tree-experiment/script_test.go</div>
+<div class="truncatable"><div class="truncatable-content"><pre class="file-content">package main
+
+import (
+	&#34;os&#34;
+	&#34;testing&#34;
+
+	&#34;github.com/rogpeppe/go-internal/testscript&#34;
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testscript.RunMain(m, map[string]func() int{
+		&#34;git-ls&#34;: run,
+	}))
+}
+
+func TestScript(t *testing.T) {
+	testscript.Run(t, testscript.Params{
+		Dir: &#34;testdata/scripts&#34;,
+	})
+}
+</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-26-04-481Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-26-04-481Z" class="timestamp-link"><time datetime="2026-04-11T02:26:04.481Z" data-timestamp="2026-04-11T02:26:04.481Z">2026-04-11T02:26:04.481Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Actually let me check what <code>Main</code> looks like — the deprecation suggests it but I want to get the signature right:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-26-05-816Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-26-05-816Z" class="timestamp-link"><time datetime="2026-04-11T02:26:05.816Z" data-timestamp="2026-04-11T02:26:05.816Z">2026-04-11T02:26:05.816Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_013sv4FP1NU2Q1Dc53Mneguf">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Check Main function signature</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">grep -A5 &#39;func Main&#39; $(go env GOMODCACHE)/github.com/rogpeppe/go-internal@v1.14.1/testscript/testscript.go 2&gt;&amp;1 | head -20</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-26-05-890Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-26-05-890Z" class="timestamp-link"><time datetime="2026-04-11T02:26:05.890Z" data-timestamp="2026-04-11T02:26:05.890Z">2026-04-11T02:26:05.890Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>[rerun: b27]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-26-11-699Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-26-11-699Z" class="timestamp-link"><time datetime="2026-04-11T02:26:11.699Z" data-timestamp="2026-04-11T02:26:11.699Z">2026-04-11T02:26:11.699Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01QN2kbtjxTxRZebFbxqF4J9">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Check Main function signature</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">grep -B2 -A10 &#39;func Main&#39; $(go env GOMODCACHE)/github.com/rogpeppe/go-internal@v1.14.1/testscript/testscript.go 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-26-11-759Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-26-11-759Z" class="timestamp-link"><time datetime="2026-04-11T02:26:11.759Z" data-timestamp="2026-04-11T02:26:11.759Z">2026-04-11T02:26:11.759Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>[rerun: b28]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-26-15-924Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-26-15-924Z" class="timestamp-link"><time datetime="2026-04-11T02:26:15.924Z" data-timestamp="2026-04-11T02:26:15.924Z">2026-04-11T02:26:15.924Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Empty output — let me check differently:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-26-16-874Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-26-16-874Z" class="timestamp-link"><time datetime="2026-04-11T02:26:16.874Z" data-timestamp="2026-04-11T02:26:16.874Z">2026-04-11T02:26:16.874Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01V7f9N849PE4sAs7fGcTb3k">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Find Main function</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">grep -rn &#39;func Main\b&#39; $(go env GOMODCACHE)/github.com/rogpeppe/go-internal@v1.14.1/testscript/ 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-26-16-945Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-26-16-945Z" class="timestamp-link"><time datetime="2026-04-11T02:26:16.945Z" data-timestamp="2026-04-11T02:26:16.945Z">2026-04-11T02:26:16.945Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>/Users/llimllib/go/pkg/mod/github.com/rogpeppe/go-internal@v1.14.1/testscript/exe.go:40:func Main(m TestingM, commands map[string]func()) {
+[rerun: b29]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-26-23-314Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-26-23-314Z" class="timestamp-link"><time datetime="2026-04-11T02:26:23.314Z" data-timestamp="2026-04-11T02:26:23.314Z">2026-04-11T02:26:23.314Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p><code>func Main(m TestingM, commands map[string]func())</code> — takes <code>func()</code> not <code>func() int</code>. That means we need a wrapper. But wait, how does it get the exit code? Let me check a bit more:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-26-23-970Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-26-23-970Z" class="timestamp-link"><time datetime="2026-04-11T02:26:23.970Z" data-timestamp="2026-04-11T02:26:23.970Z">2026-04-11T02:26:23.970Z</time></a></div><div class="message-content">
+<div class="tool-use" data-tool-id="toolu_01XYm5GpyDVeD4SAynsi93Xh"><div class="tool-header"><span class="tool-icon">⚙</span> Read</div><div class="truncatable"><div class="truncatable-content"><pre class="json">{
+  &#34;file_path&#34;: &#34;/Users/llimllib/go/pkg/mod/github.com/rogpeppe/go-internal@v1.14.1/testscript/exe.go&#34;,
+  &#34;offset&#34;: 25,
+  &#34;limit&#34;: 40
+}</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-26-23-999Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-26-23-999Z" class="timestamp-link"><time datetime="2026-04-11T02:26:23.999Z" data-timestamp="2026-04-11T02:26:23.999Z">2026-04-11T02:26:23.999Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>25	
+26	// Main should be called within a TestMain function to allow
+27	// subcommands to be run in the testscript context.
+28	// Main always calls [os.Exit], so it does not return back to the caller.
+29	//
+30	// The commands map holds the set of command names, each
+31	// with an associated run function which may call os.Exit.
+32	//
+33	// When Run is called, these commands are installed as regular commands in the shell
+34	// path, so can be invoked with &quot;exec&quot; or via any other command (for example a shell script).
+35	//
+36	// For backwards compatibility, the commands declared in the map can be run
+37	// without &quot;exec&quot; - that is, &quot;foo&quot; will behave like &quot;exec foo&quot;.
+38	// This can be disabled with Params.RequireExplicitExec to keep consistency
+39	// across test scripts, and to keep separate process executions explicit.
+40	func Main(m TestingM, commands map[string]func()) {
+41		// Depending on os.Args[0], this is either the top-level execution of
+42		// the test binary by &quot;go test&quot;, or the execution of one of the provided
+43		// commands via &quot;foo&quot; or &quot;exec foo&quot;.
+44	
+45		cmdName := filepath.Base(os.Args[0])
+46		if runtime.GOOS == &quot;windows&quot; {
+47			cmdName = strings.TrimSuffix(cmdName, &quot;.exe&quot;)
+48		}
+49		mainf := commands[cmdName]
+50		if mainf == nil {
+51			// Unknown command; this is just the top-level execution of the
+52			// test binary by &quot;go test&quot;.
+53			os.Exit(testingMRun(m, commands))
+54		}
+55		// The command being registered is being invoked, so run it, then exit.
+56		os.Args[0] = cmdName
+57		mainf()
+58		os.Exit(0)
+59	}
+60	
+61	// testingMRun exists just so that we can use `defer`, given that [Main] above uses [os.Exit].
+62	func testingMRun(m TestingM, commands map[string]func()) int {
+63		// Set up all commands in a directory, added in $PATH.
+64		tmpdir, err := os.MkdirTemp(&quot;&quot;, &quot;testscript-main&quot;)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-26-30-184Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-26-30-184Z" class="timestamp-link"><time datetime="2026-04-11T02:26:30.184Z" data-timestamp="2026-04-11T02:26:30.184Z">2026-04-11T02:26:30.184Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>OK so with <code>Main</code>, the command function calls <code>os.Exit</code> itself if it wants a non-zero exit, and if it returns normally it exits 0. Since our <code>main()</code> already does <code>os.Exit(run())</code>, I can use the same pattern:</p></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-26-31-845Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-26-31-845Z" class="timestamp-link"><time datetime="2026-04-11T02:26:31.845Z" data-timestamp="2026-04-11T02:26:31.845Z">2026-04-11T02:26:31.845Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/tree-experiment/script_test.go has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-26-31-823Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-26-31-823Z" class="timestamp-link"><time datetime="2026-04-11T02:26:31.823Z" data-timestamp="2026-04-11T02:26:31.823Z">2026-04-11T02:26:31.823Z</time></a></div><div class="message-content"><div class="file-tool write-tool" data-tool-id="toolu_01HtyoBNzQdFMemaTTUF6bHw">
+<div class="file-tool-header write-header"><span class="file-tool-icon">📝</span> Write <span class="file-tool-path">script_test.go</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/tree-experiment/script_test.go</div>
+<div class="truncatable"><div class="truncatable-content"><pre class="file-content">package main
+
+import (
+	&#34;os&#34;
+	&#34;testing&#34;
+
+	&#34;github.com/rogpeppe/go-internal/testscript&#34;
+)
+
+func TestMain(m *testing.M) {
+	testscript.Main(m, map[string]func(){
+		&#34;git-ls&#34;: func() { os.Exit(run()) },
+	})
+}
+
+func TestScript(t *testing.T) {
+	testscript.Run(t, testscript.Params{
+		Dir: &#34;testdata/scripts&#34;,
+	})
+}
+</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-26-36-531Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-26-36-531Z" class="timestamp-link"><time datetime="2026-04-11T02:26:36.531Z" data-timestamp="2026-04-11T02:26:36.531Z">2026-04-11T02:26:36.531Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now let me write the test scripts. First, a test for the <code>--changed-only</code> with subdirectory paths:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-26-45-275Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-26-45-275Z" class="timestamp-link"><time datetime="2026-04-11T02:26:45.275Z" data-timestamp="2026-04-11T02:26:45.275Z">2026-04-11T02:26:45.275Z</time></a></div><div class="message-content"><div class="file-tool write-tool" data-tool-id="toolu_01MzyUagSkRPGTECjza6qRMp">
+<div class="file-tool-header write-header"><span class="file-tool-icon">📝</span> Write <span class="file-tool-path">changed_only_paths.txtar</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/tree-experiment/testdata/scripts/changed_only_paths.txtar</div>
+<div class="truncatable"><div class="truncatable-content"><pre class="file-content"># --changed-only shows full relative paths for files in subdirectories
+env NO_COLOR=1
+env HOME=$WORK
+
+exec git init -b main
+exec git config user.email test@test.com
+exec git config user.name Test
+
+# Create files in nested directories
+mkdir src/network
+mkdir src/trimble
+cp README.md README.md
+cp server.go src/network/server.go
+cp tork.go src/network/tork.go
+cp alpha.go src/trimble/alpha.go
+
+exec git add .
+exec git commit -m &#39;initial commit&#39;
+
+# Modify files at different levels
+cp modified-readme.txt README.md
+cp modified-server.go src/network/server.go
+cp modified-tork.go src/network/tork.go
+
+# From repo root, --changed-only should show full relative paths
+exec git-ls --changed-only
+stdout &#39;README\.md&#39;
+stdout &#39;src/network/server\.go&#39;
+stdout &#39;src/network/tork\.go&#39;
+! stdout &#39;src/trimble&#39;
+
+# From a subdirectory, only files at or below that dir should appear
+cd src
+exec git-ls --changed-only
+stdout &#39;network/server\.go&#39;
+stdout &#39;network/tork\.go&#39;
+! stdout &#39;README&#39;
+! stdout &#39;trimble&#39;
+
+# From a leaf directory, just basenames
+cd network
+exec git-ls --changed-only
+stdout &#39;server\.go&#39;
+stdout &#39;tork\.go&#39;
+! stdout &#39;src&#39;
+
+-- README.md --
+# readme
+-- modified-readme.txt --
+# updated readme
+-- server.go --
+package network
+-- modified-server.go --
+package network // modified server
+-- tork.go --
+package network
+-- modified-tork.go --
+package network // modified tork
+-- alpha.go --
+package trimble
+</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-26-45-310Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-26-45-310Z" class="timestamp-link"><time datetime="2026-04-11T02:26:45.310Z" data-timestamp="2026-04-11T02:26:45.310Z">2026-04-11T02:26:45.310Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>File created successfully at: /Users/llimllib/code/git-ls/tree-experiment/testdata/scripts/changed_only_paths.txtar (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-26-51-332Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-26-51-332Z" class="timestamp-link"><time datetime="2026-04-11T02:26:51.332Z" data-timestamp="2026-04-11T02:26:51.332Z">2026-04-11T02:26:51.332Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Now a test for basic <code>--changed-only</code> filtering (the existing behavior that should still work):</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-26-54-139Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-26-54-139Z" class="timestamp-link"><time datetime="2026-04-11T02:26:54.139Z" data-timestamp="2026-04-11T02:26:54.139Z">2026-04-11T02:26:54.139Z</time></a></div><div class="message-content"><div class="file-tool write-tool" data-tool-id="toolu_01BjS2U3haMoNApiaV6k6dTP">
+<div class="file-tool-header write-header"><span class="file-tool-icon">📝</span> Write <span class="file-tool-path">changed_only_filter.txtar</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/tree-experiment/testdata/scripts/changed_only_filter.txtar</div>
+<div class="truncatable"><div class="truncatable-content"><pre class="file-content"># --changed-only should only show files with git status changes
+env NO_COLOR=1
+env HOME=$WORK
+
+exec git init -b main
+exec git config user.email test@test.com
+exec git config user.name Test
+
+cp clean.go clean.go
+cp modified.go modified.go
+exec git add .
+exec git commit -m &#39;initial commit&#39;
+
+# Modify one file, leave the other untouched
+cp modified-v2.go modified.go
+
+exec git-ls --changed-only
+stdout &#39;modified\.go&#39;
+! stdout &#39;clean\.go&#39;
+
+-- clean.go --
+package main
+-- modified.go --
+package main // v1
+-- modified-v2.go --
+package main // v2
+</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-26-54-173Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-26-54-173Z" class="timestamp-link"><time datetime="2026-04-11T02:26:54.173Z" data-timestamp="2026-04-11T02:26:54.173Z">2026-04-11T02:26:54.173Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>File created successfully at: /Users/llimllib/code/git-ls/tree-experiment/testdata/scripts/changed_only_filter.txtar (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-26-58-293Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-26-58-293Z" class="timestamp-link"><time datetime="2026-04-11T02:26:58.293Z" data-timestamp="2026-04-11T02:26:58.293Z">2026-04-11T02:26:58.293Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>And a basic test for normal (non <code>--changed-only</code>) mode:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-27-00-525Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-27-00-525Z" class="timestamp-link"><time datetime="2026-04-11T02:27:00.525Z" data-timestamp="2026-04-11T02:27:00.525Z">2026-04-11T02:27:00.525Z</time></a></div><div class="message-content"><div class="file-tool write-tool" data-tool-id="toolu_014LqjDQ1dC1GtXNC1aLXEjq">
+<div class="file-tool-header write-header"><span class="file-tool-icon">📝</span> Write <span class="file-tool-path">basic.txtar</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/tree-experiment/testdata/scripts/basic.txtar</div>
+<div class="truncatable"><div class="truncatable-content"><pre class="file-content"># Basic git-ls should list current directory entries
+env NO_COLOR=1
+env HOME=$WORK
+
+exec git init -b main
+exec git config user.email test@test.com
+exec git config user.name Test
+
+cp main.go main.go
+mkdir src
+cp server.go src/server.go
+exec git add .
+exec git commit -m &#39;initial commit&#39;
+
+exec git-ls
+stdout &#39;main\.go&#39;
+# Directories should show as directory name, not expanded contents
+stdout &#39;src&#39;
+! stdout &#39;server\.go&#39;
+
+-- main.go --
+package main
+-- server.go --
+package server
+</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-27-00-554Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-27-00-554Z" class="timestamp-link"><time datetime="2026-04-11T02:27:00.554Z" data-timestamp="2026-04-11T02:27:00.554Z">2026-04-11T02:27:00.554Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>File created successfully at: /Users/llimllib/code/git-ls/tree-experiment/testdata/scripts/basic.txtar (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-27-04-440Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-27-04-440Z" class="timestamp-link"><time datetime="2026-04-11T02:27:04.440Z" data-timestamp="2026-04-11T02:27:04.440Z">2026-04-11T02:27:04.440Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Let me run the tests:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-27-05-366Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-27-05-366Z" class="timestamp-link"><time datetime="2026-04-11T02:27:05.366Z" data-timestamp="2026-04-11T02:27:05.366Z">2026-04-11T02:27:05.366Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01KafvxiEWq8KHpPBDFkse1Y">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Run testscript tests</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go test -run TestScript -v 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-27-07-583Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-27-07-583Z" class="timestamp-link"><time datetime="2026-04-11T02:27:07.583Z" data-timestamp="2026-04-11T02:27:07.583Z">2026-04-11T02:27:07.583Z</time></a></div><div class="message-content"><div class="tool-result tool-error"><div class="truncatable"><div class="truncatable-content"><pre>Exit code 1
+=== RUN   TestScript
+=== RUN   TestScript/basic
+=== PAUSE TestScript/basic
+=== RUN   TestScript/changed_only_filter
+=== PAUSE TestScript/changed_only_filter
+=== RUN   TestScript/changed_only_paths
+=== PAUSE TestScript/changed_only_paths
+=== CONT  TestScript/basic
+=== CONT  TestScript/changed_only_paths
+=== CONT  TestScript/changed_only_filter
+    testscript.go:584: WORK=$WORK
+        PATH=/var/folders/wd/0tvjmfdn4zl71ds6q1v6t3600000gn/T/testscript-main3816863872/bin:/Users/llimllib/.local/share/mise/installs/go/1.25.5/bin:/Users/llimllib/.local/share/mise/installs/go/1.25.5/bin:/Users/llimllib/.local/share/mise/installs/node/24.8.0/bin:/Users/llimllib/.local/share/mise/installs/python/3.14.3/bin:/Users/llimllib/.cargo/bin:/Users/llimllib/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/llimllib/go/bin:/Users/llimllib/Library/pnpm:/Users/llimllib/.cache/.bun/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/kitty.app/Contents/MacOS:/opt/homebrew/opt/fzf/bin:/Users/llimllib/.claude/plugins/cache/claude-plugins-official/rust-analyzer-lsp/1.0.0/bin:/Users/llimllib/.claude/plugins/cache/claude-plugins-official/gopls-lsp/1.0.0/bin
+        GOTRACEBACK=system
+        HOME=/no-home
+        TMPDIR=$WORK/.tmp
+        devnull=/dev/null
+        /=/
+        :=:
+        $=$
+        exe=
+        
+        # --changed-only should only show files with git status changes (0.127s)
+        &gt; env NO_COLOR=1
+        &gt; env HOME=$WORK
+        &gt; exec git init -b main
+        [stdout]
+        Initialized empty Git repository in $WORK/.git/
+        &gt; exec git config user.email test@test.com
+        &gt; exec git config user.name Test
+        &gt; cp clean.go clean.go
+        &gt; cp modified.go modified.go
+        &gt; exec git add .
+        &gt; exec git commit -m &#x27;initial commit&#x27;
+        [stdout]
+        [main (root-commit) 982ab6b] initial commit
+         3 files changed, 3 insertions(+)
+         create mode 100644 clean.go
+         create mode 100644 modified-v2.go
+         create mode 100644 modified.go
+        # Modify one file, leave the other untouched (0.295s)
+        &gt; cp modified-v2.go modified.go
+        &gt; exec git-ls --changed-only
+        [stdout]
+        On branch main
+        
+         M +- ]8;;file://adama$WORK/modified.go\modified.go]8;;\ 982ab6b 2026-04-10 Test initial commit
+        &gt; stdout &#x27;modified\.go&#x27;
+        &gt; ! stdout &#x27;clean\.go&#x27;
+        PASS
+        
+=== NAME  TestScript/basic
+    testscript.go:584: WORK=$WORK
+        PATH=/var/folders/wd/0tvjmfdn4zl71ds6q1v6t3600000gn/T/testscript-main3816863872/bin:/Users/llimllib/.local/share/mise/installs/go/1.25.5/bin:/Users/llimllib/.local/share/mise/installs/go/1.25.5/bin:/Users/llimllib/.local/share/mise/installs/node/24.8.0/bin:/Users/llimllib/.local/share/mise/installs/python/3.14.3/bin:/Users/llimllib/.cargo/bin:/Users/llimllib/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/llimllib/go/bin:/Users/llimllib/Library/pnpm:/Users/llimllib/.cache/.bun/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/kitty.app/Contents/MacOS:/opt/homebrew/opt/fzf/bin:/Users/llimllib/.claude/plugins/cache/claude-plugins-official/rust-analyzer-lsp/1.0.0/bin:/Users/llimllib/.claude/plugins/cache/claude-plugins-official/gopls-lsp/1.0.0/bin
+        GOTRACEBACK=system
+        HOME=/no-home
+        TMPDIR=$WORK/.tmp
+        devnull=/dev/null
+        /=/
+        :=:
+        $=$
+        exe=
+        
+        # Basic git-ls should list current directory entries (0.422s)
+        &gt; env NO_COLOR=1
+        &gt; env HOME=$WORK
+        &gt; exec git init -b main
+        [stdout]
+        Initialized empty Git repository in $WORK/.git/
+        &gt; exec git config user.email test@test.com
+        &gt; exec git config user.name Test
+        &gt; cp main.go main.go
+        &gt; mkdir src
+        &gt; cp server.go src/server.go
+        &gt; exec git add .
+        &gt; exec git commit -m &#x27;initial commit&#x27;
+        [stdout]
+        [main (root-commit) 398f055] initial commit
+         3 files changed, 3 insertions(+)
+         create mode 100644 main.go
+         create mode 100644 server.go
+         create mode 100644 src/server.go
+        &gt; exec git-ls
+        [stdout]
+        On branch main
+        
+        *  ]8;;file://adama$WORK/.git\.git]8;;\                                            
+           ]8;;file://adama$WORK/.tmp\.tmp]8;;\  
+
+... [513 characters truncated] ...
+
+FAIL: testdata/scripts/basic.txtar:19: unexpected match for `server\.go` found in stdout: server.go
+        
+=== NAME  TestScript/changed_only_paths
+    testscript.go:584: WORK=$WORK
+        PATH=/var/folders/wd/0tvjmfdn4zl71ds6q1v6t3600000gn/T/testscript-main3816863872/bin:/Users/llimllib/.local/share/mise/installs/go/1.25.5/bin:/Users/llimllib/.local/share/mise/installs/go/1.25.5/bin:/Users/llimllib/.local/share/mise/installs/node/24.8.0/bin:/Users/llimllib/.local/share/mise/installs/python/3.14.3/bin:/Users/llimllib/.cargo/bin:/Users/llimllib/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/llimllib/go/bin:/Users/llimllib/Library/pnpm:/Users/llimllib/.cache/.bun/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/kitty.app/Contents/MacOS:/opt/homebrew/opt/fzf/bin:/Users/llimllib/.claude/plugins/cache/claude-plugins-official/rust-analyzer-lsp/1.0.0/bin:/Users/llimllib/.claude/plugins/cache/claude-plugins-official/gopls-lsp/1.0.0/bin
+        GOTRACEBACK=system
+        HOME=/no-home
+        TMPDIR=$WORK/.tmp
+        devnull=/dev/null
+        /=/
+        :=:
+        $=$
+        exe=
+        
+        # --changed-only shows full relative paths for files in subdirectories (0.066s)
+        &gt; env NO_COLOR=1
+        &gt; env HOME=$WORK
+        &gt; exec git init -b main
+        [stdout]
+        Initialized empty Git repository in $WORK/.git/
+        &gt; exec git config user.email test@test.com
+        &gt; exec git config user.name Test
+        # Create files in nested directories (0.061s)
+        &gt; mkdir src/network
+        &gt; mkdir src/trimble
+        &gt; cp README.md README.md
+        &gt; cp server.go src/network/server.go
+        &gt; cp tork.go src/network/tork.go
+        &gt; cp alpha.go src/trimble/alpha.go
+        &gt; exec git add .
+        &gt; exec git commit -m &#x27;initial commit&#x27;
+        [stdout]
+        [main (root-commit) d26a3d5] initial commit
+         10 files changed, 10 insertions(+)
+         create mode 100644 README.md
+         create mode 100644 alpha.go
+         create mode 100644 modified-readme.txt
+         create mode 100644 modified-server.go
+         create mode 100644 modified-tork.go
+         create mode 100644 server.go
+         create mode 100644 src/network/server.go
+         create mode 100644 src/network/tork.go
+         create mode 100644 src/trimble/alpha.go
+         create mode 100644 tork.go
+        # Modify files at different levels (0.000s)
+        &gt; cp modified-readme.txt README.md
+        &gt; cp modified-server.go src/network/server.go
+        &gt; cp modified-tork.go src/network/tork.go
+        # From repo root, --changed-only should show full relative paths (0.294s)
+        &gt; exec git-ls --changed-only
+        [stdout]
+        On branch main
+        
+         M +- ]8;;file://adama$WORK/README.md\README.md]8;;\             d26a3d5 2026-04-10 Test initial commit
+         M +- ]8;;file://adama$WORK/src/network/server.go\src/network/server.go]8;;\ d26a3d5 2026-04-10 Test initial commit
+         M +- ]8;;file://adama$WORK/src/network/tork.go\src/network/tork.go]8;;\   d26a3d5 2026-04-10 Test initial commit
+        &gt; stdout &#x27;README\.md&#x27;
+        &gt; stdout &#x27;src/network/server\.go&#x27;
+        &gt; stdout &#x27;src/network/tork\.go&#x27;
+        &gt; ! stdout &#x27;src/trimble&#x27;
+        # From a subdirectory, only files at or below that dir should appear (0.049s)
+        &gt; cd src
+        $WORK/src
+        &gt; exec git-ls --changed-only
+        [stdout]
+        On branch main
+        
+         M +- ]8;;file://adama$WORK/src/network/server.go\network/server.go]8;;\ d26a3d5 2026-04-10 Test initial commit
+         M +- ]8;;file://adama$WORK/src/network/tork.go\network/tork.go]8;;\   d26a3d5 2026-04-10 Test initial commit
+        &gt; stdout &#x27;network/server\.go&#x27;
+        &gt; stdout &#x27;network/tork\.go&#x27;
+        &gt; ! stdout &#x27;README&#x27;
+        &gt; ! stdout &#x27;trimble&#x27;
+        # From a leaf directory, just basenames (0.051s)
+        &gt; cd network
+        $WORK/src/network
+        &gt; exec git-ls --changed-only
+        [stdout]
+        On branch main
+        
+         M +- ]8;;file://adama$WORK/src/network/server.go\server.go]8;;\ d26a3d5 2026-04-10 Test initial commit
+         M +- ]8;;file://adama$WORK/src/network/tork.go\tork.go]8;;\   d26a3d5 2026-04-10 Test initial commit
+        &gt; stdout &#x27;server\.go&#x27;
+        &gt; stdout &#x27;tork\.go&#x27;
+        &gt; ! stdout &#x27;src&#x27;
+        FAIL: testdata/scripts/changed_only_paths.txtar:45: unexpected match for `src` found in stdout: src
+        
+--- FAIL: TestScript (0.00s)
+    --- PASS: TestScript/changed_only_filter (0.43s)
+    --- FAIL: TestScript/basic (0.43s)
+    --- FAIL: TestScript/changed_only_paths (0.53s)
+FAIL
+exit status 1
+FAIL	github.com/llimllib/git-ls	0.861s
+[rerun: b30]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-27-18-210Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-27-18-210Z" class="timestamp-link"><time datetime="2026-04-11T02:27:18.210Z" data-timestamp="2026-04-11T02:27:18.210Z">2026-04-11T02:27:18.210Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Two failures to fix:</p>
+<ol>
+<li>
+<p><strong>basic.txtar</strong>: The txtar archive files (<code>server.go</code>) get placed in the work dir root, so <code>git add .</code> adds them too and they show up in the listing. I need to not have the source files overlap.</p>
+</li>
+<li>
+<p><strong>changed_only_paths.txtar</strong>: Same issue — the archive files (<code>server.go</code>, <code>tork.go</code>, etc.) are in the root and show up. Also, the <code>! stdout 'src'</code> check at line 45 fails because <code>server.go</code> in the hyperlink URL contains <code>src</code>. I need to match more carefully.</p>
+</li>
+</ol>
+<p>Let me fix both. The key insight is that txtar archive files all land in the work directory root, so I need to use distinct names for source files vs. what gets committed, or use a subdirectory for staging.</p></div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-27-20-893Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-27-20-893Z" class="timestamp-link"><time datetime="2026-04-11T02:27:20.893Z" data-timestamp="2026-04-11T02:27:20.893Z">2026-04-11T02:27:20.893Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/tree-experiment/testdata/scripts/basic.txtar has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-27-20-871Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-27-20-871Z" class="timestamp-link"><time datetime="2026-04-11T02:27:20.871Z" data-timestamp="2026-04-11T02:27:20.871Z">2026-04-11T02:27:20.871Z</time></a></div><div class="message-content"><div class="file-tool write-tool" data-tool-id="toolu_01X62ZA8kU2t4hdwewTRC4uF">
+<div class="file-tool-header write-header"><span class="file-tool-icon">📝</span> Write <span class="file-tool-path">basic.txtar</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/tree-experiment/testdata/scripts/basic.txtar</div>
+<div class="truncatable"><div class="truncatable-content"><pre class="file-content"># Basic git-ls should list current directory entries
+env NO_COLOR=1
+env HOME=$WORK
+
+mkdir repo
+cd repo
+exec git init -b main
+exec git config user.email test@test.com
+exec git config user.name Test
+
+cp $WORK/files/main.go main.go
+mkdir src
+cp $WORK/files/server.go src/server.go
+exec git add .
+exec git commit -m &#39;initial commit&#39;
+
+exec git-ls
+stdout &#39;main\.go&#39;
+# Directories should show as directory name, not expanded contents
+stdout &#39; src &#39;
+! stdout &#39;server\.go&#39;
+
+-- files/main.go --
+package main
+-- files/server.go --
+package server
+</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-27-30-285Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-27-30-285Z" class="timestamp-link"><time datetime="2026-04-11T02:27:30.285Z" data-timestamp="2026-04-11T02:27:30.285Z">2026-04-11T02:27:30.285Z</time></a></div><div class="message-content"><div class="file-tool write-tool" data-tool-id="toolu_019aKFZKRnqywmbQauRLvxNx">
+<div class="file-tool-header write-header"><span class="file-tool-icon">📝</span> Write <span class="file-tool-path">changed_only_paths.txtar</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/tree-experiment/testdata/scripts/changed_only_paths.txtar</div>
+<div class="truncatable"><div class="truncatable-content"><pre class="file-content"># --changed-only shows full relative paths for files in subdirectories
+env NO_COLOR=1
+env HOME=$WORK
+
+mkdir repo
+cd repo
+exec git init -b main
+exec git config user.email test@test.com
+exec git config user.name Test
+
+# Create files in nested directories
+mkdir src/network
+mkdir src/trimble
+cp $WORK/files/readme.txt README.md
+cp $WORK/files/server.txt src/network/server.go
+cp $WORK/files/tork.txt src/network/tork.go
+cp $WORK/files/alpha.txt src/trimble/alpha.go
+
+exec git add .
+exec git commit -m &#39;initial commit&#39;
+
+# Modify files at different levels
+cp $WORK/files/modified-readme.txt README.md
+cp $WORK/files/modified-server.txt src/network/server.go
+cp $WORK/files/modified-tork.txt src/network/tork.go
+
+# From repo root, --changed-only should show full relative paths
+exec git-ls --changed-only
+stdout &#39;README\.md&#39;
+stdout &#39;src/network/server\.go&#39;
+stdout &#39;src/network/tork\.go&#39;
+! stdout &#39;trimble&#39;
+
+# From a subdirectory, only files at or below that dir should appear
+cd src
+exec git-ls --changed-only
+stdout &#39;network/server\.go&#39;
+stdout &#39;network/tork\.go&#39;
+! stdout &#39;README&#39;
+! stdout &#39;trimble&#39;
+
+# From a leaf directory, just basenames
+cd network
+exec git-ls --changed-only
+stdout &#39;\\server\.go&#39;
+stdout &#39;\\tork\.go&#39;
+
+-- files/readme.txt --
+# readme
+-- files/modified-readme.txt --
+# updated readme
+-- files/server.txt --
+package network
+-- files/modified-server.txt --
+package network // modified server
+-- files/tork.txt --
+package network
+-- files/modified-tork.txt --
+package network // modified tork
+-- files/alpha.txt --
+package trimble
+</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-27-30-289Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-27-30-289Z" class="timestamp-link"><time datetime="2026-04-11T02:27:30.289Z" data-timestamp="2026-04-11T02:27:30.289Z">2026-04-11T02:27:30.289Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/tree-experiment/testdata/scripts/changed_only_paths.txtar has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-27-37-734Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-27-37-734Z" class="timestamp-link"><time datetime="2026-04-11T02:27:37.734Z" data-timestamp="2026-04-11T02:27:37.734Z">2026-04-11T02:27:37.734Z</time></a></div><div class="message-content"><div class="file-tool write-tool" data-tool-id="toolu_01V5ANTDaMoR3nV6tcxAigfT">
+<div class="file-tool-header write-header"><span class="file-tool-icon">📝</span> Write <span class="file-tool-path">changed_only_filter.txtar</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/tree-experiment/testdata/scripts/changed_only_filter.txtar</div>
+<div class="truncatable"><div class="truncatable-content"><pre class="file-content"># --changed-only should only show files with git status changes
+env NO_COLOR=1
+env HOME=$WORK
+
+mkdir repo
+cd repo
+exec git init -b main
+exec git config user.email test@test.com
+exec git config user.name Test
+
+cp $WORK/files/clean.go clean.go
+cp $WORK/files/modified-v1.go modified.go
+exec git add .
+exec git commit -m &#39;initial commit&#39;
+
+# Modify one file, leave the other untouched
+cp $WORK/files/modified-v2.go modified.go
+
+exec git-ls --changed-only
+stdout &#39;modified\.go&#39;
+! stdout &#39;clean\.go&#39;
+
+-- files/clean.go --
+package main
+-- files/modified-v1.go --
+package main // v1
+-- files/modified-v2.go --
+package main // v2
+</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-27-37-760Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-27-37-760Z" class="timestamp-link"><time datetime="2026-04-11T02:27:37.760Z" data-timestamp="2026-04-11T02:27:37.760Z">2026-04-11T02:27:37.760Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/tree-experiment/testdata/scripts/changed_only_filter.txtar has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-27-43-609Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-27-43-609Z" class="timestamp-link"><time datetime="2026-04-11T02:27:43.609Z" data-timestamp="2026-04-11T02:27:43.609Z">2026-04-11T02:27:43.609Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_019teT1xqba7ps6NfRJcr66u">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Run testscript tests</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go test -run TestScript -v 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-27-44-982Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-27-44-982Z" class="timestamp-link"><time datetime="2026-04-11T02:27:44.982Z" data-timestamp="2026-04-11T02:27:44.982Z">2026-04-11T02:27:44.982Z</time></a></div><div class="message-content"><div class="tool-result tool-error"><div class="truncatable"><div class="truncatable-content"><pre>Exit code 1
+=== RUN   TestScript
+=== RUN   TestScript/basic
+=== PAUSE TestScript/basic
+=== RUN   TestScript/changed_only_filter
+=== PAUSE TestScript/changed_only_filter
+=== RUN   TestScript/changed_only_paths
+=== PAUSE TestScript/changed_only_paths
+=== CONT  TestScript/basic
+=== CONT  TestScript/changed_only_paths
+=== CONT  TestScript/changed_only_filter
+=== NAME  TestScript/basic
+    testscript.go:584: WORK=$WORK
+        PATH=/var/folders/wd/0tvjmfdn4zl71ds6q1v6t3600000gn/T/testscript-main912405768/bin:/Users/llimllib/.local/share/mise/installs/go/1.25.5/bin:/Users/llimllib/.local/share/mise/installs/go/1.25.5/bin:/Users/llimllib/.local/share/mise/installs/node/24.8.0/bin:/Users/llimllib/.local/share/mise/installs/python/3.14.3/bin:/Users/llimllib/.cargo/bin:/Users/llimllib/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/llimllib/go/bin:/Users/llimllib/Library/pnpm:/Users/llimllib/.cache/.bun/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/kitty.app/Contents/MacOS:/opt/homebrew/opt/fzf/bin:/Users/llimllib/.claude/plugins/cache/claude-plugins-official/rust-analyzer-lsp/1.0.0/bin:/Users/llimllib/.claude/plugins/cache/claude-plugins-official/gopls-lsp/1.0.0/bin
+        GOTRACEBACK=system
+        HOME=/no-home
+        TMPDIR=$WORK/.tmp
+        devnull=/dev/null
+        /=/
+        :=:
+        $=$
+        exe=
+        
+        # Basic git-ls should list current directory entries (0.393s)
+        &gt; env NO_COLOR=1
+        &gt; env HOME=$WORK
+        &gt; mkdir repo
+        &gt; cd repo
+        $WORK/repo
+        &gt; exec git init -b main
+        [stdout]
+        Initialized empty Git repository in $WORK/repo/.git/
+        &gt; exec git config user.email test@test.com
+        &gt; exec git config user.name Test
+        &gt; cp $WORK/files/main.go main.go
+        &gt; mkdir src
+        &gt; cp $WORK/files/server.go src/server.go
+        &gt; exec git add .
+        &gt; exec git commit -m &#x27;initial commit&#x27;
+        [stdout]
+        [main (root-commit) ef808a5] initial commit
+         2 files changed, 2 insertions(+)
+         create mode 100644 main.go
+         create mode 100644 src/server.go
+        &gt; exec git-ls
+        [stdout]
+        On branch main
+        
+        *  ]8;;file://adama$WORK/repo/.git\.git]8;;\                                          
+           ]8;;file://adama$WORK/repo/main.go\main.go]8;;\ ef808a5 2026-04-10 Test initial commit
+           ]8;;file://adama$WORK/repo/src\src]8;;\     ef808a5 2026-04-10 Test initial commit
+        &gt; stdout &#x27;main\.go&#x27;
+        # Directories should show as directory name, not expanded contents (0.000s)
+        &gt; stdout &#x27; src &#x27;
+        FAIL: testdata/scripts/basic.txtar:20: no match for ` src ` found in stdout
+        
+=== NAME  TestScript/changed_only_filter
+    testscript.go:584: WORK=$WORK
+        PATH=/var/folders/wd/0tvjmfdn4zl71ds6q1v6t3600000gn/T/testscript-main912405768/bin:/Users/llimllib/.local/share/mise/installs/go/1.25.5/bin:/Users/llimllib/.local/share/mise/installs/go/1.25.5/bin:/Users/llimllib/.local/share/mise/installs/node/24.8.0/bin:/Users/llimllib/.local/share/mise/installs/python/3.14.3/bin:/Users/llimllib/.cargo/bin:/Users/llimllib/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/llimllib/go/bin:/Users/llimllib/Library/pnpm:/Users/llimllib/.cache/.bun/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/kitty.app/Contents/MacOS:/opt/homebrew/opt/fzf/bin:/Users/llimllib/.claude/plugins/cache/claude-plugins-official/rust-analyzer-lsp/1.0.0/bin:/Users/llimllib/.claude/plugins/cache/claude-plugins-official/gopls-lsp/1.0.0/bin
+        GOTRACEBACK=system
+        HOME=/no-home
+        TMPDIR=$WORK/.tmp
+        devnull=/dev/null
+        /=/
+        :=:
+        $=$
+        exe=
+        
+        # --changed-only should only show files with git status changes (0.122s)
+        &gt; env NO_COLOR=1
+        &gt; env HOME=$WORK
+        &gt; mkdir repo
+        &gt; cd repo
+        $WORK/repo
+        &gt; exec git init -b main
+        [stdout]
+        Initialized empty Git repository in $WORK/repo/.git/
+        &gt; exec git config user.email test@test.com
+        &gt; exec git config user.name Test
+        &gt; cp $WORK/files/clean.go clean.go
+        &gt; cp $WORK/files/modified-v1.go modified.go
+        &gt; exec git add .
+        &gt; exec git commit -m &#x27;initial commit&#x27;
+        [stdout]
+        [main (root-commit) dcd0707] 
+
+... [247 characters truncated] ...
+
+
+        &gt; exec git-ls --changed-only
+        [stdout]
+        On branch main
+        
+         M +- ]8;;file://adama$WORK/repo/modified.go\modified.go]8;;\ dcd0707 2026-04-10 Test initial commit
+        &gt; stdout &#x27;modified\.go&#x27;
+        &gt; ! stdout &#x27;clean\.go&#x27;
+        PASS
+        
+=== NAME  TestScript/changed_only_paths
+    testscript.go:584: WORK=$WORK
+        PATH=/var/folders/wd/0tvjmfdn4zl71ds6q1v6t3600000gn/T/testscript-main912405768/bin:/Users/llimllib/.local/share/mise/installs/go/1.25.5/bin:/Users/llimllib/.local/share/mise/installs/go/1.25.5/bin:/Users/llimllib/.local/share/mise/installs/node/24.8.0/bin:/Users/llimllib/.local/share/mise/installs/python/3.14.3/bin:/Users/llimllib/.cargo/bin:/Users/llimllib/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/llimllib/go/bin:/Users/llimllib/Library/pnpm:/Users/llimllib/.cache/.bun/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/kitty.app/Contents/MacOS:/opt/homebrew/opt/fzf/bin:/Users/llimllib/.claude/plugins/cache/claude-plugins-official/rust-analyzer-lsp/1.0.0/bin:/Users/llimllib/.claude/plugins/cache/claude-plugins-official/gopls-lsp/1.0.0/bin
+        GOTRACEBACK=system
+        HOME=/no-home
+        TMPDIR=$WORK/.tmp
+        devnull=/dev/null
+        /=/
+        :=:
+        $=$
+        exe=
+        
+        # --changed-only shows full relative paths for files in subdirectories (0.070s)
+        &gt; env NO_COLOR=1
+        &gt; env HOME=$WORK
+        &gt; mkdir repo
+        &gt; cd repo
+        $WORK/repo
+        &gt; exec git init -b main
+        [stdout]
+        Initialized empty Git repository in $WORK/repo/.git/
+        &gt; exec git config user.email test@test.com
+        &gt; exec git config user.name Test
+        # Create files in nested directories (0.052s)
+        &gt; mkdir src/network
+        &gt; mkdir src/trimble
+        &gt; cp $WORK/files/readme.txt README.md
+        &gt; cp $WORK/files/server.txt src/network/server.go
+        &gt; cp $WORK/files/tork.txt src/network/tork.go
+        &gt; cp $WORK/files/alpha.txt src/trimble/alpha.go
+        &gt; exec git add .
+        &gt; exec git commit -m &#x27;initial commit&#x27;
+        [stdout]
+        [main (root-commit) 1c2cf24] initial commit
+         4 files changed, 4 insertions(+)
+         create mode 100644 README.md
+         create mode 100644 src/network/server.go
+         create mode 100644 src/network/tork.go
+         create mode 100644 src/trimble/alpha.go
+        # Modify files at different levels (0.001s)
+        &gt; cp $WORK/files/modified-readme.txt README.md
+        &gt; cp $WORK/files/modified-server.txt src/network/server.go
+        &gt; cp $WORK/files/modified-tork.txt src/network/tork.go
+        # From repo root, --changed-only should show full relative paths (0.277s)
+        &gt; exec git-ls --changed-only
+        [stdout]
+        On branch main
+        
+         M +- ]8;;file://adama$WORK/repo/README.md\README.md]8;;\             1c2cf24 2026-04-10 Test initial commit
+         M +- ]8;;file://adama$WORK/repo/src/network/server.go\src/network/server.go]8;;\ 1c2cf24 2026-04-10 Test initial commit
+         M +- ]8;;file://adama$WORK/repo/src/network/tork.go\src/network/tork.go]8;;\   1c2cf24 2026-04-10 Test initial commit
+        &gt; stdout &#x27;README\.md&#x27;
+        &gt; stdout &#x27;src/network/server\.go&#x27;
+        &gt; stdout &#x27;src/network/tork\.go&#x27;
+        &gt; ! stdout &#x27;trimble&#x27;
+        # From a subdirectory, only files at or below that dir should appear (0.047s)
+        &gt; cd src
+        $WORK/repo/src
+        &gt; exec git-ls --changed-only
+        [stdout]
+        On branch main
+        
+         M +- ]8;;file://adama$WORK/repo/src/network/server.go\network/server.go]8;;\ 1c2cf24 2026-04-10 Test initial commit
+         M +- ]8;;file://adama$WORK/repo/src/network/tork.go\network/tork.go]8;;\   1c2cf24 2026-04-10 Test initial commit
+        &gt; stdout &#x27;network/server\.go&#x27;
+        &gt; stdout &#x27;network/tork\.go&#x27;
+        &gt; ! stdout &#x27;README&#x27;
+        &gt; ! stdout &#x27;trimble&#x27;
+        # From a leaf directory, just basenames (0.045s)
+        &gt; cd network
+        $WORK/repo/src/network
+        &gt; exec git-ls --changed-only
+        [stdout]
+        On branch main
+        
+         M +- ]8;;file://adama$WORK/repo/src/network/server.go\server.go]8;;\ 1c2cf24 2026-04-10 Test initial commit
+         M +- ]8;;file://adama$WORK/repo/src/network/tork.go\tork.go]8;;\   1c2cf24 2026-04-10 Test initial commit
+        &gt; stdout &#x27;\\server\.go&#x27;
+        &gt; stdout &#x27;\\tork\.go&#x27;
+        PASS
+        
+--- FAIL: TestScript (0.00s)
+    --- FAIL: TestScript/basic (0.40s)
+    --- PASS: TestScript/changed_only_filter (0.40s)
+    --- PASS: TestScript/changed_only_paths (0.50s)
+FAIL
+exit status 1
+FAIL	github.com/llimllib/git-ls	0.863s
+[rerun: b31]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-27-51-636Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-27-51-636Z" class="timestamp-link"><time datetime="2026-04-11T02:27:51.636Z" data-timestamp="2026-04-11T02:27:51.636Z">2026-04-11T02:27:51.636Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>The two <code>changed_only</code> tests pass. Just <code>basic.txtar</code> needs fixing — the <code>src</code> output has a hyperlink escape between <code>src</code> and the padding, not a raw space. The actual output is <code>src\]8;;\</code> then spaces. Let me just match <code>src</code> without requiring surrounding spaces:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-27-53-290Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-27-53-290Z" class="timestamp-link"><time datetime="2026-04-11T02:27:53.290Z" data-timestamp="2026-04-11T02:27:53.290Z">2026-04-11T02:27:53.290Z</time></a></div><div class="message-content"><div class="file-tool edit-tool" data-tool-id="toolu_01ETDk3LckxUM9vACt3tdUM4">
+<div class="file-tool-header edit-header"><span class="file-tool-icon">✏️</span> Edit <span class="file-tool-path">basic.txtar</span></div>
+<div class="file-tool-fullpath">/Users/llimllib/code/git-ls/tree-experiment/testdata/scripts/basic.txtar</div>
+<div class="truncatable"><div class="truncatable-content">
+<div class="edit-section edit-old"><div class="edit-label">−</div><pre class="edit-content"># Directories should show as directory name, not expanded contents
+stdout &#39; src &#39;
+! stdout &#39;server\.go&#39;</pre></div>
+<div class="edit-section edit-new"><div class="edit-label">+</div><pre class="edit-content"># Directories should show as directory name, not expanded contents
+stdout &#39;\\src&#39;
+! stdout &#39;server\.go&#39;</pre></div>
+</div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-27-53-325Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-27-53-325Z" class="timestamp-link"><time datetime="2026-04-11T02:27:53.325Z" data-timestamp="2026-04-11T02:27:53.325Z">2026-04-11T02:27:53.325Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>The file /Users/llimllib/code/git-ls/tree-experiment/testdata/scripts/basic.txtar has been updated successfully. (file state is current in your context — no need to Read it back)</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-27-58-664Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-27-58-664Z" class="timestamp-link"><time datetime="2026-04-11T02:27:58.664Z" data-timestamp="2026-04-11T02:27:58.664Z">2026-04-11T02:27:58.664Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01PT3uF9nShz2he2mcNAWY6P">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Run testscript tests</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go test -run TestScript -v 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-27-59-669Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-27-59-669Z" class="timestamp-link"><time datetime="2026-04-11T02:27:59.669Z" data-timestamp="2026-04-11T02:27:59.669Z">2026-04-11T02:27:59.669Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>=== RUN   TestScript
+=== RUN   TestScript/basic
+=== PAUSE TestScript/basic
+=== RUN   TestScript/changed_only_filter
+=== PAUSE TestScript/changed_only_filter
+=== RUN   TestScript/changed_only_paths
+=== PAUSE TestScript/changed_only_paths
+=== CONT  TestScript/basic
+=== CONT  TestScript/changed_only_filter
+=== CONT  TestScript/changed_only_paths
+=== NAME  TestScript/changed_only_filter
+    testscript.go:584: WORK=$WORK
+        PATH=/var/folders/wd/0tvjmfdn4zl71ds6q1v6t3600000gn/T/testscript-main910104045/bin:/Users/llimllib/.local/share/mise/installs/go/1.25.5/bin:/Users/llimllib/.local/share/mise/installs/go/1.25.5/bin:/Users/llimllib/.local/share/mise/installs/node/24.8.0/bin:/Users/llimllib/.local/share/mise/installs/python/3.14.3/bin:/Users/llimllib/.cargo/bin:/Users/llimllib/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/llimllib/go/bin:/Users/llimllib/Library/pnpm:/Users/llimllib/.cache/.bun/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/kitty.app/Contents/MacOS:/opt/homebrew/opt/fzf/bin:/Users/llimllib/.claude/plugins/cache/claude-plugins-official/rust-analyzer-lsp/1.0.0/bin:/Users/llimllib/.claude/plugins/cache/claude-plugins-official/gopls-lsp/1.0.0/bin
+=== NAME  TestScript/basic
+    testscript.go:584: WORK=$WORK
+        PATH=/var/folders/wd/0tvjmfdn4zl71ds6q1v6t3600000gn/T/testscript-main910104045/bin:/Users/llimllib/.local/share/mise/installs/go/1.25.5/bin:/Users/llimllib/.local/share/mise/installs/go/1.25.5/bin:/Users/llimllib/.local/share/mise/installs/node/24.8.0/bin:/Users/llimllib/.local/share/mise/installs/python/3.14.3/bin:/Users/llimllib/.cargo/bin:/Users/llimllib/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/llimllib/go/bin:/Users/llimllib/Library/pnpm:/Users/llimllib/.cache/.bun/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/kitty.app/Contents/MacOS:/opt/homebrew/opt/fzf/bin:/Users/llimllib/.claude/plugins/cache/claude-plugins-official/rust-analyzer-lsp/1.0.0/bin:/Users/llimllib/.claude/plugins/cache/claude-plugins-official/gopls-lsp/1.0.0/bin
+        GOTRACEBACK=system
+        HOME=/no-home
+        TMPDIR=$WORK/.tmp
+        devnull=/dev/null
+        /=/
+        :=:
+        $=$
+        exe=
+        
+        # Basic git-ls should list current directory entries (0.436s)
+        &gt; env NO_COLOR=1
+        &gt; env HOME=$WORK
+        &gt; mkdir repo
+        &gt; cd repo
+=== NAME  TestScript/changed_only_filter
+        GOTRACEBACK=system
+        HOME=/no-home
+        TMPDIR=$WORK/.tmp
+        devnull=/dev/null
+        /=/
+        :=:
+        $=$
+        exe=
+        
+        # --changed-only should only show files with git status changes (0.116s)
+        &gt; env NO_COLOR=1
+        &gt; env HOME=$WORK
+        &gt; mkdir repo
+        &gt; cd repo
+        $WORK/repo
+        &gt; exec git init -b main
+        [stdout]
+        Initialized empty Git repository in $WORK/repo/.git/
+        &gt; exec git config user.email test@test.com
+        &gt; exec git config user.name Test
+        &gt; cp $WORK/files/clean.go clean.go
+        &gt; cp $WORK/files/modified-v1.go modified.go
+        &gt; exec git add .
+        &gt; exec git commit -m &#x27;initial commit&#x27;
+        [stdout]
+        [main (root-commit) 7d76a0d] initial commit
+         2 files changed, 2 insertions(+)
+         create mode 100644 clean.go
+         create mode 100644 modified.go
+        # Modify one file, leave the other untouched (0.320s)
+        &gt; cp $WORK/files/modified-v2.go modified.go
+        &gt; exec git-ls --changed-only
+        [stdout]
+        On branch main
+        
+         M +- ]8;;file://adama$WORK/repo/modified.go\modified.go]8;;\ 7d76a0d 2026-04-10 Test initial commit
+        &gt; stdout &#x27;modified\.go&#x27;
+        &gt; ! stdout &#x27;clean\.go&#x27;
+        PASS
+=== NAME  TestScript/basic
+        $WORK/repo
+        &gt; exec git init -b main
+        [stdout]
+        Initialized empty Git repository in $WORK/repo/.git/
+        &gt; exec git config user.email test@test.com
+        &gt; exec git config user.name Test
+        &gt; cp $WORK/files/main.go main.go
+        &gt; mkdir src
+        &gt; cp $WORK/files/server.go src/server.go
+        &gt; exec git add .
+        &gt; exec git commit -m &#x27;initial commit&#x27;
+        [stdout]
+        [main (root-commit) 2ac5cc0] initial commit
+         2 files changed, 2 insertions(+)
+         create mode 100644 main.go
+         create mode 100644 src/server.go
+        &gt; exec git-ls
+        [stdout]
+        On branch main
+        
+        *  ]8;;file://adama$WORK/repo/.git\.git]8;;\                                          
+           ]8;;file://adama$WORK/repo/main.go\main.go]8;;\ 2ac5cc0 2026-04-10 Test initial commit
+           ]8;;file://adama$WORK/repo/src\src]8;;\     2ac5cc0 2026-04-10 Test initial commit
+        &gt; stdout &#x27;main\.go&#x27;
+=== NAME  TestScript/changed_only_filter
+        
+=== NAME  TestScript/basic
+        # Directories should show as directory name, not expanded contents (0.000s)
+        &gt; stdout &#x27;\\src&#x27;
+        &gt; ! stdout &#x27;server\.go&#x27;
+        PASS
+        
+=== NAME  TestScript/changed_only_paths
+    testscript.go:584: WORK=$WORK
+        PATH=/var/folders/wd/0tvjmfdn4zl71ds6q1v6t3600000gn/T/testscript-main910104045/bin:/Users/llimllib/.local/share/mise/installs/go/1.25.5/bin:/Users/llimllib/.local/share/mise/installs/go/1.25.5/bin:/Users/llimllib/.local/share/mise/installs/node/24.8.0/bin:/Users/llimllib/.local/share/mise/installs/python/3.14.3/bin:/Users/llimllib/.cargo/bin:/Users/llimllib/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/llimllib/go/bin:/Users/llimllib/Library/pnpm:/Users/llimllib/.cache/.bun/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/kitty.app/Contents/MacOS:/opt/homebrew/opt/fzf/bin:/Users/llimllib/.claude/plugins/cache/claude-plugins-official/rust-analyzer-lsp/1.0.0/bin:/Users/llimllib/.claude/plugins/cache/claude-plugins-official/gopls-lsp/1.0.0/bin
+        GOTRACEBACK=system
+        HOME=/no-home
+        TMPDIR=$WORK/.tmp
+        devnull=/dev/null
+        /=/
+        :=:
+        $=$
+        exe=
+        
+        # --changed-only shows full relative paths for files in subdirectories (0.064s)
+        &gt; env NO_COLOR=1
+        &gt; env HOME=$WORK
+        &gt; mkdir repo
+        &gt; cd repo
+        $WORK/repo
+        &gt; exec git init -b main
+        [stdout]
+        Initialized empty Git repository in $WORK/repo/.git/
+        &gt; exec git config user.email test@test.com
+        &gt; exec git config user.name Test
+        # Create files in nested directories (0.051s)
+        &gt; mkdir src/network
+        &gt; mkdir src/trimble
+        &gt; cp $WORK/files/readme.txt README.md
+        &gt; cp $WORK/files/server.txt src/network/server.go
+        &gt; cp $WORK/files/tork.txt src/network/tork.go
+        &gt; cp $WORK/files/alpha.txt src/trimble/alpha.go
+        &gt; exec git add .
+        &gt; exec git commit -m &#x27;initial commit&#x27;
+        [stdout]
+        [main (root-commit) c6a4360] initial commit
+         4 files changed, 4 insertions(+)
+         create mode 100644 README.md
+         create mode 100644 src/network/server.go
+         create mode 100644 src/network/tork.go
+         create mode 100644 src/trimble/alpha.go
+        # Modify files at different levels (0.000s)
+        &gt; cp $WORK/files/modified-readme.txt README.md
+        &gt; cp $WORK/files/modified-server.txt src/network/server.go
+        &gt; cp $WORK/files/modified-tork.txt src/network/tork.go
+        # From repo root, --changed-only should show full relative paths (0.306s)
+        &gt; exec git-ls --changed-only
+        [stdout]
+        On branch main
+        
+         M +- ]8;;file://adama$WORK/repo/README.md\README.md]8;;\             c6a4360 2026-04-10 Test initial commit
+         M +- ]8;;file://adama$WORK/repo/src/network/server.go\src/network/server.go]8;;\ c6a4360 2026-04-10 Test initial commit
+         M +- ]8;;file://adama$WORK/repo/src/network/tork.go\src/network/tork.go]8;;\   c6a4360 2026-04-10 Test initial commit
+        &gt; stdout &#x27;README\.md&#x27;
+        &gt; stdout &#x27;src/network/server\.go&#x27;
+        &gt; stdout &#x27;src/network/tork\.go&#x27;
+        &gt; ! stdout &#x27;trimble&#x27;
+        # From a subdirectory, only files at or below that dir should appear (0.048s)
+        &gt; cd src
+        $WORK/repo/src
+        &gt; exec git-ls --changed-only
+        [stdout]
+        On branch main
+        
+         M +- ]8;;file://adama$WORK/repo/src/network/server.go\network/server.go]8;;\ c6a4360 2026-04-10 Test initial commit
+         M +- ]8;;file://adama$WORK/repo/src/network/tork.go\network/tork.go]8;;\   c6a4360 2026-04-10 Test initial commit
+        &gt; stdout &#x27;network/server\.go&#x27;
+        &gt; stdout &#x27;network/tork\.go&#x27;
+        &gt; ! stdout &#x27;README&#x27;
+        &gt; ! stdout &#x27;trimble&#x27;
+        # From a leaf directory, just basenames (0.044s)
+        &gt; cd network
+        $WORK/repo/src/network
+        &gt; exec git-ls --changed-only
+        [stdout]
+        On branch main
+        
+         M +- ]8;;file://adama$WORK/repo/src/network/server.go\server.go]8;;\ c6a4360 2026-04-10 Test initial commit
+         M +- ]8;;file://adama$WORK/repo/src/network/tork.go\tork.go]8;;\   c6a4360 2026-04-10 Test initial commit
+        &gt; stdout &#x27;\\server\.go&#x27;
+        &gt; stdout &#x27;\\tork\.go&#x27;
+        PASS
+        
+--- PASS: TestScript (0.00s)
+    --- PASS: TestScript/changed_only_filter (0.44s)
+    --- PASS: TestScript/basic (0.44s)
+    --- PASS: TestScript/changed_only_paths (0.52s)
+PASS
+ok  	github.com/llimllib/git-ls	0.804s
+[rerun: b32]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-28-05-595Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-28-05-595Z" class="timestamp-link"><time datetime="2026-04-11T02:28:05.595Z" data-timestamp="2026-04-11T02:28:05.595Z">2026-04-11T02:28:05.595Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>All three testscript tests pass. Let me also make sure the existing tests still pass:</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-28-06-314Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-28-06-314Z" class="timestamp-link"><time datetime="2026-04-11T02:28:06.314Z" data-timestamp="2026-04-11T02:28:06.314Z">2026-04-11T02:28:06.314Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01FdkMpj7sfHiqDcSTVrGoEW">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Run all tests</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">go test ./... -v 2&gt;&amp;1 | tail -40</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T02-28-07-950Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T02-28-07-950Z" class="timestamp-link"><time datetime="2026-04-11T02:28:07.950Z" data-timestamp="2026-04-11T02:28:07.950Z">2026-04-11T02:28:07.950Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>         M +- ]8;;file://adama$WORK/repo/README.md\README.md]8;;\             cee216b 2026-04-10 Test initial commit
+         M +- ]8;;file://adama$WORK/repo/src/network/server.go\src/network/server.go]8;;\ cee216b 2026-04-10 Test initial commit
+         M +- ]8;;file://adama$WORK/repo/src/network/tork.go\src/network/tork.go]8;;\   cee216b 2026-04-10 Test initial commit
+        &gt; stdout &#x27;README\.md&#x27;
+        &gt; stdout &#x27;src/network/server\.go&#x27;
+        &gt; stdout &#x27;src/network/tork\.go&#x27;
+        &gt; ! stdout &#x27;trimble&#x27;
+        # From a subdirectory, only files at or below that dir should appear (0.046s)
+        &gt; cd src
+        $WORK/repo/src
+        &gt; exec git-ls --changed-only
+        [stdout]
+        On branch main
+        
+         M +- ]8;;file://adama$WORK/repo/src/network/server.go\network/server.go]8;;\ cee216b 2026-04-10 Test initial commit
+         M +- ]8;;file://adama$WORK/repo/src/network/tork.go\network/tork.go]8;;\   cee216b 2026-04-10 Test initial commit
+        &gt; stdout &#x27;network/server\.go&#x27;
+        &gt; stdout &#x27;network/tork\.go&#x27;
+        &gt; ! stdout &#x27;README&#x27;
+        &gt; ! stdout &#x27;trimble&#x27;
+        # From a leaf directory, just basenames (0.045s)
+        &gt; cd network
+        $WORK/repo/src/network
+        &gt; exec git-ls --changed-only
+        [stdout]
+        On branch main
+        
+         M +- ]8;;file://adama$WORK/repo/src/network/server.go\server.go]8;;\ cee216b 2026-04-10 Test initial commit
+         M +- ]8;;file://adama$WORK/repo/src/network/tork.go\tork.go]8;;\   cee216b 2026-04-10 Test initial commit
+        &gt; stdout &#x27;\\server\.go&#x27;
+        &gt; stdout &#x27;\\tork\.go&#x27;
+        PASS
+        
+--- PASS: TestScript (0.00s)
+    --- PASS: TestScript/changed_only_filter (0.42s)
+    --- PASS: TestScript/basic (0.43s)
+    --- PASS: TestScript/changed_only_paths (0.52s)
+PASS
+ok  	github.com/llimllib/git-ls	1.393s
+[rerun: b33]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T02-28-21-355Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T02-28-21-355Z" class="timestamp-link"><time datetime="2026-04-11T02:28:21.355Z" data-timestamp="2026-04-11T02:28:21.355Z">2026-04-11T02:28:21.355Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>All tests pass — both the existing unit/integration tests and the new testscript tests. Here's a summary of everything done:</p>
+<p><strong>Feature: <code>--changed-only</code> shows full relative paths</strong>
+- <code>changedFilesFromStatus()</code> builds file list from git status with relative paths
+- <code>parseGitLog</code> matches full paths, falling back to first-component matching
+- <code>parseDiffStat</code> stores stats under both full path and first component
+- Scoped to current directory — from <code>src/</code>, you see <code>network/server.go</code>, not files in parent dirs</p>
+<p><strong><code>NO_COLOR</code> support</strong>
+- Color vars changed from <code>const</code> to <code>var</code>
+- <code>init()</code> checks <code>NO_COLOR</code> env and blanks them all out
+- <code>hashToColor</code> returns empty string when colors are disabled</p>
+<p><strong><code>run()</code> refactor</strong>
+- <code>main()</code> → <code>os.Exit(run())</code>, with <code>run() int</code> doing all the work
+- <code>log.Fatalf</code> in main flow replaced with <code>fmt.Fprintf(os.Stderr, ...)</code> + <code>return 1</code>
+- Helper functions (<code>gitRemotes</code>, <code>gitRoot</code>, etc.) still use <code>log.Fatalf</code> for now</p>
+<p><strong>testscript integration</strong>
+- Added <code>github.com/rogpeppe/go-internal/testscript</code> dependency
+- <code>script_test.go</code> wires up <code>git-ls</code> as an in-process command
+- Three test scripts in <code>testdata/scripts/</code>:
+  - <code>basic.txtar</code> — normal mode lists directory entries
+  - <code>changed_only_filter.txtar</code> — only changed files appear
+  - <code>changed_only_paths.txtar</code> — full relative paths from root, scoped from subdirs</p></div></div></div>
+<div class="message user" id="msg-2026-04-11T03-01-40-385Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T03-01-40-385Z" class="timestamp-link"><time datetime="2026-04-11T03:01:40.385Z" data-timestamp="2026-04-11T03:01:40.385Z">2026-04-11T03:01:40.385Z</time></a></div><div class="message-content">
+<div class="user-content"><p>one thing I noticed is that uncommitted directories appear as the directory name, but when added appear as each file. That's the same behavior as "git status" right?</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T03-01-46-559Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T03-01-46-559Z" class="timestamp-link"><time datetime="2026-04-11T03:01:46.559Z" data-timestamp="2026-04-11T03:01:46.559Z">2026-04-11T03:01:46.559Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01RtnfgJBmYdj7McpZ52CcvC">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Check git status porcelain output</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">cd /tmp/claude/test-tree &amp;&amp; git status --porcelain 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T03-01-46-611Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T03-01-46-611Z" class="timestamp-link"><time datetime="2026-04-11T03:01:46.611Z" data-timestamp="2026-04-11T03:01:46.611Z">2026-04-11T03:01:46.611Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre> M README.md
+ M src/network/server.go
+ M src/network/tork.go
+MM src/trimble/alpha.go
+A  src/trimble/bananas
+Shell cwd was reset to /Users/llimllib/code/git-ls/tree-experiment
+[rerun: b34]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T03-01-51-788Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T03-01-51-788Z" class="timestamp-link"><time datetime="2026-04-11T03:01:51.788Z" data-timestamp="2026-04-11T03:01:51.788Z">2026-04-11T03:01:51.788Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_013pjrh6cWr2ZCusXx2hntAb">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Check untracked directory in git status</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">cd /tmp/claude/test-tree &amp;&amp; mkdir -p newdir &amp;&amp; echo &#34;hi&#34; &gt; newdir/one.go &amp;&amp; echo &#34;hi&#34; &gt; newdir/two.go &amp;&amp; git status --porcelain 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T03-01-51-849Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T03-01-51-849Z" class="timestamp-link"><time datetime="2026-04-11T03:01:51.849Z" data-timestamp="2026-04-11T03:01:51.849Z">2026-04-11T03:01:51.849Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre> M README.md
+ M src/network/server.go
+ M src/network/tork.go
+MM src/trimble/alpha.go
+A  src/trimble/bananas
+?? newdir/
+Shell cwd was reset to /Users/llimllib/code/git-ls/tree-experiment
+[rerun: b35]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T03-01-58-856Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T03-01-58-856Z" class="timestamp-link"><time datetime="2026-04-11T03:01:58.856Z" data-timestamp="2026-04-11T03:01:58.856Z">2026-04-11T03:01:58.856Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>Yeah — git's porcelain output reports untracked directories as a single <code>?? newdir/</code> entry rather than listing each file inside. Once you <code>git add</code> them, each file gets its own <code>A</code> entry. Our <code>changedFilesFromStatus</code> just passes through whatever git status reports, so we inherit that same behavior.</p></div></div></div>
+<div class="message user" id="msg-2026-04-11T03-06-22-554Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T03-06-22-554Z" class="timestamp-link"><time datetime="2026-04-11T03:06:22.554Z" data-timestamp="2026-04-11T03:06:22.554Z">2026-04-11T03:06:22.554Z</time></a></div><div class="message-content">
+<div class="user-content"><p>alright, let's commit and file a PR</p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T03-06-28-885Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T03-06-28-885Z" class="timestamp-link"><time datetime="2026-04-11T03:06:28.885Z" data-timestamp="2026-04-11T03:06:28.885Z">2026-04-11T03:06:28.885Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01FFSWQ6vk5amz4Lu3Ma9QNa">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Check git state</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git status &amp;&amp; git diff --stat &amp;&amp; git log --oneline -5</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T03-06-28-984Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T03-06-28-984Z" class="timestamp-link"><time datetime="2026-04-11T03:06:28.984Z" data-timestamp="2026-04-11T03:06:28.984Z">2026-04-11T03:06:28.984Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>On branch tree-experiment
+Changes to be committed:
+  (use &quot;git restore --staged &lt;file&gt;...&quot; to unstage)
+	modified:   go.mod
+	modified:   go.sum
+	modified:   main.go
+	new file:   script_test.go
+	new file:   testdata/scripts/basic.txtar
+	new file:   testdata/scripts/changed_only_filter.txtar
+	new file:   testdata/scripts/changed_only_paths.txtar
+
+Untracked files:
+  (use &quot;git add &lt;file&gt;...&quot; to include in what will be committed)
+	.claude/
+
+7197d13 feat: strip ignored files from --changed-only (#46)
+079d7ed chore: bump to 5.9.0
+cad5a9c fix: handle detached HEAD and rebase states (#45)
+84a45fb chore: bump version to 5.8.0
+d84ca28 fix: unmodified tracked files show no commit info after --changed-only was added (#43)
+[rerun: b36]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T03-06-34-535Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T03-06-34-535Z" class="timestamp-link"><time datetime="2026-04-11T03:06:34.535Z" data-timestamp="2026-04-11T03:06:34.535Z">2026-04-11T03:06:34.535Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01CppjHjDcU4oGxmPuPN9wbD">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Check staged changes</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git diff --cached --stat</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T03-06-34-611Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T03-06-34-611Z" class="timestamp-link"><time datetime="2026-04-11T03:06:34.611Z" data-timestamp="2026-04-11T03:06:34.611Z">2026-04-11T03:06:34.611Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre> go.mod                                     |  11 +-
+ go.sum                                     |   6 +
+ main.go                                    | 196 +++++++++++++++++++++++------
+ script_test.go                             |  20 +++
+ testdata/scripts/basic.txtar               |  26 ++++
+ testdata/scripts/changed_only_filter.txtar |  28 +++++
+ testdata/scripts/changed_only_paths.txtar  |  61 +++++++++
+ 7 files changed, 309 insertions(+), 39 deletions(-)
+[rerun: b37]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T03-06-42-443Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T03-06-42-443Z" class="timestamp-link"><time datetime="2026-04-11T03:06:42.443Z" data-timestamp="2026-04-11T03:06:42.443Z">2026-04-11T03:06:42.443Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01UjBF9rXnLYdkSLxsRuUJbe">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Create commit</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git commit -m &#34;$(cat &lt;&lt;&#39;EOF&#39;
+feat: --changed-only shows full relative paths for subdirectory files
+
+Previously, --changed-only would only show files in the current directory
+(collapsing subdirectories into directory names). Now it shows all changed
+files at or below the current directory with their relative paths, e.g.
+&#34;src/network/server.go&#34; instead of just &#34;src/&#34;.
+
+Also adds:
+- NO_COLOR environment variable support (https://no-color.org)
+- Extract run() from main() for testability
+- testscript-based integration tests
+EOF
+)&#34;</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T03-06-42-525Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T03-06-42-525Z" class="timestamp-link"><time datetime="2026-04-11T03:06:42.525Z" data-timestamp="2026-04-11T03:06:42.525Z">2026-04-11T03:06:42.525Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><div class="commit-card"><a href="https://github.com/llimllib/git-ls/commit/303a7fc"><span class="commit-card-hash">303a7fc</span> feat: --changed-only shows full relative paths for subdirectory files</a></div><pre>7 files changed, 309 insertions(+), 39 deletions(-)
+ create mode 100644 script_test.go
+ create mode 100644 testdata/scripts/basic.txtar
+ create mode 100644 testdata/scripts/changed_only_filter.txtar
+ create mode 100644 testdata/scripts/changed_only_paths.txtar
+[rerun: b38]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T03-06-48-134Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T03-06-48-134Z" class="timestamp-link"><time datetime="2026-04-11T03:06:48.134Z" data-timestamp="2026-04-11T03:06:48.134Z">2026-04-11T03:06:48.134Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01496ePNXWws3P3YZzj7naqo">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Push branch to remote</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">git push -u origin tree-experiment 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T03-06-49-077Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T03-06-49-077Z" class="timestamp-link"><time datetime="2026-04-11T03:06:49.077Z" data-timestamp="2026-04-11T03:06:49.077Z">2026-04-11T03:06:49.077Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>remote: 
+remote: Create a pull request for &#x27;tree-experiment&#x27; on GitHub by visiting:        
+remote:      https://github.com/llimllib/git-ls/pull/new/tree-experiment        
+remote: 
+To https://github.com/llimllib/git-ls.git
+ * [new branch]      tree-experiment -&gt; tree-experiment
+branch &#x27;tree-experiment&#x27; set up to track &#x27;origin/tree-experiment&#x27;.
+[rerun: b39]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T03-06-59-637Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T03-06-59-637Z" class="timestamp-link"><time datetime="2026-04-11T03:06:59.637Z" data-timestamp="2026-04-11T03:06:59.637Z">2026-04-11T03:06:59.637Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01GM7FzHgG7rTbnNikFXW2r5">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Create pull request</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">gh pr create --title &#34;feat: --changed-only shows full relative paths&#34; --body &#34;$(cat &lt;&lt;&#39;EOF&#39;
+## Summary
+
+- `--changed-only` now shows all changed files at or below the current directory with their relative paths (e.g. `src/network/server.go` instead of collapsing to `src/`)
+- Paths are relative to where you run it: from repo root you see `src/network/server.go`, from `src/` you see `network/server.go`, from `src/network/` you see `server.go`
+- Adds `NO_COLOR` environment variable support (https://no-color.org)
+- Extracts `run()` from `main()` for testability
+- Adds `testscript`-based integration tests
+
+Closes #44
+
+## Test plan
+
+- [x] Existing unit tests pass
+- [x] New integration tests cover: basic listing, changed-only filtering, full relative paths from root, scoped paths from subdirectories, leaf directory basenames
+- [x] Manual testing with `--nerdfont`, `NO_COLOR`, normal mode
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)&#34; 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T03-07-01-324Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T03-07-01-324Z" class="timestamp-link"><time datetime="2026-04-11T03:07:01.324Z" data-timestamp="2026-04-11T03:07:01.324Z">2026-04-11T03:07:01.324Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Warning: 1 uncommitted change
+https://github.com/llimllib/git-ls/pull/47
+[rerun: b40]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T03-07-07-238Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T03-07-07-238Z" class="timestamp-link"><time datetime="2026-04-11T03:07:07.238Z" data-timestamp="2026-04-11T03:07:07.238Z">2026-04-11T03:07:07.238Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>PR is up: https://github.com/llimllib/git-ls/pull/47</p></div></div></div>
+<div class="message user" id="msg-2026-04-11T03-11-46-304Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2026-04-11T03-11-46-304Z" class="timestamp-link"><time datetime="2026-04-11T03:11:46.304Z" data-timestamp="2026-04-11T03:11:46.304Z">2026-04-11T03:11:46.304Z</time></a></div><div class="message-content">
+<div class="user-content"><p>create a transcript in the transcripts dir with <code>uvx claude-code-transcripts --help</code></p></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T03-11-51-162Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T03-11-51-162Z" class="timestamp-link"><time datetime="2026-04-11T03:11:51.162Z" data-timestamp="2026-04-11T03:11:51.162Z">2026-04-11T03:11:51.162Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_012rFTo8MiZSpT146bnFeVDZ">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Check transcript tool help</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">uvx claude-code-transcripts --help 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T03-11-54-491Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T03-11-54-491Z" class="timestamp-link"><time datetime="2026-04-11T03:11:54.491Z" data-timestamp="2026-04-11T03:11:54.491Z">2026-04-11T03:11:54.491Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>Installed 15 packages in 14ms
+Usage: claude-code-transcripts [OPTIONS] COMMAND [ARGS]...
+
+  Convert Claude Code session JSON to mobile-friendly HTML pages.
+
+Options:
+  -v, --version  Show the version and exit.
+  --help         Show this message and exit.
+
+Commands:
+  local*  Select and convert a local Claude Code session to HTML.
+  all     Convert all local Claude Code sessions to a browsable HTML archive.
+  json    Convert a Claude Code session JSON/JSONL file or URL to HTML.
+  web     Select and convert a web session from the Claude API to HTML.
+[rerun: b41]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T03-11-59-349Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T03-11-59-349Z" class="timestamp-link"><time datetime="2026-04-11T03:11:59.349Z" data-timestamp="2026-04-11T03:11:59.349Z">2026-04-11T03:11:59.349Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01YFe9H8FRvDMK4niXFa8wCW">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Check transcripts directory</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">ls /Users/llimllib/code/git-ls/tree-experiment/transcripts/ 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T03-11-59-412Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T03-11-59-412Z" class="timestamp-link"><time datetime="2026-04-11T03:11:59.412Z" data-timestamp="2026-04-11T03:11:59.412Z">2026-04-11T03:11:59.412Z</time></a></div><div class="message-content"><div class="tool-result"><div class="truncatable"><div class="truncatable-content"><pre>25-fix-directory-arg-hang.html
+28-show-deleted-files.html
+30-fix-hyperlinks.html
+33-optimize-git-log-streaming.html
+35-fix-symlink-worktree-panic.html
+36-fix-empty-repo.html
+37-fix-subdirectory-git-info.html
+38-fix-rename-copy-status.html
+39-nerdfont-flag.html
+41-changed-only-flag.html
+42-add-man-page.html
+43-fix-unmodified-files-git-info.html
+45-handle-detached-head/
+[rerun: b42]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T03-12-05-719Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T03-12-05-719Z" class="timestamp-link"><time datetime="2026-04-11T03:12:05.719Z" data-timestamp="2026-04-11T03:12:05.719Z">2026-04-11T03:12:05.719Z</time></a></div><div class="message-content">
+<div class="tool-use bash-tool" data-tool-id="toolu_01CwjzyWas7FXgFecH9ok8kW">
+<div class="tool-header"><span class="tool-icon">$</span> Bash</div>
+<div class="tool-description">Create transcript from current session</div><div class="truncatable"><div class="truncatable-content"><pre class="bash-command">uvx claude-code-transcripts local --output /Users/llimllib/code/git-ls/tree-experiment/transcripts/47-changed-only-relative-paths.html 2&gt;&amp;1</pre></div><button class="expand-btn">Show more</button></div>
+</div></div></div>
+<div class="message tool-reply" id="msg-2026-04-11T03-12-05-969Z"><div class="message-header"><span class="role-label">Tool reply</span><a href="#msg-2026-04-11T03-12-05-969Z" class="timestamp-link"><time datetime="2026-04-11T03:12:05.969Z" data-timestamp="2026-04-11T03:12:05.969Z">2026-04-11T03:12:05.969Z</time></a></div><div class="message-content"><div class="tool-result tool-error"><div class="truncatable"><div class="truncatable-content"><pre>Exit code 1
+Loading local sessions...
+Warning: Input is not a terminal (fd=0).
+Traceback (most recent call last):
+  File &quot;/Users/llimllib/.cache/uv/archive-v0/rm-jRIY6HL4J6riYYNZlY/bin/claude-code-transcripts&quot;, line 12, in &lt;module&gt;
+    sys.exit(main())
+             ~~~~^^
+  File &quot;/Users/llimllib/.cache/uv/archive-v0/rm-jRIY6HL4J6riYYNZlY/lib/python3.14/site-packages/claude_code_transcripts/__init__.py&quot;, line 2224, in main
+    cli()
+    ~~~^^
+  File &quot;/Users/llimllib/.cache/uv/archive-v0/rm-jRIY6HL4J6riYYNZlY/lib/python3.14/site-packages/click/core.py&quot;, line 1485, in __call__
+    return self.main(*args, **kwargs)
+           ~~~~~~~~~^^^^^^^^^^^^^^^^^
+  File &quot;/Users/llimllib/.cache/uv/archive-v0/rm-jRIY6HL4J6riYYNZlY/lib/python3.14/site-packages/click/core.py&quot;, line 1406, in main
+    rv = self.invoke(ctx)
+  File &quot;/Users/llimllib/.cache/uv/archive-v0/rm-jRIY6HL4J6riYYNZlY/lib/python3.14/site-packages/click/core.py&quot;, line 1873, in invoke
+    return _process_result(sub_ctx.command.invoke(sub_ctx))
+                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
+  File &quot;/Users/llimllib/.cache/uv/archive-v0/rm-jRIY6HL4J6riYYNZlY/lib/python3.14/site-packages/click/core.py&quot;, line 1269, in invoke
+    return ctx.invoke(self.callback, **ctx.params)
+           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File &quot;/Users/llimllib/.cache/uv/archive-v0/rm-jRIY6HL4J6riYYNZlY/lib/python3.14/site-packages/click/core.py&quot;, line 824, in invoke
+    return callback(*args, **kwargs)
+  File &quot;/Users/llimllib/.cache/uv/archive-v0/rm-jRIY6HL4J6riYYNZlY/lib/python3.14/site-packages/claude_code_transcripts/__init__.py&quot;, line 1551, in local_cmd
+    ).ask()
+      ~~~^^
+  File &quot;/Users/llimllib/.cache/uv/archive-v0/rm-jRIY6HL4J6riYYNZlY/lib/python3.14/site-packages/questionary/question.py&quot;, line 64, in ask
+    return self.unsafe_ask(patch_stdout)
+           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
+  File &quot;/Users/llimllib/.cache/uv/archive-v0/rm-jRIY6HL4J6riYYNZlY/lib/python3.14/site-packages/questionary/question.py&quot;, line 89, in unsafe_ask
+    return self.application.run()
+           ~~~~~~~~~~~~~~~~~~~~^^
+  File &quot;/Users/llimllib/.cache/uv/archive-v0/rm-jRIY6HL4J6riYYNZlY/lib/python3.14/site-packages/prompt_toolkit/application/application.py&quot;, line 1002, in run
+    return asyncio.run(coro)
+           ~~~~~~~~~~~^^^^^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/asyncio/runners.py&quot;, line 204, in run
+    return runner.run(main)
+           ~~~~~~~~~~^^^^^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/asyncio/runners.py&quot;, line 127, in run
+    return self._loop.run_until_complete(task)
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/asyncio/base_events.py&quot;, line 719, in run_until_complete
+    return future.result()
+           ~~~~~~~~~~~~~^^
+  File &quot;/Users/llimllib/.cache/uv/archive-v0/rm-jRIY6HL4J6riYYNZlY/lib/python3.14/site-packages/prompt_toolkit/application/application.py&quot;, line 886, in run_async
+    return await _run_async(f)
+           ^^^^^^^^^^^^^^^^^^^
+  File &quot;/Users/llimllib/.cache/uv/archive-v0/rm-jRIY6HL4J6riYYNZlY/lib/python3.14/site-packages/prompt_toolkit/application/application.py&quot;, line 734, in _run_async
+    with self.input.raw_mode(), self.input.attach(
+                                ~~~~~~~~~~~~~~~~~^
+        read_from_input_in_context
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ), attach_winch_signal_handler(self._on_resize):
+    ^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/contextlib.py&quot;, line 141, in __enter__
+    return next(self.gen)
+  File &quot;/Users/llimllib/.cache/uv/archive-v0/rm-jRIY6HL4J6riYYNZlY/lib/python3.14/site-packages/prompt_toolkit/input/vt100.py&quot;, line 165, in _attached_input
+    loop.add_reader(fd, callback_wrapper)
+    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/asyncio/selector_events.py&quot;, line 351, in add_reader
+    self._add_reader(fd, callback, *args)
+    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/asyncio/selector_events.py&quot;, line 283, in _add_reader
+    self._selector.register(fd, selectors.EVENT_READ,
+    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
+                            (handle, None))
+                            ^^^^^^^^^^^^^^^
+  File &quot;/Users/llimllib/.local/share/mise/installs/python/3.14.3/lib/python3.14/selectors.py&quot;, line 505, in register
+    self._selector.control([kev], 0, 0)
+    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
+OSError: [Errno 22] Invalid argument
+[rerun: b43]</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
+<div class="message assistant" id="msg-2026-04-11T03-12-12-441Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2026-04-11T03-12-12-441Z" class="timestamp-link"><time datetime="2026-04-11T03:12:12.441Z" data-timestamp="2026-04-11T03:12:12.441Z">2026-04-11T03:12:12.441Z</time></a></div><div class="message-content">
+<div class="assistant-text"><p>It needs an interactive terminal for the session picker. You'll need to run it yourself — try:</p>
+<pre><code>! uvx claude-code-transcripts local --output transcripts/47-changed-only-relative-paths.html
+</code></pre>
+<p>The <code>!</code> prefix runs it in your terminal so the interactive session selector works.</p></div></div></div>
+        
+
+<div class="pagination">
+<a href="index.html" class="index-link">Index</a>
+<a href="page-004.html">&larr; Prev</a>
+<a href="page-001.html">1</a>
+<a href="page-002.html">2</a>
+<a href="page-003.html">3</a>
+<a href="page-004.html">4</a>
+<span class="current">5</span>
+<span class="disabled">Next &rarr;</span>
+</div>
+
+    </div>
+    <script>
+document.querySelectorAll('time[data-timestamp]').forEach(function(el) {
+    const timestamp = el.getAttribute('data-timestamp');
+    const date = new Date(timestamp);
+    const now = new Date();
+    const isToday = date.toDateString() === now.toDateString();
+    const timeStr = date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+    if (isToday) { el.textContent = timeStr; }
+    else { el.textContent = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' ' + timeStr; }
+});
+document.querySelectorAll('pre.json').forEach(function(el) {
+    let text = el.textContent;
+    text = text.replace(/"([^"]+)":/g, '<span style="color: #ce93d8">"$1"</span>:');
+    text = text.replace(/: "([^"]*)"/g, ': <span style="color: #81d4fa">"$1"</span>');
+    text = text.replace(/: (\d+)/g, ': <span style="color: #ffcc80">$1</span>');
+    text = text.replace(/: (true|false|null)/g, ': <span style="color: #f48fb1">$1</span>');
+    el.innerHTML = text;
+});
+document.querySelectorAll('.truncatable').forEach(function(wrapper) {
+    const content = wrapper.querySelector('.truncatable-content');
+    const btn = wrapper.querySelector('.expand-btn');
+    if (content.scrollHeight > 250) {
+        wrapper.classList.add('truncated');
+        btn.addEventListener('click', function() {
+            if (wrapper.classList.contains('truncated')) { wrapper.classList.remove('truncated'); wrapper.classList.add('expanded'); btn.textContent = 'Show less'; }
+            else { wrapper.classList.remove('expanded'); wrapper.classList.add('truncated'); btn.textContent = 'Show more'; }
+        });
+    }
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- `--changed-only` now shows all changed files at or below the current directory with their relative paths (e.g. `src/network/server.go` instead of collapsing to `src/`)
- Paths are relative to where you run it: from repo root you see `src/network/server.go`, from `src/` you see `network/server.go`, from `src/network/` you see `server.go`
- Adds `NO_COLOR` environment variable support (https://no-color.org)
- Extracts `run()` from `main()` for testability
- Adds `testscript`-based integration tests

Closes #44

## Test plan

- [x] Existing unit tests pass
- [x] New integration tests cover: basic listing, changed-only filtering, full relative paths from root, scoped paths from subdirectories, leaf directory basenames
- [x] Manual testing with `--nerdfont`, `NO_COLOR`, normal mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)