### PR TITLE
fix: drain trailing resets

### DIFF
--- a/main.go
+++ b/main.go
@@ -713,11 +713,18 @@ func makeDiffGraph(file *File, width int) string {
 			strings.Repeat("-", minus),
 			RESET)
 	}
+	scaledPlus := scaleLinear(plus, width, plus+minus)
+	scaledMinus := scaleLinear(minus, width, plus+minus)
+	// scaleLinear guarantees at least 1 for non-zero values, so the sum
+	// can exceed width. Cap the total to width, preserving the ratio.
+	if scaledPlus+scaledMinus > width {
+		scaledMinus = width - scaledPlus
+	}
 	return fmt.Sprintf("%s%s%s%s%s",
 		GREEN,
-		strings.Repeat("+", scaleLinear(plus, width, plus+minus)),
+		strings.Repeat("+", scaledPlus),
 		RED,
-		strings.Repeat("-", scaleLinear(minus, width, plus+minus)),
+		strings.Repeat("-", scaledMinus),
 		RESET)
 }
 

--- a/terminal.go
+++ b/terminal.go
@@ -202,6 +202,18 @@ func truncateToWidth(s string, maxWidth int) string {
 		i += size
 	}
 
+	// Drain any trailing ANSI escape sequences (e.g. RESET) that follow
+	// the last visible character. These have zero visual width and must
+	// be preserved to avoid color bleeding into subsequent columns.
+	for i < len(s) {
+		if n := skipANSI(s, i); n > 0 {
+			result.WriteString(s[i : i+n])
+			i += n
+		} else {
+			break
+		}
+	}
+
 	return result.String()
 }
 

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -310,19 +310,20 @@ func TestTruncateToWidth(t *testing.T) {
 
 func TestTruncateToWidthPreservesANSI(t *testing.T) {
 	// Verify that ANSI codes pass through (not stripped) when text fits.
-	// Note: trailing ANSI codes after visible content may be omitted since
-	// truncateToWidth stops once visible width is consumed.
+	// Trailing ANSI codes (like RESET) after the last visible character must
+	// be preserved to avoid color bleeding into subsequent output.
 	input := "\x1b[32mgreen\x1b[0m"
 	got := truncateToWidth(input, 5)
-	// The fast path (no ANSI) won't apply here, so the slow path will
-	// include the leading color but stop after 'green' since width is met.
-	// The reset code comes after the visible chars, so it may or may not be included.
 	gotVisible := stripANSI(got)
 	if gotVisible != "green" {
 		t.Errorf("truncateToWidth visible text = %q, want %q", gotVisible, "green")
 	}
 	if !strings.Contains(got, "\x1b[32m") {
 		t.Errorf("truncateToWidth should preserve leading ANSI: %q", got)
+	}
+	// Trailing RESET must be preserved
+	if !strings.Contains(got, "\x1b[0m") {
+		t.Errorf("truncateToWidth should preserve trailing RESET: %q", got)
 	}
 
 	// Verify color code is kept even when text is truncated
@@ -332,6 +333,16 @@ func TestTruncateToWidthPreservesANSI(t *testing.T) {
 	}
 	if width(got) != 3 {
 		t.Errorf("truncateToWidth visible width = %d, want 3", width(got))
+	}
+
+	// Verify diff graph pattern: GREEN+++RED--RESET doesn't lose RESET
+	diffGraph := "\x1b[32m+++\x1b[31m--\x1b[0m"
+	got = truncateToWidth(diffGraph, 5)
+	if !strings.HasSuffix(got, "\x1b[0m") {
+		t.Errorf("truncateToWidth should preserve trailing RESET in diff graph: %q", got)
+	}
+	if width(got) != 5 {
+		t.Errorf("truncateToWidth diff graph visible width = %d, want 5", width(got))
 	}
 }
 


### PR DESCRIPTION
When running `git-ls -c`, certain files would have their filename printed in red. This happened when the diff graph's minus characters
(colored red) were not followed by a RESET escape sequence, causing the color to bleed into the next column.

Root cause: Two bugs working together:

1. `makeDiffGraph` could exceed `diffWidth` — The `scaleLinear` function (ported from git) guarantees at least 1 character for any non-zero value. When both additions and deletions were present, their scaled sum could exceed the requested width. For example, a file with +4/-2 changes and diffWidth=4 would produce `+++--` (5 chars).
2. `truncateToWidth` dropped trailing ANSI escapes — When visible width exactly reached `maxWidth`, the loop exited without consuming any trailing zero-width ANSI sequences (like RESET). So if the diff graph happened to be the widest in its column, it wasn't truncated and the RESET was preserved. But if it was truncated to fit, the RESET was lost.

Fix:

- Cap `makeDiffGraph` output to never exceed `diffWidth` characters
- After `truncateToWidth`'s main loop, drain any immediately-trailing ANSI escape sequences so color resets are never dropped
